### PR TITLE
Deactivate sourcemap during ci frontend build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,54 +3,54 @@ jobs:
   build_frontend:
     docker:
       - image: circleci/node:12.9.1-browsers
-  
+
     working_directory: ~/repo
 
     steps:
-        - checkout
+      - checkout
 
-        - restore_cache:
-            keys:
+      - restore_cache:
+          keys:
             - v1-dependencies-{{ checksum "package.json" }}
             - v1-dependencies-
-        
-        - run: yarn install
-    
-        - save_cache:
-            paths:
+
+      - run: yarn install
+
+      - save_cache:
+          paths:
             - node_modules
-            key: v1-dependencies-{{ checksum "package.json" }}
-        
-        - run: yarn test
-        - run: yarn lint
-        - run: yarn build
+          key: v1-dependencies-{{ checksum "package.json" }}
+
+      - run: yarn test
+      - run: yarn lint
+      - run: GENERATE_SOURCEMAP=false yarn build
 
   build_api:
     machine:
-      image: ubuntu-1604:201903-01 
+      image: ubuntu-1604:201903-01
     steps:
-        - checkout
+      - checkout
 
-        - run:
-            name: Install Docker Compose
-            command: |
-                curl -L https://github.com/docker/compose/releases/download/1.11.2/docker-compose-`uname -s`-`uname -m` > ~/docker-compose
-                chmod +x ~/docker-compose
-                sudo mv ~/docker-compose /usr/local/bin/docker-compose
+      - run:
+          name: Install Docker Compose
+          command: |
+            curl -L https://github.com/docker/compose/releases/download/1.11.2/docker-compose-`uname -s`-`uname -m` > ~/docker-compose
+            chmod +x ~/docker-compose
+            sudo mv ~/docker-compose /usr/local/bin/docker-compose
 
-        - run:
-            name: Build containers
-            command: cd api-flask && docker-compose build api
-        - run:
-            name: Run linters
-            command: cd api-flask && make api-lint
-        - run:
-            name: Run tests
-            command: cd api-flask && make api-test
+      - run:
+          name: Build containers
+          command: cd api-flask && docker-compose build api
+      - run:
+          name: Run linters
+          command: cd api-flask && make api-lint
+      - run:
+          name: Run tests
+          command: cd api-flask && make api-test
 
 workflows:
   version: 2.1
   build:
-      jobs:
-          - build_frontend
-          - build_api
+    jobs:
+      - build_frontend
+      - build_api


### PR DESCRIPTION
To avoid CI failures due to excess memory use such as here - https://app.circleci.com/pipelines/github/WFP-VAM/prism-frontend/1605/workflows/9867af11-2eb3-48e6-a453-c613568188fc/jobs/2895

We try to deactivate sourcemap.