### PR TITLE
Fetch first available date on a month switch event

### DIFF
--- a/src/components/MapView/DateSelector/index.tsx
+++ b/src/components/MapView/DateSelector/index.tsx
@@ -18,7 +18,7 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 import 'react-datepicker/dist/react-datepicker.css';
 import { updateDateRange } from '../../../context/mapStateSlice';
-import { getMonthStartAndEnd, isAvailableMonth, months } from './utils';
+import { isAvailableMonth, months, findAvailableDayInMonth } from './utils';
 import { dateRangeSelector } from '../../../context/mapStateSlice/selectors';
 
 interface InputProps {
@@ -53,8 +53,8 @@ function DateSelector({ availableDates = [], classes }: DateSelectorProps) {
     setSelectedDate(moment(stateStartDate));
   }, [stateStartDate]);
   function updateMonth(month: number) {
-    const { startDate, endDate } = getMonthStartAndEnd(month, selectedYear);
-    dispatch(updateDateRange({ startDate, endDate }));
+    const dates = findAvailableDayInMonth(month, selectedYear, availableDates);
+    dispatch(updateDateRange({ startDate: dates[0] }));
   }
   function incrementYear() {
     setSelectedDate(selectedDate.clone().year(selectedYear + 1));

--- a/src/components/MapView/DateSelector/utils.ts
+++ b/src/components/MapView/DateSelector/utils.ts
@@ -16,6 +16,35 @@ export const months = [
 ];
 
 /**
+ * Return the closest date from a given list of available dates
+ * @param date
+ * @param availableDates
+ * @return date as momentjs object
+ */
+export function findClosestDate(
+  date: number,
+  availableDates: ReturnType<Date['getTime']>[],
+) {
+  const dateToCheck = moment(date);
+
+  const reducerFunc = (
+    closest: ReturnType<Date['getTime']>,
+    current: ReturnType<Date['getTime']>,
+  ) => {
+    const diff = Math.abs(moment(current).diff(dateToCheck));
+    const closestDiff = Math.abs(moment(closest).diff(dateToCheck));
+
+    if (diff < closestDiff) {
+      return current;
+    }
+
+    return closest;
+  };
+
+  return moment(availableDates.reduce(reducerFunc));
+}
+
+/**
  * Return the start and end date of a month (utc format)
  * @param month
  * @param year

--- a/src/components/MapView/index.tsx
+++ b/src/components/MapView/index.tsx
@@ -27,12 +27,13 @@ import { DiscriminateUnion, LayerType } from '../../config/types';
 import { getBoundaryLayerSingleton } from '../../config/utils';
 
 import DateSelector from './DateSelector';
+import { findClosestDate } from './DateSelector/utils';
 import {
   dateRangeSelector,
   isLoading,
   layersSelector,
 } from '../../context/mapStateSlice/selectors';
-import { addLayer, setMap } from '../../context/mapStateSlice';
+import { addLayer, setMap, updateDateRange } from '../../context/mapStateSlice';
 import { hidePopup } from '../../context/tooltipStateSlice';
 import {
   availableDatesSelector,
@@ -148,19 +149,31 @@ function MapView({ classes }: MapViewProps) {
     // let users know if their current date doesn't exist in possible dates
     if (selectedDate) {
       selectedLayersWithDateSupport.forEach(layer => {
+        const momentSelectedDate = moment(selectedDate);
+
         // we convert to date strings, so hh:ss is irrelevant
         if (
           !getPossibleDatesForLayer(layer, serverAvailableDates)
             .map(date => moment(date).format('YYYY-MM-DD'))
-            .includes(moment(selectedDate).format('YYYY-MM-DD'))
+            .includes(momentSelectedDate.format('YYYY-MM-DD'))
         ) {
           if (layer.group && layer.group.main === false) {
             return;
           }
 
+          const closestDate = findClosestDate(selectedDate, selectedLayerDates);
+
+          dispatch(updateDateRange({ startDate: closestDate.valueOf() }));
+
           dispatch(
             addNotification({
-              message: `Selected Date isn't compatible with Layer: ${layer.title}`,
+              message: `No data was found for the layer '${
+                layer.title
+              }' on ${momentSelectedDate.format(
+                'YYYY-MM-DD',
+              )}. The closest date ${closestDate.format(
+                'YYYY-MM-DD',
+              )} has been loaded instead`,
               type: 'warning',
             }),
           );
@@ -170,7 +183,7 @@ function MapView({ classes }: MapViewProps) {
   }, [
     dispatch,
     selectedDate,
-    selectedLayerDates.length,
+    selectedLayerDates,
     selectedLayersWithDateSupport,
     serverAvailableDates,
   ]);


### PR DESCRIPTION
This PR closes #153 

- Available dates are collected from an already defined function **findAvailableDayInMonth**

![available_month](https://user-images.githubusercontent.com/3285923/114225265-be4e8500-9937-11eb-8b1e-458a07668161.gif)

**UPDATE**

- This commit also includes the fetch of the closest date on a layer switch event. This is done, since there is a possibility that no available date might be found within the selected month.

Please check instance in http://homeless-giraffe.surge.sh
