### PR TITLE
🐛 Fix Exposure Population Analysis Minor issues

### DIFF
--- a/src/components/MapView/Layers/AnalysisLayer/index.tsx
+++ b/src/components/MapView/Layers/AnalysisLayer/index.tsx
@@ -49,8 +49,8 @@ function AnalysisLayer() {
 
   return (
     <GeoJSONLayer
+      before="boundaries-line"
       id="layer-analysis"
-      below="boundaries"
       data={analysisData.featureCollection}
       fillPaint={fillPaintData(analysisData.legend, property)}
       fillOnClick={(evt: any) => {

--- a/src/components/MapView/Layers/ImpactLayer/index.tsx
+++ b/src/components/MapView/Layers/ImpactLayer/index.tsx
@@ -86,8 +86,8 @@ const ImpactLayer = ({ classes, layer }: ComponentProps) => {
 
   return (
     <GeoJSONLayer
+      before="boundaries-line"
       id={`layer-${layer.id}`}
-      below="boundaries"
       data={noMatchingDistricts ? boundaries : impactFeatures}
       linePaint={linePaint}
       fillPaint={fillPaint}

--- a/src/components/MapView/Layers/NSOLayer/index.tsx
+++ b/src/components/MapView/Layers/NSOLayer/index.tsx
@@ -43,8 +43,8 @@ function NSOLayers({ layer }: { layer: NSOLayerProps }) {
 
   return (
     <GeoJSONLayer
+      before="boundaries-line"
       id={`layer-${layer.id}`}
-      below="boundaries"
       data={features}
       fillPaint={fillPaintData}
       fillOnClick={(evt: any) => {

--- a/src/components/MapView/Layers/PointDataLayer/index.tsx
+++ b/src/components/MapView/Layers/PointDataLayer/index.tsx
@@ -45,8 +45,8 @@ function PointDataLayer({ layer }: { layer: PointDataLayerProps }) {
 
   return (
     <GeoJSONLayer
+      before="boundaries-line"
       id={`layer-${layer.id}`}
-      below="boundaries"
       data={data}
       circleLayout={circleLayout}
       circlePaint={circlePaint}

--- a/src/components/MapView/Layers/WMSLayer/index.tsx
+++ b/src/components/MapView/Layers/WMSLayer/index.tsx
@@ -36,7 +36,7 @@ function WMSLayers({
       />
 
       <Layer
-        below="boundaries"
+        before="boundaries-line"
         type="raster"
         id={`layer-${id}`}
         sourceId={`source-${id}`}

--- a/src/components/MapView/Legends/index.tsx
+++ b/src/components/MapView/Legends/index.tsx
@@ -229,7 +229,7 @@ function LegendItem({
   };
 
   if (analysisResult instanceof ExposedPopulationResult) {
-    const tableData = convertToTableData(analysisResult, 'TS');
+    const tableData = convertToTableData(analysisResult);
     dispatch(addTableData(tableData));
   }
 

--- a/src/components/MapView/utils.ts
+++ b/src/components/MapView/utils.ts
@@ -4,7 +4,7 @@ import {
   assign,
   difference,
   mapValues,
-  groupBy,
+  groupBy as _groupBy,
   keysIn,
   keyBy,
   uniq,
@@ -60,12 +60,10 @@ export const getFeatureInfoParams = (
   return params;
 };
 
-export const convertToTableData = (
-  result: ExposedPopulationResult,
-  groupedBy: string,
-) => {
+export const convertToTableData = (result: ExposedPopulationResult) => {
   const {
     key,
+    groupBy,
     statistic,
     featureCollection: { features },
   } = result;
@@ -74,18 +72,18 @@ export const convertToTableData = (
 
   const featureProperties = features.map(feature => {
     return {
-      [groupedBy]: feature.properties?.[groupedBy],
+      [groupBy]: feature.properties?.[groupBy],
       [key]: feature.properties?.[key],
       [statistic]: feature.properties?.[statistic],
     };
   });
-  const rowData = mapValues(groupBy(featureProperties, groupedBy), k => {
-    return mapValues(keyBy(k, 'label'), obj => parseInt(obj[statistic], 10));
+  const rowData = mapValues(_groupBy(featureProperties, groupBy), k => {
+    return mapValues(keyBy(k, key), obj => parseInt(obj[statistic], 10));
   });
 
   const groupedRowData = Object.keys(rowData).map(k => {
     return {
-      [groupedBy]: k,
+      [groupBy]: k,
       ...rowData[k],
     };
   });
@@ -100,7 +98,7 @@ export const convertToTableData = (
     const total = fields.reduce((acc, o) => row[acc] + row[o]);
     return assign(row, { Total: total });
   });
-  const columns = [groupedBy, ...fields, 'Total'];
+  const columns = [groupBy, ...fields, 'Total'];
   const headRow = zipObject(columns, columns);
   const rows = [headRow, ...headlessRows];
   return { columns, rows };

--- a/src/components/MapView/utils.ts
+++ b/src/components/MapView/utils.ts
@@ -83,9 +83,9 @@ export const convertToTableData = (
     return mapValues(keyBy(k, 'label'), obj => parseInt(obj[statistic], 10));
   });
 
-  const groupedRowData = Object.keys(rowData).map((k, i: number) => {
+  const groupedRowData = Object.keys(rowData).map(k => {
     return {
-      [groupedBy]: i,
+      [groupedBy]: k,
       ...rowData[k],
     };
   });

--- a/src/context/analysisResultStateSlice.ts
+++ b/src/context/analysisResultStateSlice.ts
@@ -252,6 +252,7 @@ export const requestAndStoreExposedPopulation = createAsyncThunk<
     features,
   };
 
+  const groupBy = apiRequest.group_by;
   const legend = createLegendFromFeatureArray(features, statistic);
   const legendText = wfsLayer.title;
 
@@ -260,6 +261,7 @@ export const requestAndStoreExposedPopulation = createAsyncThunk<
     statistic,
     legend,
     legendText,
+    groupBy,
     key,
   );
 });

--- a/src/utils/analysis-utils.ts
+++ b/src/utils/analysis-utils.ts
@@ -540,6 +540,7 @@ export function createLegendFromFeatureArray(
 
 export class ExposedPopulationResult {
   key: string;
+  groupBy: string;
   featureCollection: FeatureCollection;
   legend: LegendDefinition;
   legendText: string;
@@ -558,12 +559,14 @@ export class ExposedPopulationResult {
     statistic: AggregationOperations,
     legend: LegendDefinition,
     legendText: string,
+    groupBy: string,
     key: string,
   ) {
     this.featureCollection = featureCollection;
     this.statistic = statistic;
     this.legend = legend;
     this.legendText = legendText;
+    this.groupBy = groupBy;
     this.key = key;
   }
 }


### PR DESCRIPTION
Here is a list of minor issues and improvement added with regard to `exposure population analysis` table rendering
- Fixed `table` showing `index` number instead of `Group By` value
- Improved `table rendering` to be more dynamic and remove had-coded `Group By` and `label`
- Fixed `map` rendering to always show the `boundaries` layer before all other layers