### PR TITLE
🎉 Feature/pop analysis data table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ yarn-error.log*
 # Editors
 .vscode/
 .idea/
+/.log/

--- a/src/components/AnalysisDataDrawer/DataTable/DataTableRow/index.tsx
+++ b/src/components/AnalysisDataDrawer/DataTable/DataTableRow/index.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { TableRow, TableCell } from '@material-ui/core';
+import { TableRowType } from '../../../../context/tableStateSlice';
+
+export interface TableRowProps {
+  className?: string;
+  columns: string[];
+  rowData?: TableRowType;
+}
+
+const DataTableRow = ({ className, columns, rowData }: TableRowProps) => (
+  <TableRow>
+    {columns.map(column => (
+      <TableCell className={className} key={column}>
+        {' '}
+        {rowData ? rowData[column] : column}{' '}
+      </TableCell>
+    ))}
+  </TableRow>
+);
+
+export default DataTableRow;

--- a/src/components/AnalysisDataDrawer/DataTable/index.tsx
+++ b/src/components/AnalysisDataDrawer/DataTable/index.tsx
@@ -53,7 +53,7 @@ const DataTable = ({ classes, maxResults }: DataTableProps) => {
   }
 
   const title = data.getTitle();
-  const legendText = data.getStatTitle();
+  const { legendText } = data;
   const { features } = data.featureCollection;
   const featureProperties = features.map(feature => {
     return {

--- a/src/components/AnalysisDataDrawer/DataTable/index.tsx
+++ b/src/components/AnalysisDataDrawer/DataTable/index.tsx
@@ -56,19 +56,28 @@ const DataTable = ({ classes, maxResults }: DataTableProps) => {
   const legendText = data.getStatTitle();
   const { features } = data.featureCollection;
   const featureProperties = features.map(feature => {
-    return { name: feature.properties?.TS, value: feature.properties?.label };
+    return {
+      name: feature.properties?.TS,
+      speed: feature.properties?.label,
+      sum: feature.properties?.sum,
+    };
   });
 
   type RowType = {
     name: string;
-    value: string[];
+    value: number[];
+    total: number;
   }[];
 
   const tableData: RowType = Object.entries(
     _.mapValues(_.groupBy(featureProperties, 'name'), properties =>
-      properties.map(prop => prop.value),
+      properties.map(prop => prop.sum || 0),
     ),
-  ).map(feature => ({ name: feature[0], value: feature[1] }));
+  ).map(feature => ({
+    name: feature[0],
+    value: feature[1],
+    total: feature[1].reduce((a, b) => a + b),
+  }));
 
   return (
     <div>
@@ -93,9 +102,9 @@ const DataTable = ({ classes, maxResults }: DataTableProps) => {
                   className={classes.headCells}
                   columns={[
                     'Township',
-                    '60 km/h exposure',
-                    '90 km/h exposure',
-                    '120 km/h exposure',
+                    '60 km/h',
+                    '90 km/h',
+                    '120 km/h',
                     'Total',
                   ]}
                 />
@@ -114,13 +123,13 @@ const DataTable = ({ classes, maxResults }: DataTableProps) => {
                       {rowData.value[0]}
                     </TableCell>
                     <TableCell className={classes.tableCells}>
-                      {rowData.value[1] || '-'}
+                      {rowData.value[1] || 0}
                     </TableCell>
                     <TableCell className={classes.tableCells}>
-                      {rowData.value[2] || '-'}
+                      {rowData.value[2] || 0}
                     </TableCell>
                     <TableCell className={classes.tableCells}>
-                      {rowData.value[3] || '-'}
+                      {rowData.total || 0}
                     </TableCell>
                   </TableRow>
                 ))}

--- a/src/components/AnalysisDataDrawer/DataTable/index.tsx
+++ b/src/components/AnalysisDataDrawer/DataTable/index.tsx
@@ -1,0 +1,139 @@
+import _ from 'lodash';
+import React from 'react';
+import { useSelector } from 'react-redux';
+import {
+  Table,
+  TableBody,
+  TableContainer,
+  TableRow,
+  TableCell,
+  TableHead,
+  withStyles,
+  WithStyles,
+  createStyles,
+  CircularProgress,
+  Paper,
+  Box,
+} from '@material-ui/core';
+import {
+  isAnalysisLoadingSelector,
+  analysisResultSelector,
+} from '../../../context/analysisResultStateSlice';
+import DataTableRow from './DataTableRow';
+
+const styles = () =>
+  createStyles({
+    root: {
+      width: '100%',
+      height: '100%',
+      color: 'black',
+    },
+    container: {
+      height: '100%',
+      maxHeight: '100%',
+    },
+    headCells: {
+      color: 'black',
+    },
+    tableCells: {
+      color: 'darkGrey',
+    },
+  });
+
+export interface DataTableProps extends WithStyles<typeof styles> {
+  maxResults: number;
+}
+
+const DataTable = ({ classes, maxResults }: DataTableProps) => {
+  const loading = useSelector(isAnalysisLoadingSelector);
+  const data = useSelector(analysisResultSelector);
+
+  if (!data) {
+    return null;
+  }
+
+  const title = data.getTitle();
+  const legendText = data.getStatTitle();
+
+  const dataTable: string[][] = [];
+  const { features } = data.featureCollection;
+
+  const featureProperties = features.map(feature => {
+    return { name: feature.properties?.TS, value: feature.properties?.label };
+  });
+
+  type RowType = {
+    name: string;
+    value: string[];
+  }[];
+
+  const tableData: RowType = Object.entries(
+    _.mapValues(_.groupBy(featureProperties, 'name'), properties =>
+      properties.map(prop => prop.value),
+    ),
+  ).map(feature => ({ name: feature[0], value: feature[1] }));
+
+  return (
+    <div>
+      <h2>{title}</h2>
+      <p>{legendText}</p>
+
+      {loading ? (
+        <Box
+          display="flex"
+          justifyContent="center"
+          alignItems="center"
+          height={300}
+        >
+          <CircularProgress size={40} color="secondary" />
+        </Box>
+      ) : (
+        <Paper className={classes.root}>
+          <TableContainer className={classes.container}>
+            <Table stickyHeader aria-label={`table showing ${title}`}>
+              <TableHead>
+                <DataTableRow
+                  className={classes.headCells}
+                  columns={[
+                    'Township',
+                    '60 km/h exposure',
+                    '90 km/h exposure',
+                    '120 km/h exposure',
+                    'Total',
+                  ]}
+                />
+              </TableHead>
+              <TableBody>
+                {tableData.slice(1, maxResults).map((rowData, idx) => (
+                  <TableRow
+                    // eslint-disable-next-line react/no-array-index-key
+                    key={idx}
+                    className={classes.tableCells}
+                  >
+                    <TableCell className={classes.tableCells}>
+                      {rowData.name}
+                    </TableCell>
+                    <TableCell className={classes.tableCells}>
+                      {rowData.value[0]}
+                    </TableCell>
+                    <TableCell className={classes.tableCells}>
+                      {rowData.value[1] || '-'}
+                    </TableCell>
+                    <TableCell className={classes.tableCells}>
+                      {rowData.value[2] || '-'}
+                    </TableCell>
+                    <TableCell className={classes.tableCells}>
+                      {rowData.value[3] || '-'}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </Paper>
+      )}
+    </div>
+  );
+};
+
+export default withStyles(styles)(DataTable);

--- a/src/components/AnalysisDataDrawer/DataTable/index.tsx
+++ b/src/components/AnalysisDataDrawer/DataTable/index.tsx
@@ -54,10 +54,7 @@ const DataTable = ({ classes, maxResults }: DataTableProps) => {
 
   const title = data.getTitle();
   const legendText = data.getStatTitle();
-
-  const dataTable: string[][] = [];
   const { features } = data.featureCollection;
-
   const featureProperties = features.map(feature => {
     return { name: feature.properties?.TS, value: feature.properties?.label };
   });

--- a/src/components/AnalysisDataDrawer/index.tsx
+++ b/src/components/AnalysisDataDrawer/index.tsx
@@ -8,29 +8,22 @@ import {
   Drawer,
 } from '@material-ui/core';
 import DataTable from './DataTable';
-import AnalysisDataTable from '../AnalysisDataDrawer/DataTable';
-import { getIsShowing, hideTable } from '../../context/tableStateSlice';
 import {
   isDataTableDrawerActiveSelector,
   hideDataTableDrawer,
 } from '../../context/analysisResultStateSlice';
 
-function DataDrawer({ classes }: DataDrawerProps) {
-  const tableIsShowing = useSelector(getIsShowing);
-  const analysisTableIsShowing = useSelector(isDataTableDrawerActiveSelector);
-  const isShowing = tableIsShowing || analysisTableIsShowing;
-
+function AnalysisDataDrawer({ classes }: DataDrawerProps) {
+  const tableIsShowing = useSelector(isDataTableDrawerActiveSelector);
   const dispatch = useDispatch();
   const handleClose = () => {
-    dispatch(hideTable());
     dispatch(hideDataTableDrawer());
   };
 
   return (
-    <Drawer anchor="left" open={isShowing} onClose={handleClose}>
+    <Drawer anchor="left" open={tableIsShowing} onClose={handleClose}>
       <div className={classes.drawerContent}>
-        {tableIsShowing && <DataTable maxResults={1000} />}
-        {analysisTableIsShowing && <AnalysisDataTable maxResults={1000} />}
+        <DataTable maxResults={1000} />
       </div>
     </Drawer>
   );
@@ -47,4 +40,4 @@ const styles = (theme: Theme) =>
 
 export interface DataDrawerProps extends WithStyles<typeof styles> {}
 
-export default withStyles(styles)(DataDrawer);
+export default withStyles(styles)(AnalysisDataDrawer);

--- a/src/components/DataDrawer/__snapshots__/index.test.tsx.snap
+++ b/src/components/DataDrawer/__snapshots__/index.test.tsx.snap
@@ -8,11 +8,7 @@ exports[`renders as expected 1`] = `
   >
     <div
       class="DataDrawer-drawerContent-1"
-    >
-      <data-table
-        maxresults="1000"
-      />
-    </div>
+    />
   </mock-drawer>
 </div>
 `;

--- a/src/components/MapView/Legends/exposedPopulationAnalysis.tsx
+++ b/src/components/MapView/Legends/exposedPopulationAnalysis.tsx
@@ -15,12 +15,12 @@ import {
 } from '../../../utils/analysis-utils';
 import { dateRangeSelector } from '../../../context/mapStateSlice/selectors';
 import {
-  isAnalysisLayerActiveSelector,
+  isDataTableDrawerActiveSelector,
   ExposedPopulationDispatchParams,
   requestAndStoreExposedPopulation,
   isExposureAnalysisLoadingSelector,
   clearAnalysisResult,
-  setIsMapLayerActive,
+  setIsDataTableDrawerActive,
 } from '../../../context/analysisResultStateSlice';
 import {
   LayerType,
@@ -52,7 +52,7 @@ const ExposedPopulationAnalysis = ({
   exposure,
 }: AnalysisProps) => {
   const { startDate: selectedDate } = useSelector(dateRangeSelector);
-  const isMapLayerActive = useSelector(isAnalysisLayerActiveSelector);
+  const isDataTableDrawerActive = useSelector(isDataTableDrawerActiveSelector);
 
   const analysisExposureLoading = useSelector(
     isExposureAnalysisLoadingSelector,
@@ -80,20 +80,26 @@ const ExposedPopulationAnalysis = ({
     await dispatch(requestAndStoreExposedPopulation(params));
   };
 
-  const ResultSwitches = () => (
-    <FormGroup>
-      <AnalysisFormControlLabel
-        control={
-          <Switch
-            color="primary"
-            checked={isMapLayerActive}
-            onChange={e => dispatch(setIsMapLayerActive(e.target.checked))}
-          />
-        }
-        label="Map View"
-      />
-    </FormGroup>
-  );
+  const ResultSwitches = () => {
+    const handleTableViewChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+      dispatch(setIsDataTableDrawerActive(e.target.checked));
+    };
+
+    return (
+      <FormGroup>
+        <AnalysisFormControlLabel
+          control={
+            <Switch
+              color="primary"
+              checked={isDataTableDrawerActive}
+              onChange={handleTableViewChange}
+            />
+          }
+          label="Table view"
+        />
+      </FormGroup>
+    );
+  };
 
   if (!result || result instanceof BaselineLayerResult) {
     return (

--- a/src/components/MapView/__snapshots__/index.test.tsx.snap
+++ b/src/components/MapView/__snapshots__/index.test.tsx.snap
@@ -22,6 +22,37 @@ exports[`renders as expected 1`] = `
         class="MuiGrid-root MuiGrid-item"
       >
         <mock-analyser />
+        <div
+          class="AlertForm-alertForm-5"
+        >
+          <mock-button
+            color="primary"
+            variant="contained"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 22c1.1 0 2-.9 2-2h-4c0 1.1.89 2 2 2zm6-6v-5c0-3.07-1.64-5.64-4.5-6.32V4c0-.83-.67-1.5-1.5-1.5s-1.5.67-1.5 1.5v.68C7.63 5.36 6 7.92 6 11v5l-2 2v1h16v-1l-2-2z"
+              />
+            </svg>
+            <mock-typography
+              classname="AlertForm-alertLabel-4"
+              variant="body2"
+            >
+              Create Alert
+            </mock-typography>
+            <mock-arrowdropdown
+              fontsize="small"
+            />
+          </mock-button>
+          <div
+            class="MuiBox-root MuiBox-root-15 AlertForm-alertFormMenu-6"
+          />
+        </div>
       </div>
       <div
         class="MuiGrid-root MuiGrid-item"

--- a/src/components/NavBar/__snapshots__/index.test.tsx.snap
+++ b/src/components/NavBar/__snapshots__/index.test.tsx.snap
@@ -32,8 +32,13 @@ exports[`renders as expected 1`] = `
           >
             <mock-menuitem
               icon="icon_climate.png"
-              layerscategories="[object Object],[object Object],[object Object]"
+              layerscategories="[object Object],[object Object],[object Object],[object Object],[object Object]"
               title="Hazards"
+            />
+            <mock-menuitem
+              icon="icon_vulnerable.png"
+              layerscategories="[object Object],[object Object],[object Object],[object Object],[object Object]"
+              title="Vulnerability"
             />
             <mock-menuitem
               icon="icon_basemap.png"
@@ -41,24 +46,9 @@ exports[`renders as expected 1`] = `
               title="Exposure"
             />
             <mock-menuitem
-              icon="icon_vulnerable.png"
-              layerscategories="[object Object],[object Object]"
-              title="Vulnerability"
-            />
-            <mock-menuitem
-              icon="icon_capacity.png"
-              layerscategories="[object Object]"
-              title="Capacity"
-            />
-            <mock-menuitem
               icon="icon_impact.png"
-              layerscategories="[object Object],[object Object]"
-              title="Risk"
-            />
-            <mock-menuitem
-              icon="icon_table.png"
               layerscategories="[object Object],[object Object],[object Object]"
-              title="Tables"
+              title="Risk"
             />
           </div>
           <div
@@ -224,8 +214,14 @@ exports[`renders as expected 1`] = `
                     <mock-menuitemmobile
                       expanded=""
                       icon="icon_climate.png"
-                      layerscategories="[object Object],[object Object],[object Object]"
+                      layerscategories="[object Object],[object Object],[object Object],[object Object],[object Object]"
                       title="Hazards"
+                    />
+                    <mock-menuitemmobile
+                      expanded=""
+                      icon="icon_vulnerable.png"
+                      layerscategories="[object Object],[object Object],[object Object],[object Object],[object Object]"
+                      title="Vulnerability"
                     />
                     <mock-menuitemmobile
                       expanded=""
@@ -235,27 +231,9 @@ exports[`renders as expected 1`] = `
                     />
                     <mock-menuitemmobile
                       expanded=""
-                      icon="icon_vulnerable.png"
-                      layerscategories="[object Object],[object Object]"
-                      title="Vulnerability"
-                    />
-                    <mock-menuitemmobile
-                      expanded=""
-                      icon="icon_capacity.png"
-                      layerscategories="[object Object]"
-                      title="Capacity"
-                    />
-                    <mock-menuitemmobile
-                      expanded=""
                       icon="icon_impact.png"
-                      layerscategories="[object Object],[object Object]"
-                      title="Risk"
-                    />
-                    <mock-menuitemmobile
-                      expanded=""
-                      icon="icon_table.png"
                       layerscategories="[object Object],[object Object],[object Object]"
-                      title="Tables"
+                      title="Risk"
                     />
                   </div>
                 </div>

--- a/src/context/analysisResultStateSlice.ts
+++ b/src/context/analysisResultStateSlice.ts
@@ -14,6 +14,7 @@ import {
   WfsRequestParams,
   LayerKey,
   ExposedPopulationDefinition,
+  TableType,
 } from '../config/types';
 import {
   BaselineLayerResult,
@@ -39,11 +40,20 @@ import { isLocalhost } from '../serviceWorker';
 
 const ANALYSIS_API_URL = 'https://prism-api.ovio.org/stats'; // TODO both needs to be stored somewhere
 
+export type TableRowType = { [key: string]: string | number };
+export type TableData = {
+  columns: string[];
+  rows: TableRowType[];
+};
+
 type AnalysisResultState = {
+  definition?: TableType;
+  tableData?: TableData;
   result?: AnalysisResult;
   error?: string;
   isLoading: boolean;
   isMapLayerActive: boolean;
+  isDataTableDrawerActive: boolean;
   isExposureLoading: boolean;
 };
 
@@ -57,6 +67,7 @@ export type TableRow = {
 const initialState: AnalysisResultState = {
   isLoading: false,
   isMapLayerActive: true,
+  isDataTableDrawerActive: false,
   isExposureLoading: false,
 };
 
@@ -331,6 +342,17 @@ export const analysisResultSlice = createSlice({
       ...state,
       isMapLayerActive: payload,
     }),
+    setIsDataTableDrawerActive: (
+      state,
+      { payload }: PayloadAction<boolean>,
+    ) => ({
+      ...state,
+      isDataTableDrawerActive: payload,
+    }),
+    hideDataTableDrawer: state => ({
+      ...state,
+      isDataTableDrawerActive: false,
+    }),
     clearAnalysisResult: state => ({
       ...state,
       result: undefined,
@@ -402,6 +424,9 @@ export const analysisResultSlice = createSlice({
 });
 
 // Getters
+export const getCurrentDefinition = (state: RootState): TableType | undefined =>
+  state.analysisResultState.definition;
+
 export const analysisResultSelector = (
   state: RootState,
 ): AnalysisResult | undefined => state.analysisResultState.result;
@@ -415,9 +440,14 @@ export const isExposureAnalysisLoadingSelector = (state: RootState): boolean =>
 export const isAnalysisLayerActiveSelector = (state: RootState): boolean =>
   state.analysisResultState.isMapLayerActive;
 
+export const isDataTableDrawerActiveSelector = (state: RootState): boolean =>
+  state.analysisResultState.isDataTableDrawerActive;
+
 // Setters
 export const {
   setIsMapLayerActive,
+  setIsDataTableDrawerActive,
+  hideDataTableDrawer,
   clearAnalysisResult,
 } = analysisResultSlice.actions;
 

--- a/src/context/analysisResultStateSlice.ts
+++ b/src/context/analysisResultStateSlice.ts
@@ -119,6 +119,7 @@ function generateTableFromApiData(
     // find feature (a cell on the map) from admin boundaries json that closely matches this api row.
     // we decide it matches if the feature json has the same name as the name for this row.
     // once we find it we can get the corresponding local name.
+
     const featureBoundary = adminLayerData.features.find(
       feature => feature.properties?.[adminLevelName] === row[adminLevelName],
     );

--- a/src/context/analysisResultStateSlice.ts
+++ b/src/context/analysisResultStateSlice.ts
@@ -240,8 +240,15 @@ export const requestAndStoreExposedPopulation = createAsyncThunk<
   };
 
   const legend = createLegendFromFeatureArray(features, statistic);
+  const legendText = wfsLayer.title;
 
-  return new ExposedPopulationResult(collection, statistic, legend, key);
+  return new ExposedPopulationResult(
+    collection,
+    statistic,
+    legend,
+    legendText,
+    key,
+  );
 });
 
 export const requestAndStoreAnalysis = createAsyncThunk<

--- a/src/utils/analysis-utils.ts
+++ b/src/utils/analysis-utils.ts
@@ -512,10 +512,11 @@ export class ExposedPopulationResult {
   key: string;
   featureCollection: FeatureCollection;
   legend: LegendDefinition;
+  legendText: string;
   statistic: AggregationOperations;
 
   getTitle = (): string => {
-    return 'Population Affected';
+    return 'Population Exposure';
   };
 
   getStatTitle = (): string => {
@@ -526,11 +527,13 @@ export class ExposedPopulationResult {
     featureCollection: FeatureCollection,
     statistic: AggregationOperations,
     legend: LegendDefinition,
+    legendText: string,
     key: string,
   ) {
     this.featureCollection = featureCollection;
     this.statistic = statistic;
     this.legend = legend;
+    this.legendText = legendText;
     this.key = key;
   }
 }
@@ -547,6 +550,7 @@ export class BaselineLayerResult {
   threshold: ThresholdDefinition;
 
   legend: LegendDefinition;
+  legendText: string;
   hazardLayerId: WMSLayerProps['id'];
   baselineLayerId: NSOLayerProps['id'];
 
@@ -564,6 +568,7 @@ export class BaselineLayerResult {
     this.statistic = statistic;
     this.threshold = threshold;
     this.legend = baselineLayer.legend;
+    this.legendText = hazardLayer.legendText;
     this.rawApiData = rawApiData;
 
     this.hazardLayerId = hazardLayer.id;


### PR DESCRIPTION
- Updated the toggle switch to activate `showing the table` instead of the map
- Massaged pop-exposure data from `object` to arrays for table consumption
- Render Pop Exposure Analysis in a drawer and showed the data in table

<img width="1552" alt="MicrosoftTeams-image" src="https://user-images.githubusercontent.com/1290048/124179939-c724a200-dab3-11eb-8f9d-53de936aa03e.png">
