### PR TITLE
Enforce WMS GetFeatureInfo version to 1.1.1

### DIFF
--- a/src/config/mozambique/layers.json
+++ b/src/config/mozambique/layers.json
@@ -183,7 +183,7 @@
         "type": "text",
         "label": "Event name"
       },
-      "pub_date": {
+      "timestamp": {
         "type": "date",
         "label": "Publication date"
       }

--- a/src/config/myanmar/layers.json
+++ b/src/config/myanmar/layers.json
@@ -1032,7 +1032,7 @@
         "type": "text",
         "label": "Event name"
       },
-      "pub_date": {
+      "timestamp": {
         "type": "date",
         "label": "Publication date"
       },
@@ -1060,7 +1060,7 @@
         "type": "text",
         "label": "Event name"
       },
-      "pub_date": {
+      "timestamp": {
         "type": "date",
         "label": "Publication date"
       },

--- a/src/utils/server-utils.ts
+++ b/src/utils/server-utils.ts
@@ -358,7 +358,7 @@ function fetchFeatureInfo(
   const requestParams = {
     service: 'WMS',
     request: 'getFeatureInfo',
-    version: '1.3.0',
+    version: '1.1.1',
     exceptions: 'application/json',
     infoFormat: 'application/json',
     layers: layerNames,


### PR DESCRIPTION
Closes #212 

This PR modifies WMS GetFeatureInfo to version 1.1.1

It also modifies layer featureInfoProps to use **timestamp** field instead of **pub_date**

This branch has been deployed to http://demo-myanmar.surge.sh/