### PR TITLE
Include wcs GetCoverage 2.x requests

### DIFF
--- a/src/components/MapView/Layers/raster-utils.ts
+++ b/src/components/MapView/Layers/raster-utils.ts
@@ -166,10 +166,7 @@ export function WCSRequestUrl(
     );
   }
 
-  if (
-    wcsConfig?.version &&
-    wcsConfig?.version !== WcsGetCoverageVersion.oneZeroZero
-  ) {
+  if (wcsConfig?.version === WcsGetCoverageVersion.twoZeroZero) {
     return getWCS2Url(layer, date, extent);
   }
 

--- a/src/components/MapView/Layers/raster-utils.ts
+++ b/src/components/MapView/Layers/raster-utils.ts
@@ -93,7 +93,7 @@ export function getWMSUrl(
 
   return formatUrl(`${baseUrl}/wms`, params);
 }
-export function getWCSUrl(
+export function getWCSUrl1(
   baseUrl: string,
   layerName: string,
   date: string | undefined,
@@ -186,7 +186,7 @@ export function WCSRequestUrl(
   const width = Math.ceil(xRange * scale);
   const height = Math.ceil(yRange * scale);
 
-  return getWCSUrl(
+  return getWCSUrl1(
     baseUrl,
     serverLayerName,
     date,
@@ -239,7 +239,7 @@ export function WCSTileUrls(
           yIdx * degPerTile + minY,
           (yIdx + 1) * degPerTile + minY,
         ] as const;
-        return getWCSUrl(baseUrl, layerName, date, x, y, pixelsPerTile);
+        return getWCSUrl1(baseUrl, layerName, date, x, y, pixelsPerTile);
       });
     })
     .flat();

--- a/src/components/MapView/Layers/raster-utils.ts
+++ b/src/components/MapView/Layers/raster-utils.ts
@@ -93,7 +93,7 @@ export function getWMSUrl(
 
   return formatUrl(`${baseUrl}/wms`, params);
 }
-export function getWCSUrl1(
+export function getWCSv1Url(
   baseUrl: string,
   layerName: string,
   date: string | undefined,
@@ -121,7 +121,7 @@ export function getWCSUrl1(
   return formatUrl(baseUrl, params);
 }
 
-export function getWCS2Url(
+export function getWCSv2Url(
   layer: WMSLayerProps,
   date: string | undefined,
   extent: Extent,
@@ -167,7 +167,7 @@ export function WCSRequestUrl(
   }
 
   if (wcsConfig?.version === WcsGetCoverageVersion.twoZeroZero) {
-    return getWCS2Url(layer, date, extent);
+    return getWCSv2Url(layer, date, extent);
   }
 
   const resolution = wcsConfig?.pixelResolution || 256;
@@ -183,7 +183,7 @@ export function WCSRequestUrl(
   const width = Math.ceil(xRange * scale);
   const height = Math.ceil(yRange * scale);
 
-  return getWCSUrl1(
+  return getWCSv1Url(
     baseUrl,
     serverLayerName,
     date,
@@ -236,7 +236,7 @@ export function WCSTileUrls(
           yIdx * degPerTile + minY,
           (yIdx + 1) * degPerTile + minY,
         ] as const;
-        return getWCSUrl1(baseUrl, layerName, date, x, y, pixelsPerTile);
+        return getWCSv1Url(baseUrl, layerName, date, x, y, pixelsPerTile);
       });
     })
     .flat();

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -128,10 +128,19 @@ export type GroupDefinition = {
   main: boolean;
 };
 
+export enum WcsGetCoverageVersion {
+  oneZeroZero = '1.0.0',
+  twoZeroZero = '2.0.0',
+}
+
 export type RawDataConfiguration = {
   scale?: number;
   offset?: number;
   noData?: number;
+
+  // WCS GetCoverage request version.
+  version?: WcsGetCoverageVersion;
+
   // Geotiff pixel resolution, in pixels per degree lat/long
   pixelResolution?: number;
 };

--- a/src/context/layers/wms.ts
+++ b/src/context/layers/wms.ts
@@ -1,4 +1,3 @@
-import { get } from 'lodash';
 import moment from 'moment';
 import type { LayerDataParams, LazyLoader } from './layer-data';
 import { WMSLayerProps } from '../../config/types';
@@ -28,11 +27,9 @@ export function getWCSLayerUrl({
   }
 
   return WCSRequestUrl(
-    layer.baseUrl,
-    layer.serverLayerName,
+    layer,
     date ? moment(date).format('YYYY-MM-DD') : undefined,
     extent,
-    get(layer, 'wcsConfig.pixelResolution'),
   );
 }
 


### PR DESCRIPTION
This Pull request allows PRISM to execute WCS GetCoverage requests using versions 2.x. This option is enabled from the layer config file.

**How to test:** 
- As an example, modify wcsConfig for a layer in myanmar https://github.com/WFP-VAM/prism-frontend/blob/master/src/config/myanmar/layers.json#L438 and include **version** parameter to **2.0.0**.
- Verify within Network tab in your browser the geotiff url when executing Layer analysis