### PR TITLE
Custom Popup URL on layer click

### DIFF
--- a/public/data/mongolia/sample_popup.json
+++ b/public/data/mongolia/sample_popup.json
@@ -1,0 +1,56 @@
+{
+    "components": [
+        {
+            "type": "RawHtml",
+            "key": 1,
+            "params": {
+                "html": "<h4 style=\"color:red\">Test Raw HTML</h4>"
+            }
+        },
+        {
+            "type": "Chartjs",
+            "key": 2,
+            "params": {
+                "type": "Bar",
+                "height": 200,
+                "data": {
+                    "labels": [
+                        "Africa",
+                        "Asia",
+                        "Europe",
+                        "Latin America",
+                        "North America"
+                    ],
+                    "datasets": [
+                        {
+                            "label": "Population (millions)",
+                            "backgroundColor": [
+                                "#3e95cd",
+                                "#8e5ea2",
+                                "#3cba9f",
+                                "#e8c3b9",
+                                "#c45850"
+                            ],
+                            "data": [
+                                2478,
+                                5267,
+                                734,
+                                784,
+                                433
+                            ]
+                        }
+                    ]
+                },
+                "options": {
+                    "legend": {
+                        "display": false
+                    },
+                    "title": {
+                        "display": true,
+                        "text": "Predicted world population (millions) in 2050"
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/src/components/MapView/Layers/BoundaryLayer/index.tsx
+++ b/src/components/MapView/Layers/BoundaryLayer/index.tsx
@@ -1,12 +1,21 @@
 import React from 'react';
+import moment from 'moment';
 import { useDispatch, useSelector } from 'react-redux';
 import { get } from 'lodash';
 import { GeoJSONLayer } from 'react-mapbox-gl';
 import * as MapboxGL from 'mapbox-gl';
-import { showPopup } from '../../../../context/tooltipStateSlice';
+import {
+  showPopup,
+  fetchPopupData,
+  clearRemotePopupData,
+} from '../../../../context/tooltipStateSlice';
 import { BoundaryLayerProps } from '../../../../config/types';
 import { LayerData } from '../../../../context/layers/layer-data';
-import { layerDataSelector } from '../../../../context/mapStateSlice/selectors';
+import {
+  layersSelector,
+  layerDataSelector,
+  dateRangeSelector,
+} from '../../../../context/mapStateSlice/selectors';
 
 /**
  * To activate fillOnClick option, we "fill in"
@@ -36,10 +45,15 @@ function BoundaryLayer({ layer }: { layer: BoundaryLayerProps }) {
   const boundaryLayer = useSelector(layerDataSelector(layer.id)) as
     | LayerData<BoundaryLayerProps>
     | undefined;
+  const layers = useSelector(layersSelector);
+  const { startDate } = useSelector(dateRangeSelector);
   const { data } = boundaryLayer || {};
   if (!data) {
     return null; // boundary layer hasn't loaded yet. We load it on init inside MapView. We can't load it here since its a dependency of other layers.
   }
+  // use last layer as reference for popup content
+  // start with index 1 because index 0 is boundary layer itself
+  const lastLayer = layers.length > 1 ? layers[layers.length - 1] : null;
   return (
     <GeoJSONLayer
       id="boundaries"
@@ -50,12 +64,35 @@ function BoundaryLayer({ layer }: { layer: BoundaryLayerProps }) {
       fillOnMouseLeave={(evt: any) => onToggleHover('', evt.target)}
       fillOnClick={(evt: any) => {
         const coordinates = evt.lngLat;
-        const locationName = layer.adminLevelNames
-          .map(
-            level => get(evt.features[0], ['properties', level], '') as string,
-          )
-          .join(', ');
-        dispatch(showPopup({ coordinates, locationName }));
+        const locationNames = layer.adminLevelNames.map(
+          level => get(evt.features[0], ['properties', level], '') as string,
+        );
+        const params = {
+          coordinates,
+          locationName: locationNames.join(', '),
+          popupUrl: lastLayer ? lastLayer.popupUrl : undefined,
+        };
+        const featureProperties = evt.features[0].properties;
+        const areacode = featureProperties[layer.adminCode];
+        dispatch(clearRemotePopupData());
+        if (params.popupUrl) {
+          const { href } = window.location;
+          const url = new URL(
+            params.popupUrl.startsWith('http')
+              ? params.popupUrl
+              : `${href}${params.popupUrl}`,
+          );
+          url.searchParams.set('lon', coordinates.lng.toString());
+          url.searchParams.set('lat', coordinates.lat.toString());
+          url.searchParams.set('location', JSON.stringify(locationNames));
+          url.searchParams.set('areacode', areacode);
+          url.searchParams.set(
+            'date',
+            startDate ? moment(startDate).format('YYYY-MM-DD') : '',
+          );
+          dispatch(fetchPopupData(url.toString()));
+        }
+        dispatch(showPopup(params));
       }}
     />
   );

--- a/src/components/MapView/MapTooltip/Components/Chartjs.tsx
+++ b/src/components/MapView/MapTooltip/Components/Chartjs.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { cloneDeep } from 'lodash';
+import * as Charts from 'react-chartjs-2';
+import { PopupComponentSpec } from '../../../../context/tooltipStateSlice';
+
+export default ({ params }: PopupComponentSpec) => {
+  const chartParams = cloneDeep(params) as Charts.ChartComponentProps;
+  const Component: any = (Charts as any)[chartParams.type!];
+  return <Component {...chartParams} />;
+};

--- a/src/components/MapView/MapTooltip/Components/RawHtml.tsx
+++ b/src/components/MapView/MapTooltip/Components/RawHtml.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { PopupComponentSpec } from '../../../../context/tooltipStateSlice';
+
+export default function ({ params }: PopupComponentSpec) {
+  const markup = { __html: params.html };
+  // eslint-disable-next-line
+  return <div dangerouslySetInnerHTML={markup} />;
+}

--- a/src/components/MapView/MapTooltip/Components/index.tsx
+++ b/src/components/MapView/MapTooltip/Components/index.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { PopupComponentSpec } from '../../../../context/tooltipStateSlice';
+import Chartjs from './Chartjs';
+import RawHtml from './RawHtml';
+
+const components = {
+  Chartjs,
+  RawHtml,
+} as {
+  [key: string]: (props: PopupComponentSpec) => JSX.Element;
+};
+
+export default (props: PopupComponentSpec) => {
+  const { type } = props;
+  const Component = components[type];
+  return <Component {...props} />;
+};

--- a/src/components/MapView/MapTooltip/index.tsx
+++ b/src/components/MapView/MapTooltip/index.tsx
@@ -1,8 +1,14 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 import { Popup } from 'react-mapbox-gl';
-import { createStyles, withStyles, WithStyles } from '@material-ui/core';
+import {
+  CircularProgress,
+  createStyles,
+  withStyles,
+  WithStyles,
+} from '@material-ui/core';
 import { tooltipSelector } from '../../../context/tooltipStateSlice';
+import TooltipComponents from './Components/index';
 
 function MapTooltip({ classes }: TooltipProps) {
   const popup = useSelector(tooltipSelector);
@@ -14,13 +20,16 @@ function MapTooltip({ classes }: TooltipProps) {
       className={classes.popup}
     >
       <h4>{popup.locationName}</h4>
-      {Object.entries(popup.data)
-        .filter(([, value]) => value.coordinates === popup.coordinates)
-        .map(([key, value]) => (
-          <h4 key={key}>
-            {key}: {value.data}
-          </h4>
-        ))}
+      {popup.loading ? <CircularProgress /> : null}
+      {popup.remoteData
+        ? popup.remoteData.components.map(TooltipComponents)
+        : Object.entries(popup.data)
+            .filter(([, value]) => value.coordinates === popup.coordinates)
+            .map(([key, value]) => (
+              <h4 key={key}>
+                {key}: {value.data}
+              </h4>
+            ))}
     </Popup>
   ) : null;
 }

--- a/src/config/mongolia/layers.json
+++ b/src/config/mongolia/layers.json
@@ -300,6 +300,7 @@
     "type": "wms",
     "server_layer_name": "ModisAnomaly",
     "base_url": "https://mongolia.sibelius-datacube.org:5000",
+    "popup_url": "../data/mongolia/sample_popup.json",
     "date_interval": "days",
     "opacity": 0.5,
     "legend_text": "Compares the current pasture conditions to the long term average to calculate pasture anomaly",

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -156,6 +156,9 @@ export class CommonLayerProps {
 
   @optional // only optional for boundary layer
   group?: GroupDefinition;
+
+  @optional
+  popupUrl?: string;
 }
 
 export class BoundaryLayerProps extends CommonLayerProps {

--- a/src/context/mapStateSlice/index.ts
+++ b/src/context/mapStateSlice/index.ts
@@ -58,7 +58,6 @@ export const mapStateSlice = createSlice({
       const groupedLayer = Object.values(LayerDefinitions).filter(
         l => l.group?.name === name,
       );
-
       return {
         ...rest,
         layers: layers


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1814324/115642968-1af16d00-a346-11eb-90cb-b8f54d1975dd.png)

Popup can now fetch dynamic content from backend API with `popup_url` property. The popup above generated with:
```
    "title": "Pasture anomaly",
    "type": "wms",
    "base_url": "https://mongolia.sibelius-datacube.org:5000",
    "popup_url": "../data/mongolia/sample_popup.json",
```

and sample_popup.json:
```
{
    "components": [
        {
            "type": "RawHtml",
            "key": 1,
            "params": {
                "html": "<h4 style=\"color:red\">Test Raw HTML</h4>"
            }
        },
        {
            "type": "Chartjs",
            "key": 2,
            "params": {
                "type": "Bar",
                "height": 200,
                "data": {
                    "labels": [
                        "Africa",
                        "Asia",
                        "Europe",
                        "Latin America",
                        "North America"
                    ],
                    "datasets": [
                        {
                            "label": "Population (millions)",
                            "backgroundColor": [
                                "#3e95cd",
                                "#8e5ea2",
                                "#3cba9f",
                                "#e8c3b9",
                                "#c45850"
                            ],
                            "data": [
                                2478,
                                5267,
                                734,
                                784,
                                433
                            ]
                        }
                    ]
                },
                "options": {
                    "legend": {
                        "display": false
                    },
                    "title": {
                        "display": true,
                        "text": "Predicted world population (millions) in 2050"
                    }
                }
            }
        }
    ]
}
```

There are only 2 components for now, Chartjs and RawHtml. To avoid XSS attack on RawHtml we need additional libraries like [react-html-parser](https://github.com/wrakky/react-html-parser), but the build artifact for js will increase from 3132K to 3264K (about 132K).

I'm using Mongolia / Pasture anomaly to demonstrate the functionality, it will be removed on merge.