### PR TITLE
Apply WCS GetCoverage request with version 2.0.0

### DIFF
--- a/src/components/MapView/Layers/raster-utils.ts
+++ b/src/components/MapView/Layers/raster-utils.ts
@@ -60,16 +60,6 @@ export type GeoTiffImage = {
   }) => Promise<Rasters>;
 };
 
-function numberOfTiles(
-  min: number,
-  max: number,
-  resolution: number,
-  pixelsPerTile: number,
-) {
-  const range = max - min;
-  return Math.ceil((range * resolution) / pixelsPerTile);
-}
-
 export function getWMSUrl(
   baseUrl: string,
   layerName: string,
@@ -95,29 +85,22 @@ export function getWMSUrl(
 export function getWCSUrl(
   baseUrl: string,
   layerName: string,
-  date: string | undefined,
-  xRange: readonly [number, number],
-  yRange: readonly [number, number],
-  width: number,
-  height?: number,
+  subsets: string[],
 ) {
   const params = {
     service: 'WCS',
     request: 'GetCoverage',
-    version: '1.0.0',
-    coverage: layerName,
-    crs: 'EPSG:4326',
-    bbox: [xRange[0], yRange[0], xRange[1], yRange[1]]
-      .map(v => v.toFixed(1))
-      .join(','),
-    width: width.toString(),
-    height: (height || width).toString(),
-    format: 'GeoTIFF',
-    ...(date && {
-      time: date,
-    }),
+    version: '2.0.0',
+    coverageId: layerName,
   };
-  return formatUrl(baseUrl, params);
+
+  const formattedUrl = formatUrl(baseUrl, params);
+
+  const formattedSubsets = subsets.map(s => `subset=${s}`).join('&');
+
+  const formattedUrlWithSubsets = `${formattedUrl}&${formattedSubsets}`;
+
+  return formattedUrlWithSubsets;
 }
 
 export function WCSRequestUrl(
@@ -125,8 +108,6 @@ export function WCSRequestUrl(
   layerName: string,
   date: string | undefined,
   extent: Extent,
-  resolution = 256,
-  maxPixels = 5096,
 ) {
   const [minX, minY, maxX, maxY] = extent;
   if (minX > maxX || minY > maxY) {
@@ -135,74 +116,18 @@ export function WCSRequestUrl(
     );
   }
 
-  // Get our image width & height at either the desired resolution or a down-sampled resolution if the resulting
-  // dimensions would exceed our `maxPixels` in height or width
-  const xRange = maxX - minX;
-  const yRange = maxY - minY;
-
-  const maxDim = Math.min(maxPixels, xRange * resolution, yRange * resolution);
-  const scale = maxDim / Math.max(xRange, yRange);
-
-  const width = Math.ceil(xRange * scale);
-  const height = Math.ceil(yRange * scale);
+  // Subsets are used as spatial and temporal filters.
+  // For mote info: https://docs.geoserver.geo-solutions.it/edu/en/wcs/get.html
+  const subsets: string[] = [
+    `longitude(${minX}, ${maxX})`,
+    `latitude(${minY}, ${maxY})`,
+  ];
 
   return getWCSUrl(
     baseUrl,
     layerName,
-    date,
-    [minX, maxX],
-    [minY, maxY],
-    width,
-    height,
+    date ? [...subsets, `time("${date}")`] : subsets,
   );
-}
-
-/**
- * Generates an array of WCS URLs to request GeoTiff tiles based on the given extent and pixel resolution.
- *
- * @param baseUrl Base resource URL
- * @param layerName ID of coverage/layer to get on the server
- * @param date
- * @param extent Full extent of the area to get coverage images for
- * @param resolution pixels per degree lat/long
- * @param pixelsPerTile
- */
-export function WCSTileUrls(
-  baseUrl: string,
-  layerName: string,
-  date: string,
-  extent: Extent,
-  resolution = 256,
-  pixelsPerTile = 512,
-): string[] {
-  // Set up tile grid in x/y.
-  const [minX, minY, maxX, maxY] = extent;
-  if (minX > maxX || minY > maxY) {
-    throw new Error(
-      `Could not generate tile grid for ${baseUrl}/${layerName}: the extent ${extent} seems malformed or else may contain "wrapping" which is not implemented in the function 'WCSTileUrls'`,
-    );
-  }
-
-  const degPerTile = pixelsPerTile / resolution;
-
-  const xTiles = numberOfTiles(minX, maxX, resolution, pixelsPerTile);
-  const yTiles = numberOfTiles(minY, maxY, resolution, pixelsPerTile);
-
-  return [...Array(xTiles)]
-    .map((_1, xIdx) => {
-      const x = [
-        xIdx * degPerTile + minX,
-        (xIdx + 1) * degPerTile + minX,
-      ] as const;
-      return [...Array(yTiles)].map((_2, yIdx) => {
-        const y = [
-          yIdx * degPerTile + minY,
-          (yIdx + 1) * degPerTile + minY,
-        ] as const;
-        return getWCSUrl(baseUrl, layerName, date, x, y, pixelsPerTile);
-      });
-    })
-    .flat();
 }
 
 export function getTransform(geoTiffImage: GeoTiffImage): TransformMatrix {

--- a/src/context/layers/wms.ts
+++ b/src/context/layers/wms.ts
@@ -1,4 +1,3 @@
-import { get } from 'lodash';
 import moment from 'moment';
 import type { LayerDataParams, LazyLoader } from './layer-data';
 import { WMSLayerProps } from '../../config/types';
@@ -32,7 +31,6 @@ export function getWCSLayerUrl({
     layer.serverLayerName,
     date ? moment(date).format('YYYY-MM-DD') : undefined,
     extent,
-    get(layer, 'wcsConfig.pixelResolution'),
   );
 }
 


### PR DESCRIPTION
This PR updates wcs request for analysis to version 2.0.0. With this version it will not be necessary to specify returning image WIDTH and HEIGHT.

**Changes**:
- Removed WCSTileUrls function. It is not used in the project.
- Modified getWCSUrl to version 2.0.0. Time parameter is now considered a subset request parameter.