### PR TITLE
Feat/admin level data endpoints

### DIFF
--- a/api-flask/app/admin_level_data.py
+++ b/api-flask/app/admin_level_data.py
@@ -1,0 +1,86 @@
+from flask import request
+from dateutil.parser import parse as dateparser
+from datetime import datetime, timedelta
+from werkzeug.exceptions import BadRequest
+import requests
+from requests.compat import urlparse, urljoin
+
+
+def is_date(val):
+    """Check weither value is a valid date"""
+    try:
+        dateparser(val, fuzzy=False)
+        return True
+    except ValueError:
+        return False
+
+
+def get_base_and_path(url):
+    scheme, netloc, path, _, _, _ = urlparse(url)
+    base = '{0}://{1}'.format(scheme, netloc)
+    return (base, path)
+
+
+def get_or_create_end_date(start, end, range_in_days):
+    """Based on start date, calculate end date based on range in days"""
+    today = datetime.today()
+    if end is None:
+        end_date = start + timedelta(range_in_days)
+        return end_date if end_date > today else today
+    return end
+
+
+def parse_admin_params():
+    """Collect and validate request parameters"""
+    data_url = request.args.get('dataUrl')
+
+    if data_url is None:
+        raise BadRequest('Missing query parameter: dataUrl')
+        
+    start_date = request.args.get('startDate')
+    if start_date is None:
+        raise BadRequest('Missing query parameter: startDate')
+    if is_date(start_date):
+        start_date = dateparser(start_date, fuzzy=False)
+    else:
+        raise BadRequest('Wrong startDate query parameter format')
+
+    end_date = request.args.get('endDate')
+    return dict(data_url=data_url, start_date=start_date, end_date=end_date)
+
+
+def parse_mvam_response(url, start, end):
+    """Parse response from Hunger Map Monitoring"""
+
+    MVAM_DAYS_RANGE = 100
+    end_date = get_or_create_end_date(start, end, MVAM_DAYS_RANGE)
+
+    base, path = get_base_and_path(url)
+    full_url = urljoin(base, path)
+    start_formatted = datetime.strftime(start, "%Y-%m-%d")
+    end_formatted = datetime.strftime(end_date, "%Y-%m-%d")
+    
+    resp = requests.get(
+        full_url,
+        params={'date_start': start_formatted, 'date_end': end_formatted}
+    )
+    raw_data = resp.json()
+    return raw_data
+
+
+def unsupported_source():
+    """Raises the bad request for unsupported sources"""
+    raise BadRequest('Unsupported admin level data source')
+
+
+def get_admin_response(url, start, end):
+    """Process admin level data from different sources"""
+    supported_data_sources = {
+        'https://api.hungermapdata.org': parse_mvam_response
+    }
+
+    base, path = get_base_and_path(url)
+    full_url = urljoin(base, path)
+    return supported_data_sources.get(base)(
+        full_url, start, end
+    )

--- a/api-flask/app/admin_level_data.py
+++ b/api-flask/app/admin_level_data.py
@@ -1,4 +1,6 @@
 """Collect and parse Admin Level Data URLs."""
+from datetime import datetime
+
 from flask import request
 
 import requests
@@ -19,42 +21,55 @@ def parse_admin_params():
     data_url = request.args.get('dataUrl')
     if data_url is None:
         raise BadRequest('Missing query parameter: dataUrl')
-    return data_url
+
+    only_dates = True if request.args.get('onlyDates') else False
+
+    return {'data_url': data_url, 'only_dates': only_dates}
 
 
-def parse_mvam_response(url):
+def parse_mvam_response(data_url, only_dates):
     """Parse response from Hunger Map Monitoring."""
-    resp = requests.get(url)
+    resp = requests.get(data_url)
 
     # instead of `resp.raise_for_status`. display the error response from mvam
+    data = resp.json()
     if not resp.ok:
-        return resp.json()
+        return data
 
-    response = {'DataList': []}
-    for item in resp.json():
-        item_details = {
-            'mvam_Code': item['region']['id'],
-            'mvam_Name': item['region']['name'],
-            'population': item['region']['population'],
-            'date': item['date']
-        }
-        for metric in item['metrics']:
-            item_details['{}_people'.format(metric)] = item['metrics'][metric]['people']
-            item_details['{}_prevalence'.format(metric)] = item['metrics'][metric]['prevalence']
-        response['DataList'].append(item_details)
-    return response
+    if only_dates:
+        response = []
+        for item in data:
+            date = datetime.strptime(item['date'], '%Y-%m-%d')
+            response.append(date.timestamp())
+        return list(set(response))
+    else:
+        response = {'DataList': []}
+        for item in data:
+            item_details = {
+                'mvam_Code': item['region']['id'],
+                'mvam_Name': item['region']['name'],
+                'population': item['region']['population'],
+                'date': item['date']
+            }
+            for metric in item['metrics']:
+                item_details['{}_people'.format(metric)] = item['metrics'][metric]['people']
+                item_details['{}_prevalence'.format(metric)] = item['metrics'][metric]['prevalence']
+            response['DataList'].append(item_details)
+        return response
 
 
-def get_admin_response(url):
+def get_admin_response(data_url, only_dates=False):
     """Process admin level data from different sources."""
-    def unsupported_source(url):
+    def unsupported_source(url, only_dates):
         """Raise the bad request for unsupported sources."""
-        raise BadRequest('Unsupported admin level data source', url)
+        raise BadRequest('Unsupported admin level data source')
 
+    # Will hold all supported data sources and define handler functions
+    # specific for every source
     supported_data_sources = {
-        'https://api.hungermapdata.org': parse_mvam_response,
-        'unsupported': unsupported_source
+        'https://api.hungermapdata.org': parse_mvam_response
+        # 'https://api.mongoliadata.org': parse_mongolia_response
     }
 
-    base = get_base(url)
-    return supported_data_sources.get(base, 'unsupported')(url)
+    base = get_base(data_url)
+    return supported_data_sources.get(base, unsupported_source)(data_url, only_dates)

--- a/api-flask/app/admin_level_data.py
+++ b/api-flask/app/admin_level_data.py
@@ -1,6 +1,8 @@
 from flask import request
+
 import requests
-from requests.compat import urlparse, urljoin
+from requests.compat import urlparse
+
 from werkzeug.exceptions import BadRequest
 
 

--- a/api-flask/app/admin_level_data.py
+++ b/api-flask/app/admin_level_data.py
@@ -1,15 +1,13 @@
 from flask import request
-from dateutil.parser import parse as dateparser
-from datetime import datetime, timedelta
-from werkzeug.exceptions import BadRequest
 import requests
 from requests.compat import urlparse, urljoin
+from werkzeug.exceptions import BadRequest
 
 
-def get_base_and_path(url):
-    scheme, netloc, path, _, _, _ = urlparse(url)
+def get_base(url):
+    scheme, netloc, _, _, _, _ = urlparse(url)
     base = '{0}://{1}'.format(scheme, netloc)
-    return (base, path)
+    return base
 
 
 def parse_admin_params():
@@ -55,6 +53,5 @@ def get_admin_response(url):
         'unsupported': unsupported_source
     }
 
-    base, path = get_base_and_path(url)
-    full_url = urljoin(base, path)
+    base = get_base(url)
     return supported_data_sources.get(base, 'unsupported')(url)

--- a/api-flask/app/admin_level_data.py
+++ b/api-flask/app/admin_level_data.py
@@ -1,3 +1,4 @@
+"""Collect and parse Admin Level Data URLs."""
 from flask import request
 
 import requests
@@ -7,13 +8,14 @@ from werkzeug.exceptions import BadRequest
 
 
 def get_base(url):
+    """Parse url to get the its base."""
     scheme, netloc, _, _, _, _ = urlparse(url)
     base = '{0}://{1}'.format(scheme, netloc)
     return base
 
 
 def parse_admin_params():
-    """Collect and validate request parameters"""
+    """Collect and validate request parameters."""
     data_url = request.args.get('dataUrl')
     if data_url is None:
         raise BadRequest('Missing query parameter: dataUrl')
@@ -21,8 +23,7 @@ def parse_admin_params():
 
 
 def parse_mvam_response(url):
-    """Parse response from Hunger Map Monitoring"""
-
+    """Parse response from Hunger Map Monitoring."""
     resp = requests.get(url)
 
     # instead of `resp.raise_for_status`. display the error response from mvam
@@ -45,9 +46,9 @@ def parse_mvam_response(url):
 
 
 def get_admin_response(url):
-    """Process admin level data from different sources"""
+    """Process admin level data from different sources."""
     def unsupported_source(url):
-        """Raises the bad request for unsupported sources"""
+        """Raise the bad request for unsupported sources."""
         raise BadRequest('Unsupported admin level data source', url)
 
     supported_data_sources = {

--- a/api-flask/app/main.py
+++ b/api-flask/app/main.py
@@ -157,8 +157,7 @@ def get_kobo_forms():
 @app.route('/admin-level-data', methods=['GET'])
 def get_admin_level_data():
     """Get admin level data from external sources."""
-    params = parse_admin_params()
-    resp = get_admin_response(params['data_url'], params['start_date'], params['end_date'])
+    resp = get_admin_response(parse_admin_params())
     return Response(json.dumps(resp), mimetype='application/json') 
 
 

--- a/api-flask/app/main.py
+++ b/api-flask/app/main.py
@@ -19,6 +19,8 @@ from flask_cors import CORS
 
 from kobo import get_form_responses, parse_datetime_params
 
+from admin_level_data import get_admin_response, parse_admin_params
+
 import rasterio
 
 from werkzeug.exceptions import BadRequest, InternalServerError, NotFound
@@ -150,6 +152,14 @@ def get_kobo_forms():
     form_responses = get_form_responses(begin_datetime, end_datetime)
 
     return Response(json.dumps(form_responses), mimetype='application/json')
+
+
+@app.route('/admin-level-data', methods=['GET'])
+def get_admin_level_data():
+    """Get admin level data from external sources."""
+    params = parse_admin_params()
+    resp = get_admin_response(params['data_url'], params['start_date'], params['end_date'])
+    return Response(json.dumps(resp), mimetype='application/json') 
 
 
 @app.route('/alerts/<id>', methods=['GET'])

--- a/api-flask/app/main.py
+++ b/api-flask/app/main.py
@@ -4,6 +4,8 @@ from distutils.util import strtobool
 from os import getenv
 from urllib.parse import ParseResult, urlencode, urlunparse
 
+from admin_level_data import get_admin_response, parse_admin_params
+
 from app.caching import cache_file, cache_geojson
 from app.database.alert_database import AlertsDataBase
 from app.database.alert_model import AlchemyEncoder, AlertModel
@@ -19,7 +21,6 @@ from flask_cors import CORS
 
 from kobo import get_form_responses, parse_datetime_params
 
-from admin_level_data import get_admin_response, parse_admin_params
 
 import rasterio
 
@@ -158,7 +159,7 @@ def get_kobo_forms():
 def get_admin_level_data():
     """Get admin level data from external sources."""
     resp = get_admin_response(parse_admin_params())
-    return Response(json.dumps(resp), mimetype='application/json') 
+    return Response(json.dumps(resp), mimetype='application/json')
 
 
 @app.route('/alerts/<id>', methods=['GET'])

--- a/api-flask/app/main.py
+++ b/api-flask/app/main.py
@@ -158,7 +158,8 @@ def get_kobo_forms():
 @app.route('/admin-level-data', methods=['GET'])
 def get_admin_level_data():
     """Get admin level data from external sources."""
-    resp = get_admin_response(parse_admin_params())
+    params = parse_admin_params()
+    resp = get_admin_response(params['data_url'], params['only_dates'])
     return Response(json.dumps(resp), mimetype='application/json')
 
 


### PR DESCRIPTION
Added `/admin-level-data` endpoint which requires a `dataUrl` parameter as a source of `Admin Level Data`.

Our endpoint `/admin-level-data?dataUrl=https://api.hungermapdata.org/v1/foodsecurity/country/MOZ/region?date_start=2021-12-15` parses primitive data into similar format we use on the `frontend`

from
```json
[
  {
    "country": {"id": 170, "name": "Mozambique", "iso3": "MOZ", "iso2": "MZ"}, "region": {"id": 900948, "name": "Cabo Delgado", "population": 2107193}, 
    "date": "2021-10-01", 
    "dataType": "SURVEY", 
    "metrics": {
      "fcs": {"people": 661806, "prevalence": 0.3140699499286492}, 
      "rcsi": {"people": 669016, "prevalence": 0.31749156342110096},
      "healthAccess": {"people": 778837, "prevalence": 0.38681952501275707},
      "marketAccess": {"people": 930978, "prevalence": 0.44180955422687906},
      "livelihoodCoping": {"people": 1235764, "prevalence": 0.5864503156568952}
    }
  },
  ...
]
```
to 
```json
{
  "DataList": [
    {
      "date": "2021-10-01",
      "fcs_people": 661806,
      "fcs_prevalence": 0.3140699499286492,
      "healthAccess_people": 778837,
      "healthAccess_prevalence": 0.38681952501275707,
      "livelihoodCoping_people": 1235764,
      "livelihoodCoping_prevalence": 0.5864503156568952,
      "marketAccess_people": 930978,
      "marketAccess_prevalence": 0.44180955422687906,
      "mvam_Code": 900948,
      "mvam_Name": "Cabo Delgado",
      "population": 2107193,
      "rcsi_people": 669016,
      "rcsi_prevalence": 0.31749156342110096
    },
    ...
  ]
}
```

We have started with MVAM HungerMapData, but defined a structure to handle data from other sources as the need arises.

