### PR TITLE
Replace slow Date fetching with new Groundstation date API

### DIFF
--- a/src/config/layers.json
+++ b/src/config/layers.json
@@ -701,7 +701,8 @@
   "avg_temperature_groundstations": {
     "title": "10-day average temperature",
     "type": "point_data",
-    "data": "https://mng.prism.services/temp/Temperature?beginDateTime=2000-01-01&endDateTime=2023-12-21",
+    "data": "https://mng.prism.services/temp/Temperature",
+    "date_url": "https://mng.prism.services/temp/getDates",
     "fallback_data": "./data/groundstations/IRIMHE_temperature_2020-01-d1.json",
     "opacity": 0.5,
     "measure": "ttt_aver",
@@ -748,7 +749,8 @@
   "min_temperature_groundstations": {
     "title": "10-day minimum temperature",
     "type": "point_data",
-    "data": "https://mng.prism.services/temp/Temperature?beginDateTime=2000-01-01&endDateTime=2023-12-21",
+    "data": "https://mng.prism.services/temp/Temperature",
+    "date_url": "https://mng.prism.services/temp/getDates",
     "fallback_data": "./data/groundstations/IRIMHE_temperature_2020-01-d1.json",
     "opacity": 0.5,
     "measure": "ttt_min",
@@ -795,7 +797,8 @@
   "max_temperature_groundstations": {
     "title": "10-day maximum temperature",
     "type": "point_data",
-    "data": "https://mng.prism.services/temp/Temperature?beginDateTime=2000-01-01&endDateTime=2023-12-21",
+    "data": "https://mng.prism.services/temp/Temperature",
+    "date_url": "https://mng.prism.services/temp/getDates",
     "fallback_data": "./data/groundstations/IRIMHE_temperature_2020-01-d1.json",
     "opacity": 0.5,
     "measure": "ttt_max",
@@ -842,7 +845,8 @@
   "total_precipitation_groundstations": {
     "title": "Total 10-day precipitation",
     "type": "point_data",
-    "data": "https://mng.prism.services/temp/percipitation?beginDateTime=2000-01-01&endDateTime=2023-12-21",
+    "data": "https://mng.prism.services/temp/percipitation",
+    "date_url": "https://mng.prism.services/temp/getDates",
     "fallback_data": "./data/groundstations/IRIMHE_precipitation_2020-05-01.json",
     "opacity": 0.5,
     "measure": "sum_rrr",
@@ -873,7 +877,8 @@
   "avg_precipitation_groundstations": {
     "title": "10-day average precipitation",
     "type": "point_data",
-    "data": "https://mng.prism.services/temp/soil?beginDateTime=2000-01-01&endDateTime=2023-12-21",
+    "data": "https://mng.prism.services/temp/soil",
+    "date_url": "https://mng.prism.services/temp/getDates",
     "opacity": 0.5,
     "measure": "ttt_aver",
     "legend_text": "Average temperature over a 10-day period from ground station data reported in degrees Celsius",

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -139,7 +139,6 @@ export class CommonLayerProps {
   type: string;
   opacity: number;
 
-  // TODO not used
   @optional
   dateInterval?: string;
 
@@ -208,7 +207,6 @@ export class StatsApi {
   groupBy: string;
 }
 
-// first is display name, second is name we store in computers
 export enum AggregationOperations {
   Mean = 'mean',
   Median = 'median',

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -139,6 +139,7 @@ export class CommonLayerProps {
   type: string;
   opacity: number;
 
+  // TODO not used
   @optional
   dateInterval?: string;
 
@@ -206,6 +207,7 @@ export class StatsApi {
   zonesUrl: string;
   groupBy: string;
 }
+
 // first is display name, second is name we store in computers
 export enum AggregationOperations {
   Mean = 'mean',
@@ -254,6 +256,8 @@ export class PointDataLayerProps extends CommonLayerProps {
   measure: string;
   @optional
   fallbackData?: string;
+  // URL to fetch all possible dates from
+  dateUrl: string;
 }
 
 export type RequiredKeys<T> = {

--- a/src/context/layers/point_data.ts
+++ b/src/context/layers/point_data.ts
@@ -6,6 +6,7 @@ import { PointDataLayerProps } from '../../config/types';
 declare module 'geojson' {
   export const version: string;
   export const defaults: object;
+
   export function parse(
     data: object,
     properties: object,
@@ -22,7 +23,7 @@ export type PointLayerData = {
 
 export const fetchPointLayerData: LazyLoader<PointDataLayerProps> = () => async ({
   date,
-  layer,
+  layer: { data: dataUrl, fallbackData },
 }) => {
   // This function fetches point data from the API.
   // If this endpoint is not available or we run into an error,
@@ -37,7 +38,7 @@ export const fetchPointLayerData: LazyLoader<PointDataLayerProps> = () => async 
   try {
     // eslint-disable-next-line fp/no-mutation
     data = (await (
-      await fetch(layer.data.substr(0, layer.data.indexOf('?')) + dateQuery, {
+      await fetch(dataUrl + dateQuery, {
         mode: 'cors',
       })
     ).json()) as PointLayerData;
@@ -45,7 +46,7 @@ export const fetchPointLayerData: LazyLoader<PointDataLayerProps> = () => async 
     // fallback data isn't filtered, therefore we must filter it.
     // eslint-disable-next-line fp/no-mutation
     data = ((await (
-      await fetch(layer.fallbackData || '')
+      await fetch(fallbackData || '')
     ).json()) as PointLayerData).filter(
       // we cant do a string comparison here because sometimes the date in json is stored as YYYY-M-D instead of YYYY-MM-DD
       // using moment here helps compensate for these discrepancies

--- a/src/utils/server-utils.ts
+++ b/src/utils/server-utils.ts
@@ -174,7 +174,7 @@ async function getPointDataCoverage(layer: PointDataLayerProps) {
   const data = await loadPointLayerDataFromURL(url).catch(err => {
     console.error(err);
     console.warn(
-      `Failed loading groundstation layer: ${id}. Attempting to load fallback URL...`,
+      `Failed loading point data layer: ${id}. Attempting to load fallback URL...`,
     );
     return loadPointLayerDataFromURL(fallbackUrl || '');
   });

--- a/src/utils/server-utils.ts
+++ b/src/utils/server-utils.ts
@@ -160,34 +160,24 @@ async function getWCSCoverage(serverUri: string) {
   }
 }
 
-type PointDataDates = Array<{
-  date: string;
-}>;
-// used to cache repeat date requests to same URL
-const pointDataFetchPromises: {
-  [k in PointDataLayerProps['dateUrl']]: Promise<PointDataDates>;
-} = {};
-
 /**
  * Gets the available dates for a point data layer.
  */
 async function getPointDataCoverage(layer: PointDataLayerProps) {
   const { dateUrl: url, fallbackData: fallbackUrl, id } = layer;
   const loadPointLayerDataFromURL = async (fetchUrl: string) => {
-    const data = (await (await fetch(fetchUrl || '')).json()) as PointDataDates; // raw data comes in as { date: yyyy-mm-dd }[]
+    const data = (await (await fetch(fetchUrl || '')).json()) as Array<{
+      date: string;
+    }>; // raw data comes in as { date: yyyy-mm-dd }[]
     return data;
   };
-  // eslint-disable-next-line fp/no-mutation
-  const data = await (pointDataFetchPromises[url] =
-    pointDataFetchPromises[url] || loadPointLayerDataFromURL(url)).catch(
-    err => {
-      console.error(err);
-      console.warn(
-        `Failed loading point data layer: ${id}. Attempting to load fallback URL...`,
-      );
-      return loadPointLayerDataFromURL(fallbackUrl || '');
-    },
-  );
+  const data = await loadPointLayerDataFromURL(url).catch(err => {
+    console.error(err);
+    console.warn(
+      `Failed loading point data layer: ${id}. Attempting to load fallback URL...`,
+    );
+    return loadPointLayerDataFromURL(fallbackUrl || '');
+  });
   const possibleDates = data
     // adding 12 hours to avoid  errors due to daylight saving, and convert to number
     .map(item => moment.utc(item.date).set({ hour: 12 }).valueOf())

--- a/src/utils/server-utils.ts
+++ b/src/utils/server-utils.ts
@@ -160,24 +160,34 @@ async function getWCSCoverage(serverUri: string) {
   }
 }
 
+type PointDataDates = Array<{
+  date: string;
+}>;
+// used to cache repeat date requests to same URL
+const pointDataFetchPromises: {
+  [k in PointDataLayerProps['dateUrl']]: Promise<PointDataDates>;
+} = {};
+
 /**
  * Gets the available dates for a point data layer.
  */
 async function getPointDataCoverage(layer: PointDataLayerProps) {
   const { dateUrl: url, fallbackData: fallbackUrl, id } = layer;
   const loadPointLayerDataFromURL = async (fetchUrl: string) => {
-    const data = (await (await fetch(fetchUrl || '')).json()) as Array<{
-      date: string;
-    }>; // raw data comes in as { date: yyyy-mm-dd }[]
+    const data = (await (await fetch(fetchUrl || '')).json()) as PointDataDates; // raw data comes in as { date: yyyy-mm-dd }[]
     return data;
   };
-  const data = await loadPointLayerDataFromURL(url).catch(err => {
-    console.error(err);
-    console.warn(
-      `Failed loading point data layer: ${id}. Attempting to load fallback URL...`,
-    );
-    return loadPointLayerDataFromURL(fallbackUrl || '');
-  });
+  // eslint-disable-next-line fp/no-mutation
+  const data = await (pointDataFetchPromises[url] =
+    pointDataFetchPromises[url] || loadPointLayerDataFromURL(url)).catch(
+    err => {
+      console.error(err);
+      console.warn(
+        `Failed loading point data layer: ${id}. Attempting to load fallback URL...`,
+      );
+      return loadPointLayerDataFromURL(fallbackUrl || '');
+    },
+  );
   const possibleDates = data
     // adding 12 hours to avoid  errors due to daylight saving, and convert to number
     .map(item => moment.utc(item.date).set({ hour: 12 }).valueOf())

--- a/src/utils/server-utils.ts
+++ b/src/utils/server-utils.ts
@@ -5,7 +5,6 @@ import { get, isEmpty, isString, merge, union } from 'lodash';
 import config from '../config/prism.json';
 import { LayerDefinitions } from '../config/utils';
 import type { AvailableDates, PointDataLayerProps } from '../config/types';
-import type { PointLayerData } from '../context/layers/point_data';
 
 // Note: PRISM's date picker is designed to work with dates in the UTC timezone
 // Therefore, ambiguous dates (dates passed as string e.g 2020-08-01) shouldn't be calculated from the user's timezone and instead be converted directly to UTC. Possibly with moment.utc(string)
@@ -154,7 +153,8 @@ async function getWCSCoverage(serverUri: string) {
       'domainSet.temporalDomain.gml:timePosition',
     );
   } catch (error) {
-    // TODO we used to throw the error here so a notification appears. Removed because a failure of one shouldn't prevent the successful requests from saving.
+    // TODO we used to throw the error here so a notification appears via middleware. Removed because a failure of one shouldn't prevent the successful requests from saving.
+    // we could do a dispatch for a notification, but getting a dispatch reference here would be complex, just for a notification
     console.error(error);
     return {};
   }
@@ -162,24 +162,14 @@ async function getWCSCoverage(serverUri: string) {
 
 /**
  * Gets the available dates for a point data layer.
- *
- * In layers.json each uri is given a constant, large date range (2000-01-01 -> 2023-12-21) to try get the api to give all possible dates
- * TODO Once the api is fixed this needs to be fixed as its currently a hacky solution to get around the api's caveats
- *
  */
 async function getPointDataCoverage(layer: PointDataLayerProps) {
-  const { data: url, fallbackData: fallbackUrl, id } = layer;
+  const { dateUrl: url, fallbackData: fallbackUrl, id } = layer;
   const loadPointLayerDataFromURL = async (fetchUrl: string) => {
-    const data = (await (
-      await fetch(fetchUrl || '', {
-        mode: fetchUrl.startsWith('http') ? 'cors' : 'same-origin',
-      })
-    ).json()) as PointLayerData & { date: string }; // raw data comes in as string yyyy-mm-dd, needs to be converted to number.
-    return data.map(item => ({
-      ...item,
-      // adding 12 hours to avoid  errors due to daylight saving
-      date: moment.utc(item.date).set({ hour: 12 }).valueOf(),
-    }));
+    const data = (await (await fetch(fetchUrl || '')).json()) as Array<{
+      date: string;
+    }>; // raw data comes in as { date: yyyy-mm-dd }[]
+    return data;
   };
   const data = await loadPointLayerDataFromURL(url).catch(err => {
     console.error(err);
@@ -189,11 +179,12 @@ async function getPointDataCoverage(layer: PointDataLayerProps) {
     return loadPointLayerDataFromURL(fallbackUrl || '');
   });
   const possibleDates = data
-    // adding 12 hours to avoid  errors due to daylight saving
+    // adding 12 hours to avoid  errors due to daylight saving, and convert to number
     .map(item => moment.utc(item.date).set({ hour: 12 }).valueOf())
+    // remove duplicate dates - indexOf returns first index of item
     .filter((date, index, arr) => {
       return arr.indexOf(date) === index;
-    }); // filter() here removes duplicate dates because indexOf will always return the first occurrence of an item
+    });
 
   return possibleDates;
 }


### PR DESCRIPTION
Replaces #102

Test URL: http://prism-date-groundstation-test.surge.sh/

Possible Areas of Improvement:
- I made each layer have its own date fetching URL just in case dates start differing in the future.  ~This creates a small performance hit because we call the url 4 times instead of just once, but for now, doesn't create a huge performance hit. Make sure to confirm this!~ Fixed with cache