### PR TITLE
Adam integration with grouped layers

### DIFF
--- a/src/components/MapView/index.tsx
+++ b/src/components/MapView/index.tsx
@@ -154,6 +154,10 @@ function MapView({ classes }: MapViewProps) {
             .map(date => moment(date).format('YYYY-MM-DD'))
             .includes(moment(selectedDate).format('YYYY-MM-DD'))
         ) {
+          if (layer.group && layer.group.main === false) {
+            return;
+          }
+
           dispatch(
             addNotification({
               message: `Selected Date isn't compatible with Layer: ${layer.title}`,

--- a/src/config/mozambique/layers.json
+++ b/src/config/mozambique/layers.json
@@ -156,5 +156,53 @@
       { "value": 30, "color": "#1d2e83" },
       { "value": "255 - no value", "color": "#ffffff", "alpha": 0 }
     ]
+  },
+  "adam_earthquakes": {
+    "title": "Adam Global Earthquakes Epicenters",
+    "type": "wms",
+    "server_layer_name": "wld_eq_historical_moz",
+    "opacity": 0.9,
+    "legend": [],
+    "legend_text": "",
+    "base_url": "https://geonode.wfp.org/geoserver"
+  },
+  "adamts_main": {
+    "title": "Adam Tropical Storms",
+    "type": "wms",
+    "server_layer_name": "wld_gdacs_tc_events_buffers_moz",
+    "opacity": 0.9,
+    "legend": [],
+    "legend_text": "",
+    "group": {
+      "name": "adam",
+      "main": true
+    },
+    "base_url": "https://geonode.wfp.org/geoserver"
+  },
+  "adamts_nodes": {
+    "title": "Current nodes",
+    "type": "wms",
+    "server_layer_name": "wld_gdacs_tc_events_nodes_moz",
+    "opacity": 0.9,
+    "legend": [],
+    "legend_text": "",
+    "group": {
+      "name": "adam",
+      "main": false
+    },
+    "base_url": "https://geonode.wfp.org/geoserver"
+  },
+  "adamts_tracks": {
+    "title": "Current tracks",
+    "type": "wms",
+    "server_layer_name": "wld_gdacs_tc_events_tracks_moz",
+    "opacity": 0.9,
+    "legend": [],
+    "legend_text": "",
+    "group": {
+      "name": "adam",
+      "main": false
+    },
+    "base_url": "https://geonode.wfp.org/geoserver"
   }
 }

--- a/src/config/mozambique/prism.json
+++ b/src/config/mozambique/prism.json
@@ -2,7 +2,8 @@
   "country": "Mozambique",
   "serversUrls": {
     "wms": [
-      "https://odc.ovio.org/wms"
+      "https://odc.ovio.org/wms",
+      "https://geonode.wfp.org/geoserver/prism/wms"
     ]
   },
   "map": {
@@ -20,6 +21,10 @@
         "dlx_dekad",
         "xnn_dekad",
         "xln_dekad"
+      ],
+      "disaster_management": [
+        "adamts_main",
+        "adam_earthquakes"
       ]  
     }
   }

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -122,6 +122,12 @@ export type LegendDefinition = {
   color: string;
 }[];
 
+export type GroupDefinition = {
+  name: string;
+  // Main layer of a group of layers. Secondary layers will not trigger notifications.
+  main: boolean;
+};
+
 export type RawDataConfiguration = {
   scale?: number;
   offset?: number;
@@ -147,6 +153,9 @@ export class CommonLayerProps {
 
   @optional // only optional for boundary layer
   legendText?: string;
+
+  @optional // only optional for boundary layer
+  group?: GroupDefinition;
 }
 
 export class BoundaryLayerProps extends CommonLayerProps {

--- a/src/context/mapStateSlice/index.ts
+++ b/src/context/mapStateSlice/index.ts
@@ -1,6 +1,7 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { Map as MapBoxMap } from 'mapbox-gl';
 import { LayerType } from '../../config/types';
+import { LayerDefinitions } from '../../config/utils';
 import { LayerData, LayerDataTypes, loadLayerData } from '../layers/layer-data';
 
 interface DateRange {
@@ -41,10 +42,30 @@ export const mapStateSlice = createSlice({
   name: 'mapState',
   initialState,
   reducers: {
-    addLayer: ({ layers, ...rest }, { payload }: PayloadAction<LayerType>) => ({
-      ...rest,
-      layers: layers.filter(layer => keepLayer(layer, payload)).concat(payload),
-    }),
+    addLayer: ({ layers, ...rest }, { payload }: PayloadAction<LayerType>) => {
+      // Check if a layer belongs to a group.
+      if (!payload.group) {
+        return {
+          ...rest,
+          layers: layers
+            .filter(layer => keepLayer(layer, payload))
+            .concat(payload),
+        };
+      }
+
+      const { name } = payload.group;
+      // Get all layers that belong to a group.
+      const groupedLayer = Object.values(LayerDefinitions).filter(
+        l => l.group?.name === name,
+      );
+
+      return {
+        ...rest,
+        layers: layers
+          .filter(layer => keepLayer(layer, payload))
+          .concat(groupedLayer),
+      };
+    },
 
     removeLayer: (
       { layers, ...rest },

--- a/src/utils/server-utils.ts
+++ b/src/utils/server-utils.ts
@@ -70,7 +70,10 @@ function formatCapabilitiesInfo(
       .filter(date => !isEmpty(date))
       .map(date =>
         // adding 12 hours to avoid  errors due to daylight saving
-        moment.utc(get(date, '_text', date)).set({ hour: 12 }).valueOf(),
+        moment
+          .utc(get(date, '_text', date).split('T')[0])
+          .set({ hour: 12 })
+          .valueOf(),
       );
 
     const { [layerId]: oldLayerDates } = acc;


### PR DESCRIPTION
This PR includes WFP ADAM layers into PRISM.

## **Changes**
- Added field group on layers type schema.
- Included adam earthquake layer.
- Included adam tropical storms layers, displayed as single layer.
- Modified date parser to remove time values.

![image](https://user-images.githubusercontent.com/3285923/113445228-1971fc00-93bb-11eb-89e4-7f57324b68fa.png)

You can see demo of this PR here: http://homeless-giraffe.surge.sh/
