### PR TITLE
Adam/geonode integration with PRISM

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,6 +120,6 @@
     "eslint-import-resolver-typescript": "^2.0.0"
   },
   "engines": {
-    "node": ">=12.x"
+    "node": "12.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -120,6 +120,6 @@
     "eslint-import-resolver-typescript": "^2.0.0"
   },
   "engines": {
-    "node": "12.x"
+    "node": ">=12.x"
   }
 }

--- a/src/components/NavBar/MenuItem/index.tsx
+++ b/src/components/NavBar/MenuItem/index.tsx
@@ -12,7 +12,12 @@ import {
 } from '@material-ui/core';
 
 import { MenuItemType, LayerType, TableType } from '../../../config/types';
-import { addLayer, removeLayer } from '../../../context/mapStateSlice';
+import {
+  removeLayers,
+  addLayer,
+  removeLayer,
+  addLayers,
+} from '../../../context/mapStateSlice';
 import { loadTable } from '../../../context/tableStateSlice';
 import { layersSelector } from '../../../context/mapStateSlice/selectors';
 
@@ -40,6 +45,20 @@ function MenuItem({ classes, title, icon, layersCategories }: MenuItemProps) {
 
   const showTableClicked = (table: TableType) => {
     dispatch(loadTable(table.id));
+  };
+
+  const toggleLayers = (layers: LayerType[]) => {
+    const layersIds = layers.map(l => l.id);
+    const selectedLayersIds = selectedLayers.map(l => l.id);
+
+    if (
+      layersIds.filter(l => selectedLayersIds.includes(l)).length ===
+      layersIds.length
+    ) {
+      dispatch(removeLayers(layersIds));
+    } else {
+      dispatch(addLayers(layers));
+    }
   };
 
   const open = Boolean(anchorEl);
@@ -74,44 +93,52 @@ function MenuItem({ classes, title, icon, layersCategories }: MenuItemProps) {
           className: classes.paper,
         }}
       >
-        {layersCategories.map(({ title: categoryTitle, layers, tables }) => (
-          <div key={categoryTitle} className={classes.categoryContainer}>
-            <Typography variant="body2" className={classes.categoryTitle}>
-              {categoryTitle}
-            </Typography>
-            <hr />
+        {layersCategories.map(
+          ({ title: categoryTitle, layers, tables, groupLayer }) => (
+            <div key={categoryTitle} className={classes.categoryContainer}>
+              <Typography variant="body2" className={classes.categoryTitle}>
+                {categoryTitle}
+              </Typography>
+              <hr />
 
-            {layers.map(layer => {
-              const { id: layerId, title: layerTitle } = layer;
-              const selected = Boolean(
-                selectedLayers.find(({ id: testId }) => testId === layerId),
-              );
-              return (
-                <div key={layerId} className={classes.layersContainer}>
-                  <Switch
-                    size="small"
-                    color="default"
-                    checked={selected}
-                    onChange={() => toggleLayerValue(selected, layer)}
-                    inputProps={{ 'aria-label': layerTitle }}
-                  />{' '}
-                  <Typography variant="body1">{layerTitle}</Typography>
-                </div>
-              );
-            })}
+              {layers.map(layer => {
+                const { id: layerId, title: layerTitle } = layer;
+                const selected = Boolean(
+                  selectedLayers.find(({ id: testId }) => testId === layerId),
+                );
+                return (
+                  <div key={layerId} className={classes.layersContainer}>
+                    <Switch
+                      size="small"
+                      color="default"
+                      checked={selected}
+                      onChange={() => toggleLayerValue(selected, layer)}
+                      inputProps={{ 'aria-label': layerTitle }}
+                    />{' '}
+                    <Typography variant="body1">{layerTitle}</Typography>
+                  </div>
+                );
+              })}
 
-            {tables.map(table => (
-              <Button
-                className={classes.button}
-                id={table.title}
-                key={table.title}
-                onClick={() => showTableClicked(table)}
-              >
-                <Typography variant="body1">{table.title}</Typography>
-              </Button>
-            ))}
-          </div>
-        ))}
+              {tables.map(table => (
+                <Button
+                  className={classes.button}
+                  id={table.title}
+                  key={table.title}
+                  onClick={() => showTableClicked(table)}
+                >
+                  <Typography variant="body1">{table.title}</Typography>
+                </Button>
+              ))}
+
+              {groupLayer === true ? (
+                <button type="button" onClick={() => toggleLayers(layers)}>
+                  View All
+                </button>
+              ) : null}
+            </div>
+          ),
+        )}
       </Popover>
     </>
   );

--- a/src/components/NavBar/MenuItem/index.tsx
+++ b/src/components/NavBar/MenuItem/index.tsx
@@ -13,10 +13,10 @@ import {
 
 import { MenuItemType, LayerType, TableType } from '../../../config/types';
 import {
-  removeLayers,
   addLayer,
-  removeLayer,
   addLayers,
+  removeLayer,
+  removeLayers,
 } from '../../../context/mapStateSlice';
 import { loadTable } from '../../../context/tableStateSlice';
 import { layersSelector } from '../../../context/mapStateSlice/selectors';

--- a/src/components/NavBar/__snapshots__/index.test.tsx.snap
+++ b/src/components/NavBar/__snapshots__/index.test.tsx.snap
@@ -32,7 +32,7 @@ exports[`renders as expected 1`] = `
           >
             <mock-menuitem
               icon="icon_climate.png"
-              layerscategories="[object Object],[object Object],[object Object]"
+              layerscategories="[object Object],[object Object],[object Object],[object Object]"
               title="Hazards"
             />
             <mock-menuitem
@@ -223,7 +223,7 @@ exports[`renders as expected 1`] = `
                   >
                     <mock-menuitem
                       icon="icon_climate.png"
-                      layerscategories="[object Object],[object Object],[object Object]"
+                      layerscategories="[object Object],[object Object],[object Object],[object Object]"
                       title="Hazards"
                     />
                     <mock-menuitem

--- a/src/components/NavBar/utils.ts
+++ b/src/components/NavBar/utils.ts
@@ -35,14 +35,18 @@ type LayersCategoriesType = LayersCategoryType[];
 
 type MenuItemsType = MenuItemType[];
 
-function formatLayersCategories(layersList: {
-  [key: string]: Array<LayerKey | TableKey>;
-}): LayersCategoriesType {
+function formatLayersCategories(
+  layersList: {
+    [key: string]: Array<LayerKey | TableKey>;
+  },
+  groupedLayers: string[],
+): LayersCategoriesType {
   return map(layersList, (layerKeys, layersListKey) => {
     return {
       title: startCase(layersListKey),
       layers: layerKeys.filter(isLayerKey).map(key => LayerDefinitions[key]),
       tables: layerKeys.filter(isTableKey).map(key => TableDefinitions[key]),
+      groupLayer: groupedLayers.includes(layersListKey),
     };
   });
 }
@@ -77,7 +81,10 @@ export const menuList: MenuItemsType = map(
     return {
       title: startCase(categoryKey),
       icon: icons[categoryKey],
-      layersCategories: formatLayersCategories(layersCategories),
+      layersCategories: formatLayersCategories(
+        layersCategories,
+        appJSON.grouped_layers,
+      ),
     };
   },
 );

--- a/src/config/layers.json
+++ b/src/config/layers.json
@@ -1069,7 +1069,7 @@
   "adam_earthquakes": {
     "title": "Global Earthquakes Epicenters",
     "type": "wms",
-    "server_layer_name": "prism:wld_eq_historical",
+    "server_layer_name": "wld_eq_historical",
     "opacity": 0.5,
     "legend": [],
     "legend_text": "",
@@ -1078,7 +1078,7 @@
   "adamts_buffers": {
     "title": "Wind buffers",
     "type": "wms",
-    "server_layer_name": "geonode:wld_nhr_adamtsbufferscurrent_wfp",
+    "server_layer_name": "wld_gdacs_tc_events_buffers",
     "opacity": 0.5,
     "legend": [],
     "legend_text": "",
@@ -1087,7 +1087,7 @@
   "adamts_nodes": {
     "title": "Current nodes",
     "type": "wms",
-    "server_layer_name": "geonode:wld_nhr_adamtsnodescurrent_wfp",
+    "server_layer_name": "wld_gdacs_tc_events_nodes",
     "opacity": 0.5,
     "legend": [],
     "legend_text": "",
@@ -1096,16 +1096,7 @@
   "adamts_tracks": {
     "title": "Current tracks",
     "type": "wms",
-    "server_layer_name": "geonode:wld_nhr_adamtstrackscurrent_wfp",
-    "opacity": 0.5,
-    "legend": [],
-    "legend_text": "",
-    "base_url": "https://geonode.wfp.org/geoserver"
-  },
-  "cyclones": {
-    "title": "World cyclones",
-    "type": "wms",
-    "server_layer_name": "prism:wld_ibtracs",
+    "server_layer_name": "wld_gdacs_tc_events_tracks",
     "opacity": 0.5,
     "legend": [],
     "legend_text": "",

--- a/src/config/layers.json
+++ b/src/config/layers.json
@@ -1065,5 +1065,50 @@
         "color": "#0868ac"
       }
     ]
+  },
+  "adam_earthquakes": {
+    "title": "Global Earthquakes Epicenters",
+    "type": "wms",
+    "server_layer_name": "prism:wld_eq_historical",
+    "opacity": 0.5,
+    "legend": [],
+    "legend_text": "",
+    "base_url": "https://geonode.wfp.org/geoserver"
+  },
+  "adamts_buffers": {
+    "title": "Wind buffers",
+    "type": "wms",
+    "server_layer_name": "geonode:wld_nhr_adamtsbufferscurrent_wfp",
+    "opacity": 0.5,
+    "legend": [],
+    "legend_text": "",
+    "base_url": "https://geonode.wfp.org/geoserver"
+  },
+  "adamts_nodes": {
+    "title": "Current nodes",
+    "type": "wms",
+    "server_layer_name": "geonode:wld_nhr_adamtsnodescurrent_wfp",
+    "opacity": 0.5,
+    "legend": [],
+    "legend_text": "",
+    "base_url": "https://geonode.wfp.org/geoserver"
+  },
+  "adamts_tracks": {
+    "title": "Current tracks",
+    "type": "wms",
+    "server_layer_name": "geonode:wld_nhr_adamtstrackscurrent_wfp",
+    "opacity": 0.5,
+    "legend": [],
+    "legend_text": "",
+    "base_url": "https://geonode.wfp.org/geoserver"
+  },
+  "cyclones": {
+    "title": "World cyclones",
+    "type": "wms",
+    "server_layer_name": "prism:wld_ibtracs",
+    "opacity": 0.5,
+    "legend": [],
+    "legend_text": "",
+    "base_url": "https://geonode.wfp.org/geoserver"
   }
 }

--- a/src/config/prism.json
+++ b/src/config/prism.json
@@ -2,20 +2,24 @@
   "country": "Mongolia",
   "serversUrls": {
     "wms": [
-      "https://mongolia.sibelius-datacube.org:5000/wms"
+      "https://mongolia.sibelius-datacube.org:5000/wms",
+      "https://geonode.wfp.org/geoserver/wms"
     ]
   },
   "map": {
     "latitude": 46.810021,
     "longitude": 103.111657,
-    "zoom": 4.5
+    "zoom": 1
   },
+  "grouped_layers": ["adam_tropical_storms", "adam_earthquakes"],
   "categories": {
     "hazards": {
       "drought_indicators": [
         "pasture_anomaly",
         "ndvi",
-        "ModisVHI"
+        "ModisVHI",
+        "cyclones",
+        "adam_earthquakes"
       ],
       "winter_conditions": [
         "ModisSnowPercentage",
@@ -26,6 +30,11 @@
         "min_temperature_groundstations",
         "max_temperature_groundstations",
         "total_precipitation_groundstations"
+      ],
+      "adam_tropical_storms": [
+        "adamts_buffers",
+        "adamts_nodes",
+        "adamts_tracks"
       ]
     },
     "exposure": {

--- a/src/config/prism.json
+++ b/src/config/prism.json
@@ -3,7 +3,7 @@
   "serversUrls": {
     "wms": [
       "https://mongolia.sibelius-datacube.org:5000/wms",
-      "https://geonode.wfp.org/geoserver/wms"
+      "https://geonode.wfp.org/geoserver/prism/wms/"
     ]
   },
   "map": {
@@ -18,7 +18,6 @@
         "pasture_anomaly",
         "ndvi",
         "ModisVHI",
-        "cyclones",
         "adam_earthquakes"
       ],
       "winter_conditions": [

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -277,6 +277,7 @@ export interface LayersCategoryType {
   title: string;
   layers: LayerType[];
   tables: TableType[];
+  groupLayer: boolean;
 }
 
 export interface MenuItemType {

--- a/src/context/mapStateSlice/index.ts
+++ b/src/context/mapStateSlice/index.ts
@@ -71,6 +71,22 @@ export const mapStateSlice = createSlice({
       ...rest,
       errors: errors.filter(msg => msg !== payload),
     }),
+
+    addLayers: (
+      { layers, ...rest },
+      { payload }: PayloadAction<LayerType[]>,
+    ) => ({
+      ...rest,
+      layers: layers.filter(l => l.type === 'boundary').concat(payload),
+    }),
+
+    removeLayers: (
+      { layers, ...rest },
+      { payload }: PayloadAction<string[]>,
+    ) => ({
+      ...rest,
+      layers: layers.filter(({ id }) => payload.includes(id) === false),
+    }),
   },
   extraReducers: builder => {
     builder.addCase(
@@ -109,6 +125,8 @@ export const {
   removeLayer,
   updateDateRange,
   setMap,
+  addLayers,
+  removeLayers,
 } = mapStateSlice.actions;
 
 export default mapStateSlice.reducer;

--- a/src/utils/server-utils.ts
+++ b/src/utils/server-utils.ts
@@ -68,10 +68,12 @@ function formatCapabilitiesInfo(
 
     const availableDates = dates
       .filter(date => !isEmpty(date))
-      .map(date => get(date, '_text', date).split('T')[0])
       .map(date =>
         // adding 12 hours to avoid  errors due to daylight saving
-        moment.utc(date).set({ hour: 12 }).valueOf(),
+        moment
+          .utc(get(date, '_text', date).split('T')[0])
+          .set({ hour: 12 })
+          .valueOf(),
       );
 
     const { [layerId]: oldLayerDates } = acc;

--- a/src/utils/server-utils.ts
+++ b/src/utils/server-utils.ts
@@ -68,9 +68,10 @@ function formatCapabilitiesInfo(
 
     const availableDates = dates
       .filter(date => !isEmpty(date))
+      .map(date => get(date, '_text', date).split('T')[0])
       .map(date =>
         // adding 12 hours to avoid  errors due to daylight saving
-        moment.utc(get(date, '_text', date)).set({ hour: 12 }).valueOf(),
+        moment.utc(date).set({ hour: 12 }).valueOf(),
       );
 
     const { [layerId]: oldLayerDates } = acc;


### PR DESCRIPTION
This PR references issues #127 and #128 with the goal of including Geonode/Adam layers within PRISM.

**Changes:**
- Enable the project to work with engines higher than 12.x
- Modify getcapabilities response by removing time values within TIME dimension.
- Include adam layers within layers.json and prism.json files.
- Include serverurl for getcapabilities request.
- Group layers to be queried at the same time. The group is set within the prism.json file, _group_layers_ field.
- Modify reducer with the goal of adding and removing multiple layers using a single toggle button.

![image](https://user-images.githubusercontent.com/3285923/106653278-92dca200-6564-11eb-9fd3-40f54eab0aae.png)





