### PR TITLE
Introduce validity days to fetch data with multiple dates

### DIFF
--- a/src/config/myanmar/layers.json
+++ b/src/config/myanmar/layers.json
@@ -1242,6 +1242,7 @@
     "type": "point_data",
     "data": "https://prism-api.ovio.org/kobo/forms",
     "date_url": "https://prism-api.ovio.org/kobo/forms",
+    "validity_days": 20,
     "additional_query_params": {
       "form_name": "test_prism_form_v3",
       "datetime_field": "date_time",

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -342,6 +342,8 @@ export class PointDataLayerProps extends CommonLayerProps {
 
   @optional
   featureInfoProps?: FeatureInfoObject;
+
+  validityDays?: number;
 }
 
 export type RequiredKeys<T> = {

--- a/src/context/layers/point_data.ts
+++ b/src/context/layers/point_data.ts
@@ -42,18 +42,26 @@ export const queryParamsToString = (queryParams?: {
 
 export const fetchPointLayerData: LazyLoader<PointDataLayerProps> = () => async ({
   date,
-  layer: { data: dataUrl, fallbackData, additionalQueryParams },
+  layer: { data: dataUrl, fallbackData, additionalQueryParams, validityDays },
 }) => {
   // This function fetches point data from the API.
   // If this endpoint is not available or we run into an error,
   // we should get the data from the local public file in layer.fallbackData
 
-  const formattedDate = date && moment(date).format('YYYY-MM-DD');
+  const formattedDate = date && moment(date);
+  const daysPeriod = validityDays ?? 0;
+
+  const startDate = formattedDate
+    ? formattedDate.clone().subtract(daysPeriod, 'days').format('YYYY-MM-DD')
+    : '2000-01-01';
+  const endDate = formattedDate
+    ? formattedDate.clone().add(daysPeriod, 'days').format('YYYY-MM-DD')
+    : '2023-12-21';
+
+  console.log(startDate, endDate);
 
   // TODO exclusive to this api...
-  const dateQuery = `beginDateTime=${
-    formattedDate || '2000-01-01'
-  }&endDateTime=${formattedDate || '2023-12-21'}`;
+  const dateQuery = `beginDateTime=${startDate}&endDateTime=${endDate}`;
 
   const requestUrl = `${dataUrl}${
     dataUrl.includes('?') ? '&' : '?'


### PR DESCRIPTION
This PR closes #210 

Using Point data layers, PRISM is able to fetch data by creating a range of dates, according to **validityDays** parameter. This is a draft PR and changes are expected