### PR TITLE
Use below/above language in the alert form. Add default boundaries file

### DIFF
--- a/alerting/src/entities/alerts.entity.ts
+++ b/alerting/src/entities/alerts.entity.ts
@@ -73,5 +73,5 @@ export class Alert {
   lastTriggered?: Date;
 
   @Column({ nullable: false, default: true })
-  active: boolean;
+  active: boolean = true;
 }

--- a/api-flask/app/database/alert_model.py
+++ b/api-flask/app/database/alert_model.py
@@ -28,7 +28,7 @@ class AlertModel(Base):
     min = Column('min', Integer)
     max = Column('max', Integer)
     zones = Column('zones', JSON, nullable=False)
-    active = Column('active', Boolean, nullable=False)
+    active = Column('active', Boolean, nullable=False, default=True)
     created_at = Column('created_at', DateTime, default=datetime.datetime.now)
     updated_at = Column('updated_at', DateTime, default=datetime.datetime.now,
                         onupdate=datetime.datetime.now)

--- a/src/components/MapView/AlertForm/__snapshots__/index.test.tsx.snap
+++ b/src/components/MapView/AlertForm/__snapshots__/index.test.tsx.snap
@@ -63,7 +63,7 @@ exports[`renders as expected 1`] = `
               classname="AlertForm-numberField-10"
               error="false"
               id="filled-number"
-              label="Min Below"
+              label="Below"
               type="number"
               value=""
               variant="filled"
@@ -71,7 +71,7 @@ exports[`renders as expected 1`] = `
             <mock-textfield
               classname="AlertForm-numberField-10"
               id="filled-number"
-              label="Max Above"
+              label="Above"
               style="padding-left: 10px;"
               type="number"
               value=""
@@ -143,6 +143,7 @@ exports[`renders as expected 1`] = `
             class="AlertForm-alertFormOptions-5"
           >
             <mock-textfield
+              fullwidth="true"
               id="alert-name"
               label="Alert Name"
               type="text"
@@ -154,6 +155,7 @@ exports[`renders as expected 1`] = `
             class="AlertForm-alertFormOptions-5"
           >
             <mock-textfield
+              fullwidth="true"
               id="email-address"
               label="Email Address"
               type="text"

--- a/src/components/MapView/AlertForm/index.tsx
+++ b/src/components/MapView/AlertForm/index.tsx
@@ -151,7 +151,7 @@ function AlertForm({ classes }: AlertFormProps) {
       thresholdType === 'below' ? changedOption : belowThreshold,
     );
     if (belowThresholdValue > aboveThresholdValue) {
-      setThresholdError('Min threshold is larger than Max!');
+      setThresholdError('Below threshold is larger than above threshold!');
     } else {
       setThresholdError(null);
     }
@@ -228,7 +228,7 @@ function AlertForm({ classes }: AlertFormProps) {
                   error={!!thresholdError}
                   helperText={thresholdError}
                   className={classes.numberField}
-                  label="Min Below"
+                  label="Below"
                   type="number"
                   value={belowThreshold}
                   onChange={onThresholdOptionChange('below')}
@@ -236,7 +236,7 @@ function AlertForm({ classes }: AlertFormProps) {
                 />
                 <TextField
                   id="filled-number"
-                  label="Max Above"
+                  label="Above"
                   className={classes.numberField}
                   style={{ paddingLeft: '10px' }}
                   value={aboveThreshold}
@@ -293,6 +293,7 @@ function AlertForm({ classes }: AlertFormProps) {
                   variant="filled"
                   value={alertName}
                   onChange={e => setAlertName(e.target.value)}
+                  fullWidth
                 />
               </div>
               <div className={classes.alertFormOptions}>
@@ -302,6 +303,7 @@ function AlertForm({ classes }: AlertFormProps) {
                   type="text"
                   variant="filled"
                   onChange={onChangeEmail}
+                  fullWidth
                 />
               </div>
             </div>

--- a/src/components/MapView/AlertForm/index.tsx
+++ b/src/components/MapView/AlertForm/index.tsx
@@ -150,7 +150,7 @@ function AlertForm({ classes }: AlertFormProps) {
     const belowThresholdValue = parseFloat(
       thresholdType === 'below' ? changedOption : belowThreshold,
     );
-    if (belowThresholdValue < aboveThresholdValue) {
+    if (belowThresholdValue > aboveThresholdValue) {
       setThresholdError('Min threshold is larger than Max!');
     } else {
       setThresholdError(null);
@@ -165,8 +165,8 @@ function AlertForm({ classes }: AlertFormProps) {
     const request: AlertRequest = {
       alert_name: alertName,
       alert_config: LayerDefinitions[hazardLayerId] as WMSLayerProps,
-      max: aboveThreshold,
-      min: belowThreshold,
+      max: parseFloat(aboveThreshold) || undefined,
+      min: parseFloat(belowThreshold) || undefined,
       zones: generateGeoJsonForRegionNames(),
       email,
       prism_url: getPrismUrl(),
@@ -230,8 +230,8 @@ function AlertForm({ classes }: AlertFormProps) {
                   className={classes.numberField}
                   label="Min Below"
                   type="number"
-                  value={aboveThreshold}
-                  onChange={onThresholdOptionChange('above')}
+                  value={belowThreshold}
+                  onChange={onThresholdOptionChange('below')}
                   variant="filled"
                 />
                 <TextField
@@ -239,8 +239,8 @@ function AlertForm({ classes }: AlertFormProps) {
                   label="Max Above"
                   className={classes.numberField}
                   style={{ paddingLeft: '10px' }}
-                  value={belowThreshold}
-                  onChange={onThresholdOptionChange('below')}
+                  value={aboveThreshold}
+                  onChange={onThresholdOptionChange('above')}
                   type="number"
                   variant="filled"
                 />

--- a/src/components/MapView/Analyser/__snapshots__/index.test.tsx.snap
+++ b/src/components/MapView/Analyser/__snapshots__/index.test.tsx.snap
@@ -194,7 +194,7 @@ exports[`renders as expected 1`] = `
               classname="Analyser-numberField-11"
               error="false"
               id="filled-number"
-              label="Min"
+              label="Below"
               type="number"
               value=""
               variant="filled"
@@ -202,7 +202,7 @@ exports[`renders as expected 1`] = `
             <mock-textfield
               classname="Analyser-numberField-11"
               id="filled-number"
-              label="Max"
+              label="Above"
               type="number"
               value=""
               variant="filled"

--- a/src/components/MapView/Analyser/index.tsx
+++ b/src/components/MapView/Analyser/index.tsx
@@ -121,7 +121,7 @@ function Analyser({ classes }: AnalyserProps) {
     const belowThresholdValue = parseFloat(
       thresholdType === 'below' ? changedOption : belowThreshold,
     );
-    if (belowThresholdValue < aboveThresholdValue) {
+    if (belowThresholdValue > aboveThresholdValue) {
       setThresholdError('Min threshold is larger than Max!');
     } else {
       setThresholdError(null);
@@ -252,16 +252,16 @@ function Analyser({ classes }: AnalyserProps) {
                   className={classes.numberField}
                   label="Min"
                   type="number"
-                  value={aboveThreshold}
-                  onChange={onThresholdOptionChange('above')}
+                  value={belowThreshold}
+                  onChange={onThresholdOptionChange('below')}
                   variant="filled"
                 />
                 <TextField
                   id="filled-number"
                   label="Max"
                   className={classes.numberField}
-                  value={belowThreshold}
-                  onChange={onThresholdOptionChange('below')}
+                  value={aboveThreshold}
+                  onChange={onThresholdOptionChange('above')}
                   type="number"
                   variant="filled"
                 />

--- a/src/components/MapView/Analyser/index.tsx
+++ b/src/components/MapView/Analyser/index.tsx
@@ -122,7 +122,7 @@ function Analyser({ classes }: AnalyserProps) {
       thresholdType === 'below' ? changedOption : belowThreshold,
     );
     if (belowThresholdValue > aboveThresholdValue) {
-      setThresholdError('Min threshold is larger than Max!');
+      setThresholdError('Below threshold is larger than above threshold!');
     } else {
       setThresholdError(null);
     }
@@ -250,7 +250,7 @@ function Analyser({ classes }: AnalyserProps) {
                   error={!!thresholdError}
                   helperText={thresholdError}
                   className={classes.numberField}
-                  label="Min"
+                  label="Below"
                   type="number"
                   value={belowThreshold}
                   onChange={onThresholdOptionChange('below')}
@@ -258,7 +258,7 @@ function Analyser({ classes }: AnalyserProps) {
                 />
                 <TextField
                   id="filled-number"
-                  label="Max"
+                  label="Above"
                   className={classes.numberField}
                   value={aboveThreshold}
                   onChange={onThresholdOptionChange('above')}

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -35,31 +35,40 @@ type Country =
 
 const DEFAULT: Country = 'mongolia';
 
+// Upload the boundary URL to S3 to enable the use of the API in a local environment.
+const DEFAULT_BOUNDARIES_FOLDER =
+  'https://prism-admin-boundaries.s3.us-east-2.amazonaws.com';
+
 const configMap = {
   indonesia: {
     appConfig: indonesiaConfig,
     rawLayers: indonesiaRawLayers,
     rawTables: indonesiaRawTables,
+    defaultBoudariesFile: `${DEFAULT_BOUNDARIES_FOLDER}/idn_admin_boundaries.json`,
   },
   mongolia: {
     appConfig: mongoliaConfig,
     rawLayers: mongoliaRawLayers,
     rawTables: mongoliaRawTables,
+    defaultBoudariesFile: `${DEFAULT_BOUNDARIES_FOLDER}/mng_admin_boundaries.json`,
   },
   mozambique: {
     appConfig: mozambiqueConfig,
     rawLayers: mozambiqueRawLayers,
     rawTables: mozambiqueRawTables,
+    defaultBoudariesFile: `${DEFAULT_BOUNDARIES_FOLDER}/moz_admin_boundaries.json`,
   },
   myanmar: {
     appConfig: myanmarConfig,
     rawLayers: myanmarRawLayers,
     rawTables: myanmarRawTables,
+    defaultBoudariesFile: `${DEFAULT_BOUNDARIES_FOLDER}/mmr_admin_boundaries.json`,
   },
   tajikistan: {
     appConfig: tajikistanConfig,
     rawLayers: tajikistanRawLayers,
     rawTables: tajikistanRawTables,
+    defaultBoudariesFile: `${DEFAULT_BOUNDARIES_FOLDER}/tjk_admin_boundaries_v2.json`,
   },
 } as const;
 
@@ -68,6 +77,8 @@ const safeCountry = (COUNTRY && has(configMap, COUNTRY)
   ? COUNTRY
   : DEFAULT) as Country;
 
-const { appConfig, rawLayers, rawTables } = configMap[safeCountry];
+const { appConfig, defaultBoudariesFile, rawLayers, rawTables } = configMap[
+  safeCountry
+];
 
-export { appConfig, rawLayers, rawTables };
+export { appConfig, defaultBoudariesFile, rawLayers, rawTables };

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -44,31 +44,31 @@ const configMap = {
     appConfig: indonesiaConfig,
     rawLayers: indonesiaRawLayers,
     rawTables: indonesiaRawTables,
-    defaultBoudariesFile: `${DEFAULT_BOUNDARIES_FOLDER}/idn_admin_boundaries.json`,
+    defaultBoundariesFile: `${DEFAULT_BOUNDARIES_FOLDER}/idn_admin_boundaries.json`,
   },
   mongolia: {
     appConfig: mongoliaConfig,
     rawLayers: mongoliaRawLayers,
     rawTables: mongoliaRawTables,
-    defaultBoudariesFile: `${DEFAULT_BOUNDARIES_FOLDER}/mng_admin_boundaries.json`,
+    defaultBoundariesFile: `${DEFAULT_BOUNDARIES_FOLDER}/mng_admin_boundaries.json`,
   },
   mozambique: {
     appConfig: mozambiqueConfig,
     rawLayers: mozambiqueRawLayers,
     rawTables: mozambiqueRawTables,
-    defaultBoudariesFile: `${DEFAULT_BOUNDARIES_FOLDER}/moz_admin_boundaries.json`,
+    defaultBoundariesFile: `${DEFAULT_BOUNDARIES_FOLDER}/moz_admin_boundaries.json`,
   },
   myanmar: {
     appConfig: myanmarConfig,
     rawLayers: myanmarRawLayers,
     rawTables: myanmarRawTables,
-    defaultBoudariesFile: `${DEFAULT_BOUNDARIES_FOLDER}/mmr_admin_boundaries.json`,
+    defaultBoundariesFile: `${DEFAULT_BOUNDARIES_FOLDER}/mmr_admin_boundaries.json`,
   },
   tajikistan: {
     appConfig: tajikistanConfig,
     rawLayers: tajikistanRawLayers,
     rawTables: tajikistanRawTables,
-    defaultBoudariesFile: `${DEFAULT_BOUNDARIES_FOLDER}/tjk_admin_boundaries_v2.json`,
+    defaultBoundariesFile: `${DEFAULT_BOUNDARIES_FOLDER}/tjk_admin_boundaries_v2.json`,
   },
 } as const;
 
@@ -77,8 +77,8 @@ const safeCountry = (COUNTRY && has(configMap, COUNTRY)
   ? COUNTRY
   : DEFAULT) as Country;
 
-const { appConfig, defaultBoudariesFile, rawLayers, rawTables } = configMap[
+const { appConfig, defaultBoundariesFile, rawLayers, rawTables } = configMap[
   safeCountry
 ];
 
-export { appConfig, defaultBoudariesFile, rawLayers, rawTables };
+export { appConfig, defaultBoundariesFile, rawLayers, rawTables };

--- a/src/context/analysisResultStateSlice.ts
+++ b/src/context/analysisResultStateSlice.ts
@@ -61,6 +61,10 @@ function getAdminBoundariesURL() {
   if (adminBoundariesPath.startsWith('http')) {
     return adminBoundariesPath;
   }
+  // do not send a local path to the API, use a fixed boundary file instead.
+  if (window.location.origin.includes('localhost')) {
+    return 'https://prism-admin-boundaries.s3.us-east-2.amazonaws.com/mng_admin_boundaries.json';
+  }
   // the regex here removes the dot at the beginning of a path, if there is one.
   // e.g the path might be ' ./data/xxx '  instead of ' /data/xxx '
   return window.location.origin + adminBoundariesPath.replace(/^\./, '');

--- a/src/context/analysisResultStateSlice.ts
+++ b/src/context/analysisResultStateSlice.ts
@@ -2,7 +2,7 @@ import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { Position } from 'geojson';
 import { get } from 'lodash';
 import type { CreateAsyncThunkTypes, RootState } from './store';
-import { defaultBoudariesFile } from '../config';
+import { defaultBoundariesFile } from '../config';
 import {
   AggregationOperations,
   AsyncReturnType,
@@ -65,7 +65,7 @@ function getAdminBoundariesURL() {
   }
   // do not send a local path to the API, use a fixed boundary file instead.
   if (isLocalhost) {
-    return defaultBoudariesFile;
+    return defaultBoundariesFile;
   }
   // the regex here removes the dot at the beginning of a path, if there is one.
   // e.g the path might be ' ./data/xxx '  instead of ' /data/xxx '

--- a/src/context/analysisResultStateSlice.ts
+++ b/src/context/analysisResultStateSlice.ts
@@ -26,6 +26,7 @@ import { layerDataSelector } from './mapStateSlice/selectors';
 import { LayerData, LayerDataParams, loadLayerData } from './layers/layer-data';
 import { DataRecord, NSOLayerData } from './layers/nso';
 import { BoundaryLayerData } from './layers/boundary';
+import { isLocalhost } from '../serviceWorker';
 
 const ANALYSIS_API_URL = 'https://prism-api.ovio.org/stats'; // TODO both needs to be stored somewhere
 
@@ -62,7 +63,7 @@ function getAdminBoundariesURL() {
     return adminBoundariesPath;
   }
   // do not send a local path to the API, use a fixed boundary file instead.
-  if (window.location.origin.includes('localhost')) {
+  if (isLocalhost) {
     return 'https://prism-admin-boundaries.s3.us-east-2.amazonaws.com/mng_admin_boundaries.json';
   }
   // the regex here removes the dot at the beginning of a path, if there is one.

--- a/src/context/analysisResultStateSlice.ts
+++ b/src/context/analysisResultStateSlice.ts
@@ -2,6 +2,7 @@ import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { Position } from 'geojson';
 import { get } from 'lodash';
 import type { CreateAsyncThunkTypes, RootState } from './store';
+import { defaultBoudariesFile } from '../config';
 import {
   AggregationOperations,
   AsyncReturnType,
@@ -64,7 +65,7 @@ function getAdminBoundariesURL() {
   }
   // do not send a local path to the API, use a fixed boundary file instead.
   if (isLocalhost) {
-    return 'https://prism-admin-boundaries.s3.us-east-2.amazonaws.com/mng_admin_boundaries.json';
+    return defaultBoudariesFile;
   }
   // the regex here removes the dot at the beginning of a path, if there is one.
   // e.g the path might be ' ./data/xxx '  instead of ' /data/xxx '

--- a/src/serviceWorker.tsx
+++ b/src/serviceWorker.tsx
@@ -12,7 +12,7 @@
 
 /* eslint-disable fp/no-mutation, no-param-reassign, no-console */
 
-const isLocalhost = Boolean(
+export const isLocalhost = Boolean(
   window.location.hostname === 'localhost' ||
     // [::1] is the IPv6 localhost address.
     window.location.hostname === '[::1]' ||

--- a/src/utils/analysis-utils.ts
+++ b/src/utils/analysis-utils.ts
@@ -30,6 +30,7 @@ import type {
 } from '../context/layers/layer-data';
 import { LayerDefinitions } from '../config/utils';
 import type { TableRow } from '../context/analysisResultStateSlice';
+import { isLocalhost } from '../serviceWorker';
 
 export type BaselineLayerData = NSOLayerData;
 type BaselineRecord = BaselineLayerData['layerData'][0];
@@ -158,8 +159,8 @@ export type AlertRequest = {
 };
 
 export function getPrismUrl(): string {
-  const { hostname, origin } = window.location;
-  if (hostname === 'localhost') {
+  const { origin } = window.location;
+  if (isLocalhost) {
     // Special case - if we're testing locally, then assume we are testing prism-mongolia
     // This is to ensure we don't pollute the database with localhost URLs
     return 'https://prism-mongolia.org';

--- a/src/utils/analysis-utils.ts
+++ b/src/utils/analysis-utils.ts
@@ -151,8 +151,8 @@ export type AlertRequest = {
   alert_name: string;
   alert_config: WMSLayerProps;
   email: string;
-  max?: string;
-  min?: string;
+  max?: number;
+  min?: number;
   prism_url: string;
   zones: object;
 };


### PR DESCRIPTION
- Re-order above / below thresholds
- transform missing min/max to undefined before sending the alert to the API
- Add "true" default to alert `active` field