### PR TITLE
Form feature for WMS Layer

### DIFF
--- a/src/components/MapView/Layers/WMSLayer/index.tsx
+++ b/src/components/MapView/Layers/WMSLayer/index.tsx
@@ -1,9 +1,12 @@
 import React from 'react';
+import { useSelector } from 'react-redux';
+import { fromPairs } from 'lodash';
 import moment from 'moment';
 import { Layer, Source } from 'react-mapbox-gl';
 import { WMSLayerProps } from '../../../../config/types';
 import { getWMSUrl } from '../raster-utils';
 import { useDefaultDate } from '../../../../utils/useDefaultDate';
+import { layerFormSelector } from '../../../../context/mapStateSlice/selectors';
 
 function WMSLayers({
   layer: {
@@ -16,6 +19,10 @@ function WMSLayers({
   },
 }: LayersProps) {
   const selectedDate = useDefaultDate(serverLayerName, group);
+  const layerForm = useSelector(layerFormSelector(id));
+  const layerFormParams = layerForm
+    ? fromPairs(layerForm.inputs.map(input => [input.id, input.value]))
+    : {};
 
   return (
     <>
@@ -26,6 +33,7 @@ function WMSLayers({
           tiles: [
             `${getWMSUrl(baseUrl, serverLayerName, {
               ...additionalQueryParams,
+              ...layerFormParams,
               ...(selectedDate && {
                 time: moment(selectedDate).format('YYYY-MM-DD'),
               }),

--- a/src/config/mongolia/layers.json
+++ b/src/config/mongolia/layers.json
@@ -309,6 +309,58 @@
       "pixelResolution": 64,
       "offset": -200
     },
+    "form_inputs": [
+      {
+        "id": "DIM_NUMDAYSOURCE",
+        "label": "Number of days",
+        "value": "5days",
+        "values": [
+          {
+            "value": "1days",
+            "label": "1 Day"
+          },
+          {
+            "value": "2days",
+            "label": "2 Days"
+          },
+          {
+            "value": "3days",
+            "label": "3 Days"
+          },
+          {
+            "value": "4days",
+            "label": "4 Days"
+          },
+          {
+            "value": "5days",
+            "label": "5 Days"
+          }
+        ]
+      },
+      {
+        "id": "DIM_HOURSOURCE",
+        "label": "Release Hour",
+        "value": "H00",
+        "values": [
+          {
+            "value": "H00",
+            "label": "00:00"
+          },
+          {
+            "value": "H06",
+            "label": "06:00"
+          },
+          {
+            "value": "H12",
+            "label": "12:00"
+          },
+          {
+            "value": "H18",
+            "label": "18:00"
+          }
+        ]
+      }
+    ],
     "legend": [
       {
         "value": "-80%",

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -184,6 +184,9 @@ export class WMSLayerProps extends CommonLayerProps {
   additionalQueryParams?: { [key: string]: string };
 
   @optional
+  formInputs?: LayerFormInput[];
+
+  @optional
   wcsConfig?: RawDataConfiguration;
 }
 
@@ -210,6 +213,21 @@ export class NSOLayerProps extends CommonLayerProps {
   dataField: string;
 }
 
+export class LayerForm {
+  id: LayerKey;
+  inputs: LayerFormInput[];
+}
+export class LayerFormInput {
+  id: LayerKey;
+  label: string;
+  value: string;
+  values: [
+    {
+      label: string;
+      value: string;
+    },
+  ];
+}
 export class StatsApi {
   url: string;
   zonesUrl: string;

--- a/src/context/mapStateSlice/selectors.ts
+++ b/src/context/mapStateSlice/selectors.ts
@@ -5,7 +5,7 @@ import { Map as MapBoxMap } from 'mapbox-gl';
 import type { RootState } from '../store';
 import type { LayerDataTypes } from '../layers/layer-data';
 import type { MapState } from '.';
-import type { LayerKey } from '../../config/types';
+import type { LayerKey, LayerForm } from '../../config/types';
 
 export const layersSelector = (state: RootState): MapState['layers'] =>
   state.mapState.layers;
@@ -21,5 +21,10 @@ export const layerDataSelector = (id: LayerKey, date?: number) => (
     ({ layer, date: dataDate }) =>
       layer.id === id && (!date || date === dataDate),
   );
+
+export const layerFormSelector = (id: LayerKey | undefined) => (
+  state: RootState,
+): LayerForm | undefined => state.mapState.layerForms.find(e => e.id === id);
+
 export const isLoading = (state: RootState): boolean =>
   state.mapState.loading > 0;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1814324/115591988-ead1ac00-a2fc-11eb-8c80-377db0b7b645.png)

This will add form for WMS Layer for additional Dimension ([AdditionalDomainAttributes](https://docs.geoserver.org/latest/en/user/data/raster/imagemosaic/configuration.html)). In Rainfall Extreme we want to see different result for different daily simulation(1, 2, 3, 4, 5days) and also different release hour for the prediction. To avoid adding one layer for each day we can use a simple selection form. Also for uniform hour availability on each day, we can use this instead of using full timestamp support as the XML text for date availability will get multiplied 

I'm using Mongolia - Pasture anomaly layer to demonstrate the config and impact on WMS image request, it will be removed upon PR passes the review