### PR TITLE
Modify cql_filter to allow 00:00:00 time values

### DIFF
--- a/api-flask/app/zonal_stats.py
+++ b/api-flask/app/zonal_stats.py
@@ -1,7 +1,7 @@
 """Calulate zonal statistics and return a json or a geojson."""
 import logging
 from collections import defaultdict
-from datetime import datetime, timedelta
+from datetime import datetime
 from json import dump, load
 from urllib.parse import urlencode
 

--- a/api-flask/app/zonal_stats.py
+++ b/api-flask/app/zonal_stats.py
@@ -35,12 +35,7 @@ def get_wfs_response(wfs_params):
     cql_filter = []
     if 'time' in wfs_params.keys():
         from_date = datetime.strptime(wfs_params.get('time'), '%Y-%m-%d')
-        to_date = from_date + timedelta(days=1)
-
-        time_filters = ['timestamp AFTER {}'.format(from_date.isoformat()),
-                        'timestamp BEFORE {}'.format(to_date.isoformat())]
-
-        cql_filter.extend(time_filters)
+        cql_filter.append('timestamp DURING {}/P1D'.format(from_date.isoformat()))
 
     params = {
         'service': 'WFS',


### PR DESCRIPTION
This PR updates the Web feature service request for zonal statistics in the backend. Basically, the change includes time values of 00:00:00z. The issue was evident while executing the following query:

```
{
	"geotiff_url": "https://odc.ovio.org/?service=WCS&request=GetCoverage&version=1.0.0&coverage=wp_pop_cicunadj&crs=EPSG%3A4326&bbox=92.2%2C9.7%2C101.2%2C28.5&width=1098&height=2304&format=GeoTIFF",
	"zones_url": "https://prism-admin-boundaries.s3.us-east-2.amazonaws.com/mmr_admin_boundaries.json",
	"group_by": "TS_PCODE",
	"wfs_params": {
		"url": "https://geonode.wfp.org/geoserver/ows",
		"layer_name": "mmr_gdacs_buffers",
		"time": "2015-07-29"
	}
}
```

For more information about cql filters, please check: https://docs.geoserver.org/stable/en/user/filter/ecql_reference.html#filter-ecql-reference




