### PR TITLE
Url parsing feature

### DIFF
--- a/src/components/MapView/DateSelector/index.test.tsx
+++ b/src/components/MapView/DateSelector/index.test.tsx
@@ -5,6 +5,14 @@ import DateSelector from '.';
 
 import { store } from '../../../context/store';
 
+jest.mock('react-router-dom', () => ({
+  useHistory: () => ({
+    replace: jest.fn(),
+    location: {
+      search: '',
+    },
+  }),
+}));
 jest.mock('../../Notifier', () => 'mock-Notifier');
 jest.mock('./TimelineItems', () => 'mock-TimelineItems');
 

--- a/src/components/MapView/DateSelector/index.tsx
+++ b/src/components/MapView/DateSelector/index.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, Ref, useEffect, useRef, useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import Moment from 'moment';
 import { extendMoment } from 'moment-range';
 import {
@@ -18,7 +18,7 @@ import { faCaretUp } from '@fortawesome/free-solid-svg-icons';
 import { ChevronLeft, ChevronRight } from '@material-ui/icons';
 import 'react-datepicker/dist/react-datepicker.css';
 import { findIndex, get, isEqual } from 'lodash';
-import { updateDateRange } from '../../../context/mapStateSlice';
+import { useUrlHistory } from '../../../utils/url-utils';
 import { DateRangeType } from '../../../config/types';
 import { findDateIndex, TIMELINE_ITEM_WIDTH, USER_DATE_OFFSET } from './utils';
 import { dateRangeSelector } from '../../../context/mapStateSlice/selectors';
@@ -53,7 +53,6 @@ function DateSelector({
   classes,
   selectedDateRef,
 }: DateSelectorProps) {
-  const dispatch = useDispatch();
   const { startDate: stateStartDate } = useSelector(dateRangeSelector);
 
   const [selectedDate, setSelectedDate] = useState(moment(stateStartDate));
@@ -76,6 +75,8 @@ function DateSelector({
 
   const timeLine = useRef(null);
   const timeLineWidth = get(timeLine.current, 'offsetWidth', 0);
+
+  const { updateHistory } = useUrlHistory();
 
   // Move the slider automatically so that the pointer always visible
   useEffect(() => {
@@ -128,7 +129,7 @@ function DateSelector({
 
   function updateStartDate(date: Date) {
     const time = date.getTime();
-    dispatch(updateDateRange({ startDate: time, endDate: time }));
+    updateHistory({ date: time });
   }
 
   function setDatePosition(date: number | undefined, increment: number) {

--- a/src/components/MapView/index.test.tsx
+++ b/src/components/MapView/index.test.tsx
@@ -15,6 +15,15 @@ jest.mock('./DateSelector', () => 'mock-DateSelector');
 jest.mock('./Analyser', () => 'mock-Analyser');
 jest.mock('./Download', () => 'mock-Download');
 
+jest.mock('react-router-dom', () => ({
+  useHistory: () => ({
+    replace: jest.fn(),
+    location: {
+      search: '',
+    },
+  }),
+}));
+
 test('renders as expected', () => {
   const { container } = render(
     <Provider store={store}>

--- a/src/components/NavBar/MenuItem/index.test.tsx
+++ b/src/components/NavBar/MenuItem/index.test.tsx
@@ -6,6 +6,14 @@ import MenuItem from '.';
 import { store } from '../../../context/store';
 import { LayerKey, MenuItemType } from '../../../config/types';
 
+jest.mock('react-router-dom', () => ({
+  useHistory: () => ({
+    replace: jest.fn(),
+    location: {
+      search: '',
+    },
+  }),
+}));
 const props: MenuItemType = {
   title: 'title',
   icon: 'icon.png',

--- a/src/components/NavBar/MenuItemMobile/index.test.tsx
+++ b/src/components/NavBar/MenuItemMobile/index.test.tsx
@@ -6,6 +6,14 @@ import MenuItemMobile from '.';
 import { store } from '../../../context/store';
 import { LayerKey, MenuItemMobileType } from '../../../config/types';
 
+jest.mock('react-router-dom', () => ({
+  useHistory: () => ({
+    replace: jest.fn(),
+    location: {
+      search: '',
+    },
+  }),
+}));
 const props: MenuItemMobileType = {
   title: 'title',
   icon: 'icon.png',

--- a/src/components/NavBar/MenuSwitch/index.test.tsx
+++ b/src/components/NavBar/MenuSwitch/index.test.tsx
@@ -6,6 +6,15 @@ import MenuSwitch from '.';
 import { store } from '../../../context/store';
 import { LayerKey, LayersCategoryType } from '../../../config/types';
 
+jest.mock('react-router-dom', () => ({
+  useHistory: () => ({
+    replace: jest.fn(),
+    location: {
+      search: '',
+    },
+  }),
+}));
+
 const props: LayersCategoryType = {
   title: 'Category 1',
   layers: [

--- a/src/components/NavBar/MenuSwitch/index.tsx
+++ b/src/components/NavBar/MenuSwitch/index.tsx
@@ -15,21 +15,29 @@ import {
   LayerType,
   TableType,
 } from '../../../config/types';
-import { addLayer, removeLayer } from '../../../context/mapStateSlice';
+import { removeLayer } from '../../../context/mapStateSlice';
 import { loadTable } from '../../../context/tableStateSlice';
 import { layersSelector } from '../../../context/mapStateSlice/selectors';
+import { useUrlHistory } from '../../../utils/url-utils';
 
 function MenuSwitch({ classes, title, layers, tables }: MenuSwitchProps) {
   const selectedLayers = useSelector(layersSelector);
   const dispatch = useDispatch();
+  const { updateHistory, removeKeyFromUrl } = useUrlHistory();
 
   const toggleLayerValue = (layer: LayerType) => (
     event: React.ChangeEvent<HTMLInputElement>,
   ) => {
     const { checked } = event.target;
+
+    const urlLayerKey =
+      layer.type === 'nso' ? 'baselineLayerId' : 'hazardLayerId';
+
     if (checked) {
-      dispatch(addLayer(layer));
+      updateHistory({ [urlLayerKey]: layer.id });
     } else {
+      removeKeyFromUrl(urlLayerKey);
+
       dispatch(removeLayer(layer));
     }
   };

--- a/src/utils/url-utils.ts
+++ b/src/utils/url-utils.ts
@@ -1,0 +1,102 @@
+import { useHistory } from 'react-router-dom';
+import moment from 'moment';
+
+export type URLParams = {
+  hazardLayerId?: string;
+  baselineLayerId?: string;
+  date?: number;
+};
+
+/*
+  transforms the string value according to the field specified in the
+  type URLParams
+*/
+const parseValue = (key: string, value: string): URLParams[keyof URLParams] => {
+  switch (key) {
+    case 'date':
+      return moment(value).valueOf();
+    default:
+      return value;
+  }
+};
+
+/*
+  Serialized value to string depending on the parameter specified in the
+  type URLParams
+*/
+const valueToString = (
+  key: string,
+  value: URLParams[keyof URLParams],
+): string => {
+  switch (key) {
+    case 'date':
+      return moment(value).format('YYYY-MM-DD');
+    default:
+      return value as string;
+  }
+};
+
+/*
+  Serialized value to string depending on the parameter specified in the
+  type URLParams
+*/
+const parseHistory = (locationSearch: string): URLParams =>
+  locationSearch === ''
+    ? ({} as URLParams)
+    : locationSearch
+        .substring(1)
+        .split('&')
+        .map(l => l.split('='))
+        .reduce(
+          (obj, [key, value]) => ({
+            ...obj,
+            [key]: parseValue(key, value),
+          }),
+          {} as URLParams,
+        );
+
+/*
+  Serialize urlParams object to string.
+*/
+const urlParamsToString = (params: URLParams): string =>
+  Object.entries(params)
+    .map(([key, value]) => `${key}=${valueToString(key, value)}`)
+    .join('&');
+
+/*
+  This custom hook tracks the browser url string, which is defined by the useHistory hook.
+  We created additional functions to update the url based on user events, such as select date
+  or select layer.
+*/
+export const useUrlHistory = () => {
+  const { replace, location } = useHistory();
+
+  const urlParams = parseHistory(location.search);
+
+  const updateHistory = (obj: URLParams) => {
+    const newUrl = { ...urlParams, ...obj };
+    replace({ search: urlParamsToString(newUrl) });
+  };
+
+  const clearHistory = () => {
+    replace({ search: '' });
+  };
+
+  const removeKeyFromUrl = (urlKey: keyof URLParams) => {
+    const newUrl = Object.entries(urlParams).reduce((obj, [key, value]) => {
+      if (key === urlKey) {
+        return obj;
+      }
+
+      if (urlKey === 'hazardLayerId' && key === 'date') {
+        return obj;
+      }
+
+      return { ...obj, [key]: value };
+    }, {} as URLParams);
+
+    replace({ search: urlParamsToString(newUrl) });
+  };
+
+  return { urlParams, updateHistory, clearHistory, removeKeyFromUrl };
+};

--- a/src/utils/useDefaultDate.ts
+++ b/src/utils/useDefaultDate.ts
@@ -3,8 +3,9 @@ import { useEffect } from 'react';
 import { AvailableDates, GroupDefinition } from '../config/types';
 import { availableDatesSelector } from '../context/serverStateSlice';
 import { dateRangeSelector } from '../context/mapStateSlice/selectors';
-import { updateDateRange } from '../context/mapStateSlice';
 import { USER_DATE_OFFSET } from '../components/MapView/DateSelector/utils';
+
+import { useUrlHistory } from './url-utils';
 /**
  * A hook designed to automatically load the default date of a layer if the user doesn't select one.
  * Returns either the user selected date or the default date, dispatching it to the date picker beforehand. Can also return undefined if no default date is available.
@@ -16,6 +17,8 @@ export function useDefaultDate(
 ): number | undefined {
   const dispatch = useDispatch();
   const { startDate: selectedDate } = useSelector(dateRangeSelector);
+
+  const { updateHistory } = useUrlHistory();
 
   const possibleDates = useSelector(availableDatesSelector)[
     availableDatesLookupKey
@@ -32,9 +35,9 @@ export function useDefaultDate(
       defaultDate &&
       (!layerGroup || layerGroup.main === true)
     ) {
-      dispatch(updateDateRange({ startDate: defaultDate }));
+      updateHistory({ date: defaultDate });
     }
-  }, [defaultDate, dispatch, selectedDate, layerGroup]);
+  }, [defaultDate, dispatch, selectedDate, layerGroup, updateHistory]);
 
   return selectedDate || defaultDate;
 }


### PR DESCRIPTION
This PR has the following changes:
- On a layer selection or date change event, an update of the prism url is executed including or modifying query parameters.
- When loading prism from a url with hazardLayerId, baselineLayerId or date parameters, PRISM automatically loads the layers which are displayed on the map.
- For the case of hazard layer removal, the date url parameter is also removed.

**Note.** This feature does not include baselineLayer or exposureAnalysis url updates yet.