### PR TITLE
Added support for unique admin layer boundary

### DIFF
--- a/src/components/MapView/Layers/AdminLevelDataLayer/index.tsx
+++ b/src/components/MapView/Layers/AdminLevelDataLayer/index.tsx
@@ -3,7 +3,11 @@ import { useSelector, useDispatch } from 'react-redux';
 import { get } from 'lodash';
 import { GeoJSONLayer } from 'react-mapbox-gl';
 import * as MapboxGL from 'mapbox-gl';
-import { AdminLevelDataLayerProps, LayerKey } from '../../../../config/types';
+import {
+  AdminLevelDataLayerProps,
+  BoundaryLayerProps,
+  LayerKey,
+} from '../../../../config/types';
 import { legendToStops } from '../layer-utils';
 import {
   LayerData,
@@ -33,8 +37,11 @@ function AdminLevelDataLayers({ layer }: { layer: AdminLevelDataLayerProps }) {
         const boundaryLayers = getBoundaryLayers();
         boundaryLayers.map(l => dispatch(removeLayer(l)));
 
-        const uniqueBoundaryLayer = LayerDefinitions[boundaryId as LayerKey];
+        const uniqueBoundaryLayer = LayerDefinitions[
+          boundaryId as LayerKey
+        ] as BoundaryLayerProps;
         dispatch(addLayer(uniqueBoundaryLayer));
+        dispatch(loadLayerData({ layer: uniqueBoundaryLayer }));
       } else {
         dispatch(
           addNotification({

--- a/src/components/MapView/index.tsx
+++ b/src/components/MapView/index.tsx
@@ -166,7 +166,8 @@ function MapView({ classes }: MapViewProps) {
       }
 
       if (Object.keys(LayerDefinitions).includes(id)) {
-        dispatch(addLayer(LayerDefinitions[id as LayerKey]));
+        const layer = LayerDefinitions[id as LayerKey];
+        dispatch(addLayer(layer));
 
         if (selectedDate && !urlDate) {
           updateHistory('date', moment(selectedDate).format('YYYY-MM-DD'));

--- a/src/components/NavBar/MenuSwitch/index.tsx
+++ b/src/components/NavBar/MenuSwitch/index.tsx
@@ -11,14 +11,16 @@ import {
   WithStyles,
 } from '@material-ui/core';
 import {
+  LayerKey,
   LayersCategoryType,
   LayerType,
   TableType,
 } from '../../../config/types';
-import { removeLayer } from '../../../context/mapStateSlice';
+import { addLayer, removeLayer } from '../../../context/mapStateSlice';
 import { loadTable } from '../../../context/tableStateSlice';
 import { layersSelector } from '../../../context/mapStateSlice/selectors';
 import { useUrlHistory } from '../../../utils/url-utils';
+import { getBoundaryLayers, LayerDefinitions } from '../../../config/utils';
 
 function MenuSwitch({ classes, title, layers, tables }: MenuSwitchProps) {
   const selectedLayers = useSelector(layersSelector);
@@ -37,8 +39,18 @@ function MenuSwitch({ classes, title, layers, tables }: MenuSwitchProps) {
       updateHistory(urlLayerKey, layer.id);
     } else {
       removeKeyFromUrl(urlLayerKey);
-
       dispatch(removeLayer(layer));
+      // re-activate boundary layers
+      if ('boundary' in layer) {
+        const boundaryId = layer.boundary || '';
+        if (Object.keys(LayerDefinitions).includes(boundaryId)) {
+          const uniqueBoundaryLayer = LayerDefinitions[boundaryId as LayerKey];
+          dispatch(removeLayer(uniqueBoundaryLayer));
+
+          const boundaryLayers = getBoundaryLayers();
+          boundaryLayers.map(l => dispatch(addLayer(l)));
+        }
+      }
     }
   };
 

--- a/src/components/NavBar/MenuSwitch/index.tsx
+++ b/src/components/NavBar/MenuSwitch/index.tsx
@@ -40,7 +40,10 @@ function MenuSwitch({ classes, title, layers, tables }: MenuSwitchProps) {
     } else {
       removeKeyFromUrl(urlLayerKey);
       dispatch(removeLayer(layer));
-      // re-activate boundary layers
+
+      // For admin boundary layers with boundary property
+      // we have to de-activate the unique boundary and re-activate
+      // default boundaries
       if ('boundary' in layer) {
         const boundaryId = layer.boundary || '';
         if (Object.keys(LayerDefinitions).includes(boundaryId)) {

--- a/src/config/myanmar/layers.json
+++ b/src/config/myanmar/layers.json
@@ -1,6 +1,7 @@
 {
   "admin_boundaries": {
     "type": "boundary",
+    "display": true,
     "path": "../data/myanmar/admin_boundaries.json",
     "opacity": 0.8,
     "admin_code": "TS_PCODE",
@@ -19,6 +20,7 @@
   },
   "admin1_boundaries": {
     "type": "boundary",
+    "display": true,
     "path": "../data/myanmar/mmr_admin1_boundaries.json",
     "opacity": 0.8,
     "admin_code": "TS_PCODE",
@@ -37,6 +39,7 @@
   },
   "admin2_boundaries": {
     "type": "boundary",
+    "display": true,
     "path": "../data/myanmar/mmr_admin2_boundaries.json",
     "opacity": 0.8,
     "admin_code": "TS_PCODE",
@@ -56,6 +59,7 @@
   "inform": {
     "title": "Vulnerability index",
     "type": "admin_level_data",
+    "boundary": "admin_boundaries",
     "path": "../data/myanmar/nso/all-vuln-layers.json",
     "content_path": "data/myanmar/contents.md#vulnerability-index",
     "data_field": "mmr_inform",

--- a/src/config/myanmar/layers.json
+++ b/src/config/myanmar/layers.json
@@ -23,9 +23,9 @@
     "display": true,
     "path": "../data/myanmar/mmr_admin1_boundaries.json",
     "opacity": 0.8,
-    "admin_code": "TS_PCODE",
-    "admin_level_names": ["TS", "ST", "DT"],
-    "admin_level_local_names": ["DT_MMR4", "TS_MMR4"],
+    "admin_code": "ST_PCODE",
+    "admin_level_names": ["ST"],
+    "admin_level_local_names": ["Name_MMR4"],
     "styles:": {
       "fill": {
         "fill-opacity": 0
@@ -55,6 +55,24 @@
         "line-opacity": 0.8
       }
     }
+  },
+  "test_admin1_data": {
+    "title": "test_admin1_data",
+    "type": "admin_level_data",
+    "boundary": "admin1_boundaries",
+    "path": "../data/myanmar/nso/poverty.json",
+    "data_field": "Poverty",
+    "admin_level": 1,
+    "admin_code": "ST_PCODE",
+    "opacity": 0.7,
+    "legend_text": "",
+    "legend": [
+      { "value": 0, "color": "#eff3ff" },
+      { "value": 10, "color": "#bdd7e7" },
+      { "value": 20, "color": "#6baed6" },
+      { "value": 30, "color": "#3182bd" },
+      { "value": 40, "color": "#08519c" }
+    ]
   },
   "inform": {
     "title": "Vulnerability index",

--- a/src/config/myanmar/layers.json
+++ b/src/config/myanmar/layers.json
@@ -1,7 +1,6 @@
 {
   "admin_boundaries": {
     "type": "boundary",
-    "display": true,
     "path": "../data/myanmar/admin_boundaries.json",
     "opacity": 0.8,
     "admin_code": "TS_PCODE",
@@ -20,7 +19,6 @@
   },
   "admin1_boundaries": {
     "type": "boundary",
-    "display": true,
     "path": "../data/myanmar/mmr_admin1_boundaries.json",
     "opacity": 0.8,
     "admin_code": "ST_PCODE",
@@ -39,7 +37,6 @@
   },
   "admin2_boundaries": {
     "type": "boundary",
-    "display": true,
     "path": "../data/myanmar/mmr_admin2_boundaries.json",
     "opacity": 0.8,
     "admin_code": "TS_PCODE",
@@ -301,7 +298,7 @@
     "content_path": "data/myanmar/contents.md#10-day-rainfall-estimate",
     "additional_query_params": {
       "styles": "rfh_350"
-    },    
+    },
     "base_url": "https://odc.ovio.org/",
     "date_interval": "days",
     "opacity": 0.7,
@@ -378,18 +375,18 @@
     "opacity": 0.7,
     "legend_text": "Total aggregate precipitation over a 1-month period, rolling every 10 days. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
     "legend": [
-      {"value": "-0", "color": "#ffffff", "alpha": 0},
-      {"value": "50", "color": "#faf3d2"},
-      {"value": "100", "color": "#dae3a1"},
-      {"value": "200", "color": "#a0c787"},
-      {"value": "300", "color": "#68ab79"},
-      {"value": "400", "color": "#9beafa"},
-      {"value": "500", "color": "#00b1de"},
-      {"value": "600", "color": "#005ae6"},
-      {"value": "800", "color": "#0000c8"},
-      {"value": "1000", "color": "#a000fa"},
-      {"value": "1500", "color": "#fa78fa"},
-      {"value": "> 1500", "color": "#ffc4ee"}
+      { "value": "-0", "color": "#ffffff", "alpha": 0 },
+      { "value": "50", "color": "#faf3d2" },
+      { "value": "100", "color": "#dae3a1" },
+      { "value": "200", "color": "#a0c787" },
+      { "value": "300", "color": "#68ab79" },
+      { "value": "400", "color": "#9beafa" },
+      { "value": "500", "color": "#00b1de" },
+      { "value": "600", "color": "#005ae6" },
+      { "value": "800", "color": "#0000c8" },
+      { "value": "1000", "color": "#a000fa" },
+      { "value": "1500", "color": "#fa78fa" },
+      { "value": "> 1500", "color": "#ffc4ee" }
     ]
   },
   "streak_dry_days": {
@@ -1198,7 +1195,7 @@
     "opacity": 0,
     "legend_text": "",
     "legend": []
-  }, 
+  },
   "adamts_tracks": {
     "title": "Tropical storm - track",
     "type": "wms",
@@ -1222,10 +1219,8 @@
     "date_interval": "days",
     "opacity": 1.0,
     "legend_text": "Flood water detected from Sentinel-1 data and a permanent water mask from JRC. Source: SERVIR Mekong HYDRAFloods",
-    "legend": [      
-      { "value": "1 - flooded", "color": "#a50f15" }
-    ]
-  },    
+    "legend": [{ "value": "1 - flooded", "color": "#a50f15" }]
+  },
   "hydra_s2": {
     "title": "Potential flooding (Sentinel-2)",
     "type": "wms",
@@ -1234,10 +1229,8 @@
     "date_interval": "days",
     "opacity": 1.0,
     "legend_text": "Flood water detected from Sentinel-2 data and a permanent water mask from JRC. Source: SERVIR Mekong HYDRAFloods",
-    "legend": [      
-      { "value": "1 - flooded", "color": "#a50f15" }
-    ]
-  },  
+    "legend": [{ "value": "1 - flooded", "color": "#a50f15" }]
+  },
   "hydra_l8": {
     "title": "Potential flooding (Landsat-8)",
     "type": "wms",
@@ -1246,10 +1239,8 @@
     "date_interval": "days",
     "opacity": 1.0,
     "legend_text": "Flood water detected from Landsat-8 data and a permanent water mask from JRC. Source: SERVIR Mekong HYDRAFloods",
-    "legend": [      
-      { "value": "1 - flooded", "color": "#a50f15" }
-    ]
-  },  
+    "legend": [{ "value": "1 - flooded", "color": "#a50f15" }]
+  },
   "forecast": {
     "title": "10-day precipitation forecast",
     "type": "wms",

--- a/src/config/myanmar/prism.json
+++ b/src/config/myanmar/prism.json
@@ -41,7 +41,7 @@
       "temperature": ["lst_daytime", "lst_anomaly", "lst_amplitude"]
     },
     "vulnerability": {
-      "vulnerability_index": ["multidimensional_disadvantage_index", "inform"],
+      "vulnerability_index": ["test_admin1_data", "multidimensional_disadvantage_index", "inform"],
       "vulnerable_populations": [
         "age_dependency_ratio",
         "female_headed_hhs",

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -220,6 +220,8 @@ export class BoundaryLayerProps extends CommonLayerProps {
   adminLevelNames: string[]; // Ordered (Admin1, Admin2, ...)
   adminLevelLocalNames: string[]; // Same as above, local to country
   styles: LayerStyleProps; // Mapbox line and fill properties.
+  @optional
+  display?: boolean; // Flag for default boundary layers to display
 }
 
 export enum LabelType {
@@ -278,6 +280,9 @@ export class AdminLevelDataLayerProps extends CommonLayerProps {
 
   @makeRequired
   dataField: string;
+
+  @optional
+  boundary?: LayerKey;
 }
 
 export class StatsApi {

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -221,7 +221,7 @@ export class BoundaryLayerProps extends CommonLayerProps {
   adminLevelLocalNames: string[]; // Same as above, local to country
   styles: LayerStyleProps; // Mapbox line and fill properties.
   @optional
-  display?: boolean; // Flag for default boundary layers to display
+  visibility?: boolean; // Flag for default boundary layers to display
 }
 
 export enum LabelType {

--- a/src/config/utils.ts
+++ b/src/config/utils.ts
@@ -133,7 +133,8 @@ export function getBoundaryLayers(): BoundaryLayerProps[] {
   const boundaryLayers = Object.values(LayerDefinitions).filter(
     (layer): layer is BoundaryLayerProps =>
       layer.type === 'boundary' &&
-      (layer as BoundaryLayerProps).display === true,
+      ((layer as BoundaryLayerProps).visibility === true ||
+        (layer as BoundaryLayerProps).visibility === undefined),
   );
   if (boundaryLayers.length === 0) {
     throw new Error(
@@ -145,7 +146,9 @@ export function getBoundaryLayers(): BoundaryLayerProps[] {
 
 export function getBoundaryLayerSingleton(): BoundaryLayerProps {
   const boundaryLayers = getBoundaryLayers();
-  const boundaryLayer = boundaryLayers.find(l => l.id === 'admin_boundaries');
+  // get boundary with visibility set to true and without visibility
+  // pick the one with the highest level instead
+  const boundaryLayer = boundaryLayers.find(l => l.type === 'boundary');
 
   if (!boundaryLayer) {
     throw new Error(

--- a/src/config/utils.ts
+++ b/src/config/utils.ts
@@ -131,7 +131,9 @@ export const LayerDefinitions: LayersMap = (() => {
 
 export function getBoundaryLayers(): BoundaryLayerProps[] {
   const boundaryLayers = Object.values(LayerDefinitions).filter(
-    (layer): layer is BoundaryLayerProps => layer.type === 'boundary',
+    (layer): layer is BoundaryLayerProps =>
+      layer.type === 'boundary' &&
+      (layer as BoundaryLayerProps).display === true,
   );
   if (boundaryLayers.length === 0) {
     throw new Error(

--- a/src/context/layers/admin_level_data.ts
+++ b/src/context/layers/admin_level_data.ts
@@ -3,9 +3,13 @@ import { get, isNull, isString } from 'lodash';
 import {
   BoundaryLayerProps,
   AdminLevelDataLayerProps,
+  LayerKey,
 } from '../../config/types';
 import type { ThunkApi } from '../store';
-import { getBoundaryLayerSingleton } from '../../config/utils';
+import {
+  getBoundaryLayerSingleton,
+  LayerDefinitions,
+} from '../../config/utils';
 import type { LayerData, LayerDataParams, LazyLoader } from './layer-data';
 import { layerDataSelector } from '../mapStateSlice/selectors';
 
@@ -23,10 +27,13 @@ export const fetchAdminLevelDataLayerData: LazyLoader<AdminLevelDataLayerProps> 
   { layer }: LayerDataParams<AdminLevelDataLayerProps>,
   api: ThunkApi,
 ) => {
-  const { path, adminCode, dataField, featureInfoProps } = layer;
+  const { path, adminCode, dataField, featureInfoProps, boundary } = layer;
   const { getState } = api;
 
-  const adminBoundaryLayer = getBoundaryLayerSingleton();
+  const adminBoundaryLayer =
+    boundary !== undefined
+      ? (LayerDefinitions[boundary as LayerKey] as BoundaryLayerProps)
+      : getBoundaryLayerSingleton();
 
   const adminBoundariesLayer = layerDataSelector(adminBoundaryLayer.id)(
     getState(),


### PR DESCRIPTION
- Added support for specifying a unique boundary for an `admin-level-data` layer by just providing `boundary` as a valid `boundary` layer.

- Changed how we define boundaries by adding `display` boolean property. With the `display` property we load only boundaries which have `true` as display value

- Test country: Myanmar all boundaries are now set with `display: true`
- Test admin-level-data layer: `Vulnerability Index` with `boundary: inform`
