### PR TITLE
Modify regular expression to replace more than one dot

### DIFF
--- a/src/context/analysisResultStateSlice.ts
+++ b/src/context/analysisResultStateSlice.ts
@@ -89,9 +89,9 @@ function getAdminBoundariesURL() {
   if (isLocalhost) {
     return defaultBoundariesFile;
   }
-  // the regex here removes the dot at the beginning of a path, if there is one.
+  // the regex here removes the dot(s) at the beginning of a path, if there is at least one.
   // e.g the path might be ' ./data/xxx '  instead of ' /data/xxx '
-  return window.location.origin + adminBoundariesPath.replace(/^\./, '');
+  return window.location.origin + adminBoundariesPath.replace(/^\.+/, '');
 }
 
 function generateTableFromApiData(


### PR DESCRIPTION
This Pull Request closes #243 

On production environments, PRISM builds the admin boundaries URL for stats analysis using PATH parameter from layers config and server hostname. However, the regular expression removes only a single dot if the path is relative.

You can verify the PR here by running exposed population analysis and checking the zones_url within payload.

![image](https://user-images.githubusercontent.com/3285923/131128922-19e6f8cf-e33d-4ff3-bf6a-e96d7964aa69.png)

deployment site: http://demo-myanmar.surge.sh/

Also, please check this comment: https://github.com/WFP-VAM/prism-frontend/issues/243#issuecomment-907178795

