### PR TITLE
update WMS version to 1.3.0

### DIFF
--- a/src/config/myanmar/layers.json
+++ b/src/config/myanmar/layers.json
@@ -1015,14 +1015,14 @@
   "adamts_nodes": {
     "title": "Tropical storm - nodes",
     "type": "wms",
-    "server_layer_name": "wld_gdacs_tc_events_nodes_mmr",
+    "server_layer_name": "wld_gdacs_tc_events_nodes",
     "opacity": 0.7,
     "legend": [],
     "legend_text": "Tropical storm - nodes",
     "base_url": "https://geonode.wfp.org/geoserver",
     "group": {
       "name": "Tropical Storms",
-      "main": true
+      "main": false
     },
     "feature_info_props": {
       "event_name": {
@@ -1042,13 +1042,13 @@
   "adamts_buffers": {
     "title": "Tropical Storms - Wind buffers",
     "type": "wms",
-    "server_layer_name": "wld_gdacs_tc_events_buffers",
+    "server_layer_name": "mmr_gdacs_buffers",
     "opacity": 0.7,
     "legend": [],
     "legend_text": "Wind buffers (radii) estimate potential wind speeds along the path of a storm with a buffer estimating the area exposed to each wind speed category. Source: GDACS",
     "group": {
       "name": "Tropical Storms",
-      "main": false
+      "main": true
     },
     "base_url": "https://geonode.wfp.org/geoserver",
     "feature_info_props": {

--- a/src/config/myanmar/prism.json
+++ b/src/config/myanmar/prism.json
@@ -14,7 +14,7 @@
   },
   "categories": {
     "hazards": {
-      "tropical_storms": ["adamts_nodes"],
+      "tropical_storms": ["adamts_buffers"],
       "floods": ["hydra_s1"],
       "rainfall": [
         "rainfall_dekad",

--- a/src/utils/server-utils.ts
+++ b/src/utils/server-utils.ts
@@ -358,7 +358,7 @@ function fetchFeatureInfo(
   const requestParams = {
     service: 'WMS',
     request: 'getFeatureInfo',
-    version: '1.1.1',
+    version: '1.3.0',
     exceptions: 'application/json',
     infoFormat: 'application/json',
     layers: layerNames,


### PR DESCRIPTION
The WMS version we were using is very out of date. 1.3.0 has been active since 2006. Tested locally for ODC OWS layers and GeoServer layers as well without issue.

This will close https://github.com/WFP-VAM/prism-frontend/issues/201 