### PR TITLE
Add intersect option to the flask API

### DIFF
--- a/api-flask/Makefile
+++ b/api-flask/Makefile
@@ -7,9 +7,6 @@ deploy:
 logs:
 	docker-compose -f docker-compose.yml -f docker-compose.deploy.yml logs -f
 
-logs:
-	docker-compose logs -f
-
 api-lint:
 	docker-compose run --no-deps api bash -c "flake8 ."
 	docker-compose run --no-deps api bash -c "pydocstyle ."

--- a/api-flask/README.md
+++ b/api-flask/README.md
@@ -8,12 +8,13 @@ The API has two endpoints for now.
 
 ### `/stats` (POST)
 
-Calculate zonal statistics for a raster / zones combination.Which takes as inputs through POST:
+Calculate zonal statistics for a raster / zones combination. Which takes as inputs through POST:
 
 - `geotiff_url`, the link to a geotiff
-- `zones_url`, the link to a geojson with admin boundaries
+- `zones_url` OR `zones`, the link to a geojson with admin boundaries / a geojson with boundaries
 - `?group_by`, a key to use to group zones in the geojson
 - `?geojson_out`, decide if the output should be a geojson or a list of data. Default is false -> List.
+- `?intersect_threshold`, ask the API to calcuate and return `percentage_over_threshold`
 - `?wfs_params`, A dictionary of parameters to compute statistics using the intersection between WFS FeatureCollection response polygons with admin boundaries. The parameters are the following.
   - `url`, WFS remote service url.
   - `layer_name`, the name of the vector layer. Geometry must be POLYGON or MULTIPOLYGON.

--- a/api-flask/README.md
+++ b/api-flask/README.md
@@ -14,7 +14,7 @@ Calculate zonal statistics for a raster / zones combination. Which takes as inpu
 - `zones_url` OR `zones`, the link to a geojson with admin boundaries / a geojson with boundaries
 - `?group_by`, a key to use to group zones in the geojson
 - `?geojson_out`, decide if the output should be a geojson or a list of data. Default is false -> List.
-- `?intersect_threshold`, ask the API to calcuate and return `percentage_over_threshold`
+- `?intersect_comparison`, ask the API to calcuate and return `intersect_percentage`. Formatted as `>=10.1`. Comparison defaults to equality if omitted.
 - `?wfs_params`, A dictionary of parameters to compute statistics using the intersection between WFS FeatureCollection response polygons with admin boundaries. The parameters are the following.
   - `url`, WFS remote service url.
   - `layer_name`, the name of the vector layer. Geometry must be POLYGON or MULTIPOLYGON.

--- a/api-flask/app/kobo.py
+++ b/api-flask/app/kobo.py
@@ -32,7 +32,7 @@ def get_kobo_params():
 
     geom_field = request.args.get('geomField')
     if geom_field is None:
-        raise BadRequest('Missing parameter geomField')
+        raise BadRequest('Missing parameter: geomField')
 
     filters = {}
     filters_params = request.args.get('filters', None)

--- a/api-flask/app/main.py
+++ b/api-flask/app/main.py
@@ -126,6 +126,14 @@ def stats():
 
         wfs_response = get_wfs_response(wfs_params)
 
+    if intersect_threshold is not None:
+        try:
+            intersect_threshold = int(intersect_threshold)
+        except ValueError:
+            raise InternalServerError(
+                'Invalid intersect_threshold format. Expecting an integer.'
+            )
+
     features = _calculate_stats(
         zones,
         geotiff,

--- a/api-flask/app/main.py
+++ b/api-flask/app/main.py
@@ -127,6 +127,7 @@ def stats():
 
         wfs_response = get_wfs_response(wfs_params)
 
+    intersect_comparison = None
     if intersect_comparison_string is not None:
         intersect_comparison = validate_intersect_parameter(
             intersect_comparison_string
@@ -260,7 +261,13 @@ def stats_demo():
 
     geojson_out = strtobool(geojson_out)
 
-    intersect_comparison = request.args.get('intersect_comparison', None)
+    intersect_comparison_string = request.args.get('intersect_comparison', None)
+
+    intersect_comparison = None
+    if intersect_comparison_string is not None:
+        intersect_comparison = validate_intersect_parameter(
+            intersect_comparison_string
+        )
 
     features = _calculate_stats(
         zones,

--- a/api-flask/app/main.py
+++ b/api-flask/app/main.py
@@ -128,10 +128,10 @@ def stats():
 
     if intersect_threshold is not None:
         try:
-            intersect_threshold = int(intersect_threshold)
+            intersect_threshold = float(intersect_threshold)
         except ValueError:
             raise InternalServerError(
-                'Invalid intersect_threshold format. Expecting an integer.'
+                'Invalid intersect_threshold format. Expecting a float.'
             )
 
     features = _calculate_stats(

--- a/api-flask/app/tests/test_calculate.py
+++ b/api-flask/app/tests/test_calculate.py
@@ -33,7 +33,12 @@ def test_calculate_stats_with_group_by():
     zones = '/app/tests/small_admin_boundaries.json'
     geotiff = '/app/tests/raster_sample.tif'
     features = calculate_stats(
-        zones, geotiff, group_by='ADM1_PCODE', geojson_out=False)
+        zones,
+        geotiff,
+        group_by='ADM1_PCODE',
+        geojson_out=False,
+        intersect_threshold=1
+    )
     assert len(features) == 4
     assert True
 

--- a/api-flask/app/tests/test_calculate.py
+++ b/api-flask/app/tests/test_calculate.py
@@ -1,4 +1,5 @@
 """Tests files for the analytics API."""
+import operator
 from datetime import datetime, timezone
 from unittest.mock import patch
 
@@ -37,7 +38,7 @@ def test_calculate_stats_with_group_by():
         geotiff,
         group_by='ADM1_PCODE',
         geojson_out=False,
-        intersect_threshold=1
+        intersect_comparison=(operator.lt, 1)
     )
     assert len(features) == 4
     assert True

--- a/api-flask/app/validation.py
+++ b/api-flask/app/validation.py
@@ -1,0 +1,37 @@
+"""A set of functions to validate and parse API request parameters."""
+import operator as op
+from typing import Function, Tuple
+
+from werkzeug.exceptions import BadRequest
+
+
+def validate_intersect_parameter(intersect_comparison_string: str) -> Tuple[Function, float]:
+    """Validate intersect parameter and return a (comparator, baseline) tuple."""
+    valid_operators = {
+      '<=': op.le,
+      '>=': op.ge,
+      '!=': op.ne,
+      '<': op.lt,
+      '=': op.eq,
+      '>': op.gt,
+    }
+
+    # extract an intersect comparison operator
+    default_operator = ('=', op.eq)
+    operator_item = next((
+        op for op in valid_operators.keys()
+        if op[0] in intersect_comparison_string[:2]),
+        default_operator)
+
+    # remove the operator from our string
+    intersect_comparison_string = intersect_comparison_string.replace(
+        operator_item[0], ''
+    )
+
+    try:
+        baseline = float(intersect_comparison_string)
+    except ValueError:
+        raise BadRequest(
+            f'Invalid intersect_comparison format {intersect_comparison_string}. Expecting a float.'
+        )
+    return (operator_item[1], baseline)

--- a/api-flask/app/validation.py
+++ b/api-flask/app/validation.py
@@ -1,11 +1,11 @@
 """A set of functions to validate and parse API request parameters."""
 import operator as op
-from typing import Function, Tuple
+from typing import Any, Tuple
 
 from werkzeug.exceptions import BadRequest
 
 
-def validate_intersect_parameter(intersect_comparison_string: str) -> Tuple[Function, float]:
+def validate_intersect_parameter(intersect_comparison_string: str) -> Tuple[Any, float]:
     """Validate intersect parameter and return a (comparator, baseline) tuple."""
     valid_operators = {
       '<=': op.le,
@@ -19,7 +19,7 @@ def validate_intersect_parameter(intersect_comparison_string: str) -> Tuple[Func
     # extract an intersect comparison operator
     default_operator = ('=', op.eq)
     operator_item = next((
-        op for op in valid_operators.keys()
+        op for op in valid_operators.items()
         if op[0] in intersect_comparison_string[:2]),
         default_operator)
 

--- a/api-flask/app/zonal_stats.py
+++ b/api-flask/app/zonal_stats.py
@@ -205,13 +205,7 @@ def calculate_stats(
             if total == 0:
                 return 0
             percentage = (intersect_operator(intersect_baseline, masked)).sum()
-            print(intersect_operator)
-            print({percentage})
-            print('over_threshold')
-            over_threshold = (masked > intersect_baseline).sum()
-            print({over_threshold})
-            result = percentage / total
-            return result  # percentage / total
+            return percentage / total
         add_stats = {
             'intersect_percentage': intersect_percentage,
         }
@@ -225,7 +219,6 @@ def calculate_stats(
             geojson_out=geojson_out,
             add_stats=add_stats,
         )
-        print(stats_results)
 
     except rasterio.errors.RasterioError as e:
         logger.error(e)

--- a/api-flask/app/zonal_stats.py
+++ b/api-flask/app/zonal_stats.py
@@ -8,8 +8,6 @@ from urllib.parse import urlencode
 from app.caching import cache_file, get_json_file
 from app.timer import timed
 
-# import numpy as np
-
 import rasterio
 
 from rasterstats import zonal_stats

--- a/api-flask/app/zonal_stats.py
+++ b/api-flask/app/zonal_stats.py
@@ -196,7 +196,7 @@ def calculate_stats(
 
     # Add function to calculate overlap percentage.
     add_stats = None
-    if intersect_threshold:
+    if intersect_threshold is not None:
         def percentage_over_threshold(masked):
             total = int(masked.count())
             over_threshold = int(

--- a/api-flask/app/zonal_stats.py
+++ b/api-flask/app/zonal_stats.py
@@ -232,6 +232,7 @@ def calculate_stats(
     if not geojson_out:
         feature_properties = _extract_features_properties(zones)
         stats_results = [
-            {**properties, **stat} for stat, properties in zip(stats_results, feature_properties)
+            {**properties, **stat} for stat, properties
+            in zip(stats_results, feature_properties)
         ]
     return stats_results

--- a/api-flask/app/zonal_stats.py
+++ b/api-flask/app/zonal_stats.py
@@ -204,7 +204,7 @@ def calculate_stats(
             # Avoid dividing by 0
             if total == 0:
                 return 0
-            percentage = (intersect_operator(intersect_baseline, masked)).sum()
+            percentage = (intersect_operator(masked, intersect_baseline)).sum()
             return percentage / total
         add_stats = {
             'intersect_percentage': intersect_percentage,

--- a/api-flask/requirements.txt
+++ b/api-flask/requirements.txt
@@ -1,6 +1,6 @@
 Flask-Caching==1.9.0
 Flask-Cors==3.0.9
-rasterstats==0.14.0
+rasterstats==0.16.0
 requests==2.23.0
 Shapely==1.7.0
 # Used by `make test` only:


### PR DESCRIPTION
When a user provides the parameter `intersect_comparison`, the API will calculate and return a new stat `intersect_percentage`.

The parameter accepts standard operators such as `<, >, <=, =, !=` in the form of `intersect_comparison=>=40`