### PR TITLE
Update docker-compose.yml with generic prism kobo user

### DIFF
--- a/api-flask/docker-compose.yml
+++ b/api-flask/docker-compose.yml
@@ -10,5 +10,5 @@ services:
     environment:
       - DATABASE_URL
       - WORKERS_PER_CORE=1
-      - KOBO_USERNAME=changeme
-      - KOBO_PW=changeme
+      - KOBO_USERNAME=prism_kobo
+      - KOBO_PW=8XQ9aHRqU5


### PR DESCRIPTION
Temporarily adding a generic prism-kobo account to the API