### PR TITLE
Cambodia EWS1294 data with trend line graph

### DIFF
--- a/api-flask/app/ews.py
+++ b/api-flask/app/ews.py
@@ -50,10 +50,9 @@ def parse_ews_params():
 
 def get_ews_responses(only_dates, begin_datetime, end_datetime):
     """Get all data using ews_1294 api endpoints."""
-    # NOTE: Since ews-1294 api have performance issues, we decided to take shortcut
-    # on parsing and delivering dates to PRISM frontend by limiting it to only today
-    # this can be removed once we are sure the ews-1294 have solved the
-    # preformance issue
+    # NOTE: PRISM will get todays' worth of data and parse them.
+    # only_dates is a shortcut to provide one day to the PRISM timeline
+    # without incurring computational cost
     if only_dates:
         today = datetime.now().replace(tzinfo=timezone.utc)
         return [today.strftime('%Y-%m-%d')]

--- a/api-flask/app/ews.py
+++ b/api-flask/app/ews.py
@@ -117,7 +117,7 @@ def get_ews_response(only_dates, begin_datetime, end_datetime):
 
             rows = list()
 
-            dates_row = {'level': 'river_level'}
+            dates_row = {'level': 'River levels'}
             for count, level in enumerate(levels_and_dates):
                 # convert naive to timezone aware and utc
                 format_str = '%Y-%m-%dT%H:%M:%S'

--- a/api-flask/app/ews.py
+++ b/api-flask/app/ews.py
@@ -1,0 +1,144 @@
+"""Collect and parse Cambodia EWS-1294."""
+import itertools
+from datetime import datetime, timedelta, timezone
+
+from dateutil.parser import parse as dtparser
+
+from flask import request
+
+import numpy
+
+import requests
+
+from werkzeug.exceptions import BadRequest
+
+
+def parse_ews_params():
+    """Transform params used for ews request."""
+    only_dates = True if request.args.get('onlyDates') else False
+
+    today = datetime.now().replace(tzinfo=timezone.utc)
+    begin_datetime_str = request.args.get('beginDateTime')
+    if begin_datetime_str is not None:
+        begin_datetime = dtparser(begin_datetime_str)
+    else:
+        # yesterday
+        begin_datetime = today
+    begin_datetime = begin_datetime.replace(tzinfo=timezone.utc)
+
+    end_datetime_str = request.args.get('endDateTime')
+    if end_datetime_str is not None:
+        end_datetime = dtparser(end_datetime_str)
+    else:
+        # today
+        end_datetime = today
+    end_datetime = end_datetime.replace(tzinfo=timezone.utc)
+
+    # strptime function includes hours, minutes, and seconds as 00 by default.
+    # This check is done in case the begin and end datetime values are the same.
+    if end_datetime == begin_datetime:
+        end_datetime = end_datetime + timedelta(days=1)
+
+    if begin_datetime > end_datetime:
+        raise BadRequest('beginDateTime value must be lower than endDateTime')
+
+    if begin_datetime > today:
+        raise BadRequest('beginDateTime value must be less or equal to today')
+
+    return only_dates, begin_datetime, end_datetime
+
+
+def get_ews_responses(only_dates, begin_datetime, end_datetime):
+    """Get all data using ews_1294 api endpoints."""
+    # NOTE: Since ews-1294 api have performance issues, we decided to take shortcut
+    # on parsing and delivering dates to PRISM frontend by limiting it to only today
+    # this can be removed once we are sure the ews-1294 have solved the
+    # preformance issue
+    if only_dates:
+        today = datetime.now().replace(tzinfo=timezone.utc)
+        return [today.strftime('%Y-%m-%d')]
+
+    start = begin_datetime.date()
+    end = end_datetime.date()
+    base_api = 'http://sms.ews1294.info/api/v1/'
+
+    def parse_location_details(data: dict):
+        """Parse location details and format them."""
+        properties = data['properties']
+        coordinates = data['geometry']['coordinates']
+
+        if properties['status1'] == 'Operational' and properties['status'] == 'active':
+            details = dict()
+            details['id'] = properties['id']
+            details['external_id'] = properties['external_id']
+            details['lon'] = coordinates[0]
+            details['lat'] = coordinates[1]
+            details['name'] = properties['name']
+            details['namekh'] = properties['namekh']
+            details['water_height'] = properties['water_height']
+            details['trigger_levels'] = properties['trigger_levels']
+            return details
+        return None
+
+    def get_level_status(current_level: float, trigger_levels: dict) -> str:
+        """Calculate water level status based on sensor details."""
+        warning = trigger_levels['warning']
+        severe_warning = trigger_levels['severe_warning']
+
+        if current_level < warning:
+            return 0
+        elif current_level < severe_warning:
+            return 1
+        else:
+            return 2
+
+    def parse_data_by_location(location: dict):
+        """Parse all data by this location."""
+        location_id = location['external_id']
+        data_url = '{0}sensors/sensor_event?external_id={1}&start={2}&end={3}'.format(
+            base_api, location_id, start, end
+        )
+
+        resp = requests.get(data_url)
+        resp.raise_for_status()
+        data_per_location = resp.json()
+
+        days = [start + timedelta(days=d) for d in range((end - start).days)]
+
+        location_data_by_day = []
+        for n in range(len(days)):
+            daily_levels = numpy.array(
+                [_['value'][1] for _ in data_per_location
+                 if dtparser(_['value'][0]).date() == days[n]]
+            )
+            dl_array = numpy.array(daily_levels)
+
+            if len(dl_array) > 0:
+                minimum = int(numpy.min(dl_array))
+                maximum = int(numpy.max(dl_array))
+                mean = round(numpy.mean(dl_array), 2)
+                median = round(numpy.median(dl_array), 2)
+                status = get_level_status(mean, location['trigger_levels'])
+
+                location_data_by_day.append({
+                    'date': days[n].strftime('%Y-%m-%d'),
+                    'level_min': minimum,
+                    'level_max': maximum,
+                    'level_mean': mean,
+                    'level_median': median,
+                    'level_status': status,
+                    **location
+                })
+
+        return location_data_by_day
+
+    location_url = '{0}location.geojson?type=river'.format(base_api)
+
+    resp = requests.get(location_url)
+    resp.raise_for_status()
+    ews_data = resp.json().get('features')
+    location_details = list(
+        filter(lambda item: item is not None, map(parse_location_details, ews_data))
+    )
+
+    return list(itertools.chain(*list(map(parse_data_by_location, location_details))))

--- a/api-flask/app/ews.py
+++ b/api-flask/app/ews.py
@@ -8,6 +8,8 @@ from flask import request
 
 import numpy
 
+import pytz
+
 import requests
 
 from werkzeug.exceptions import BadRequest
@@ -117,7 +119,13 @@ def get_ews_response(only_dates, begin_datetime, end_datetime):
 
             dates_row = dict()
             for count, level in enumerate(levels_and_dates):
-                dates_row[count] = level[0]
+                # convert naive to timezone aware and utc
+                format_str = '%Y-%m-%dT%H:%M:%S'
+                level_date = datetime.strptime(level[0], format_str)
+                ict = pytz.timezone('Asia/Phnom_Penh')
+                level_date = ict.localize(level_date)
+                level_date = level_date.astimezone(pytz.UTC)
+                dates_row[count] = level_date
             rows.append(dates_row)
 
             levels_row = dict()

--- a/api-flask/app/ews.py
+++ b/api-flask/app/ews.py
@@ -65,8 +65,6 @@ def get_ews_response(only_dates, begin_datetime, end_datetime):
     if only_dates:
         the_beginning = datetime.strptime(DATA_COLLECTION_START_DAY_STR, '%Y-%m-%d')
         today = datetime.now()
-        # delta = today - the_beginning
-        # return [{'date': (the_beginning + timedelta(days=day)).strftime('%Y-%m-%d')} for day in range(delta.days + 1)]
         days = [the_beginning + timedelta(days=d) for d in range((today - the_beginning).days+1)]
         return list(map(lambda d: {'date': d.strftime('%Y-%m-%d')}, days))
 

--- a/api-flask/app/ews.py
+++ b/api-flask/app/ews.py
@@ -117,7 +117,7 @@ def get_ews_response(only_dates, begin_datetime, end_datetime):
 
             rows = list()
 
-            dates_row = dict()
+            dates_row = {'level': 'river_level'}
             for count, level in enumerate(levels_and_dates):
                 # convert naive to timezone aware and utc
                 format_str = '%Y-%m-%dT%H:%M:%S'
@@ -125,12 +125,12 @@ def get_ews_response(only_dates, begin_datetime, end_datetime):
                 ict = pytz.timezone('Asia/Phnom_Penh')
                 level_date = ict.localize(level_date)
                 level_date = level_date.astimezone(pytz.UTC)
-                dates_row[count] = level_date
+                dates_row['level{}'.format(count)] = level_date
             rows.append(dates_row)
 
-            levels_row = dict()
+            levels_row = {'level': 'current_level'}
             for count, level in enumerate(levels_and_dates):
-                levels_row[count] = level[1]
+                levels_row['level{}'.format(count)] = level[1]
             rows.append(levels_row)
 
             daily_levels = numpy.array([_[1] for _ in levels_and_dates])

--- a/api-flask/app/main.py
+++ b/api-flask/app/main.py
@@ -11,7 +11,7 @@ from app.errors import handle_error, make_json_error
 from app.timer import timed
 from app.zonal_stats import calculate_stats, get_wfs_response
 
-from ews import get_ews_location_response, get_ews_response, parse_ews_params
+from ews import get_ews_response, parse_ews_params
 
 from flask import Flask, Response, json, jsonify, request
 
@@ -152,14 +152,6 @@ def get_kobo_forms():
     form_responses = get_form_responses(begin_datetime, end_datetime)
 
     return Response(json.dumps(form_responses), mimetype='application/json')
-
-
-@app.route('/ews/location/data', methods=['GET'])
-def get_ews_location_data():
-    """Get datapoints for only one location."""
-    _, begin_datetime, end_datetime = parse_ews_params()
-    resp = get_ews_location_response(begin_datetime, end_datetime)
-    return Response(json.dumps(resp), mimetype='application/json')
 
 
 @app.route('/ews/data', methods=['GET'])

--- a/api-flask/app/main.py
+++ b/api-flask/app/main.py
@@ -11,6 +11,8 @@ from app.errors import handle_error, make_json_error
 from app.timer import timed
 from app.zonal_stats import calculate_stats, get_wfs_response
 
+from ews import get_ews_responses, parse_ews_params
+
 from flask import Flask, Response, json, jsonify, request
 
 from flask_caching import Cache
@@ -150,6 +152,15 @@ def get_kobo_forms():
     form_responses = get_form_responses(begin_datetime, end_datetime)
 
     return Response(json.dumps(form_responses), mimetype='application/json')
+
+
+@app.route('/ews/data', methods=['GET'])
+@cache.cached(timeout=900, query_string=True)
+def get_ews_data():
+    """Get all early warning from all locations."""
+    only_dates, begin_datetime, end_datetime = parse_ews_params()
+    ews_responses = get_ews_responses(only_dates, begin_datetime, end_datetime)
+    return Response(json.dumps(ews_responses), mimetype='application/json')
 
 
 @app.route('/alerts/<id>', methods=['GET'])

--- a/api-flask/app/main.py
+++ b/api-flask/app/main.py
@@ -11,7 +11,7 @@ from app.errors import handle_error, make_json_error
 from app.timer import timed
 from app.zonal_stats import calculate_stats, get_wfs_response
 
-from ews import get_ews_responses, parse_ews_params
+from ews import get_ews_location_response, get_ews_response, parse_ews_params
 
 from flask import Flask, Response, json, jsonify, request
 
@@ -154,12 +154,20 @@ def get_kobo_forms():
     return Response(json.dumps(form_responses), mimetype='application/json')
 
 
+@app.route('/ews/location/data', methods=['GET'])
+def get_ews_location_data():
+    """Get datapoints for only one location."""
+    _, begin_datetime, end_datetime = parse_ews_params()
+    resp = get_ews_location_response(begin_datetime, end_datetime)
+    return Response(json.dumps(resp), mimetype='application/json')
+
+
 @app.route('/ews/data', methods=['GET'])
 @cache.cached(timeout=900, query_string=True)
 def get_ews_data():
     """Get all early warning from all locations."""
     only_dates, begin_datetime, end_datetime = parse_ews_params()
-    ews_responses = get_ews_responses(only_dates, begin_datetime, end_datetime)
+    ews_responses = get_ews_response(only_dates, begin_datetime, end_datetime)
     return Response(json.dumps(ews_responses), mimetype='application/json')
 
 

--- a/api-flask/app/main.py
+++ b/api-flask/app/main.py
@@ -155,7 +155,6 @@ def get_kobo_forms():
 
 
 @app.route('/ews/data', methods=['GET'])
-@cache.cached(timeout=900, query_string=True)
 def get_ews_data():
     """Get all early warning from all locations."""
     only_dates, begin_datetime, end_datetime = parse_ews_params()

--- a/api-flask/requirements.txt
+++ b/api-flask/requirements.txt
@@ -3,6 +3,7 @@ Flask-Cors==3.0.9
 rasterstats==0.14.0
 requests==2.23.0
 Shapely==1.7.0
+pytz==2021.3
 # Used by `make test` only:
 mock==4.0.2
 pytest==5.4.3

--- a/src/components/App/__snapshots__/index.test.tsx.snap
+++ b/src/components/App/__snapshots__/index.test.tsx.snap
@@ -9,7 +9,6 @@ exports[`renders as expected 1`] = `
   >
     <mock-mapview />
     <mock-datadrawer />
-    <mock-datadrawer />
   </div>
 </div>
 `;

--- a/src/components/App/index.test.tsx
+++ b/src/components/App/index.test.tsx
@@ -7,7 +7,6 @@ jest.mock('../DataDrawer', () => 'mock-DataDrawer');
 jest.mock('../MapView', () => 'mock-MapView');
 jest.mock('../404Page', () => 'mock-NotFound');
 jest.mock('../Notifier', () => 'mock-Notifier');
-jest.mock('../DataViewer', () => 'mock-DataDrawer');
 
 test('renders as expected', () => {
   const { container } = render(<App />);

--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -7,7 +7,6 @@ import './app.css';
 import NavBar from '../NavBar';
 import DataDrawer from '../DataDrawer';
 import MapView from '../MapView';
-import DataViewer from '../DataViewer';
 import NotFound from '../404Page';
 import muiTheme from '../../muiTheme';
 import Notifier from '../Notifier';
@@ -34,7 +33,6 @@ function App() {
             <Route exact path="/">
               <MapView />
               <DataDrawer />
-              <DataViewer />
             </Route>
             <Route default component={NotFound} />
           </Switch>

--- a/src/components/DataDrawer/Chart/index.tsx
+++ b/src/components/DataDrawer/Chart/index.tsx
@@ -23,7 +23,7 @@ function getChartConfig(stacked: boolean, title: string) {
       fontColor: '#CCC',
       display: true,
       text: title,
-      fontSize: 20,
+      fontSize: 16,
     },
     scales: {
       xAxes: [

--- a/src/components/DataDrawer/Chart/index.tsx
+++ b/src/components/DataDrawer/Chart/index.tsx
@@ -34,6 +34,7 @@ function getChartConfig(stacked: boolean, title: string) {
           },
           ticks: {
             fontColor: '#CCC',
+            fontSize: 9,
           },
         },
       ],
@@ -41,6 +42,7 @@ function getChartConfig(stacked: boolean, title: string) {
         {
           ticks: {
             fontColor: '#CCC',
+            fontSize: 9,
           },
           stacked,
           gridLines: {
@@ -115,7 +117,8 @@ function formatChartData(data: TableData, config: ChartConfig) {
         fill: config.fill || false,
         backgroundColor: colors[i],
         borderColor: colors[i],
-        borderWidth: 2,
+        borderWidth: 1,
+        pointRadius: 1,
         data: indices.map(index => (row[index] as number) || null),
       }))
     : indices.map((index, i) => ({
@@ -123,7 +126,8 @@ function formatChartData(data: TableData, config: ChartConfig) {
         fill: config.fill || false,
         backgroundColor: colors[i],
         borderColor: colors[i],
-        borderWidth: 2,
+        borderWidth: 1,
+        pointRadius: 1,
         data: tableRows.map(row => (row[index] as number) || null),
       }));
 

--- a/src/components/DataDrawer/Chart/index.tsx
+++ b/src/components/DataDrawer/Chart/index.tsx
@@ -112,15 +112,31 @@ function formatChartData(data: TableData, config: ChartConfig) {
     : tableRows.map(row => row[config.category]);
 
   const datasets = !transpose
-    ? tableRows.map((row, i) => ({
-        label: (row[config.category] as string) || '',
-        fill: config.fill || false,
-        backgroundColor: colors[i],
-        borderColor: colors[i],
-        borderWidth: 1,
-        pointRadius: 1,
-        data: indices.map(index => (row[index] as number) || null),
-      }))
+    ? tableRows.map((row, i) => {
+        // Unique check to change appearence of baselines
+        // to show water levels in Cambodia EWS
+        const hasLevel = 'level' in row;
+        const isNormal = hasLevel && row.level === 'watch_level';
+        const isWarning = hasLevel && row.level === 'warning';
+        const isSevere = hasLevel && row.level === 'severe_warning';
+
+        return {
+          label:
+            (row[config.category] as string) ||
+            (hasLevel && (row.level as string).replace('_', ' ')) ||
+            '',
+          fill: config.fill || false,
+          backgroundColor: colors[i],
+          borderColor:
+            (isNormal && '#31a354') ||
+            (isWarning && '#fdae6b') ||
+            (isSevere && '#e34a33') ||
+            colors[i],
+          borderWidth: isNormal || isWarning || isSevere ? 2 : 1,
+          pointRadius: isNormal || isWarning || isSevere ? 0 : 1,
+          data: indices.map(index => (row[index] as number) || null),
+        };
+      })
     : indices.map((index, i) => ({
         label: header[index] as string,
         fill: config.fill || false,

--- a/src/components/DataDrawer/Chart/index.tsx
+++ b/src/components/DataDrawer/Chart/index.tsx
@@ -119,6 +119,10 @@ function formatChartData(data: TableData, config: ChartConfig) {
         const isNormal = hasLevel && row.level === 'watch_level';
         const isWarning = hasLevel && row.level === 'warning';
         const isSevere = hasLevel && row.level === 'severe_warning';
+        const levelColors =
+          (isNormal && '#31a354') ||
+          (isWarning && '#fdae6b') ||
+          (isSevere && '#e34a33');
 
         return {
           label:
@@ -126,12 +130,8 @@ function formatChartData(data: TableData, config: ChartConfig) {
             (hasLevel && (row.level as string).replace('_', ' ')) ||
             '',
           fill: config.fill || false,
-          backgroundColor: colors[i],
-          borderColor:
-            (isNormal && '#31a354') ||
-            (isWarning && '#fdae6b') ||
-            (isSevere && '#e34a33') ||
-            colors[i],
+          backgroundColor: levelColors || colors[i],
+          borderColor: levelColors || colors[i],
           borderWidth: isNormal || isWarning || isSevere ? 2 : 1,
           pointRadius: isNormal || isWarning || isSevere ? 0 : 1,
           data: indices.map(index => (row[index] as number) || null),

--- a/src/components/DataViewer/index.tsx
+++ b/src/components/DataViewer/index.tsx
@@ -8,7 +8,7 @@ import {
   WithStyles,
   withStyles,
 } from '@material-ui/core';
-import { DatasetSelector } from '../../context/layers/boundary';
+import { DatasetSelector } from '../../context/chartDataStateSlice';
 import Chart from '../DataDrawer/Chart';
 import { ChartConfig } from '../../config/types';
 

--- a/src/components/MapView/DataViewer/index.tsx
+++ b/src/components/MapView/DataViewer/index.tsx
@@ -7,7 +7,9 @@ import {
   Paper,
   WithStyles,
   withStyles,
+  IconButton,
 } from '@material-ui/core';
+import { Close } from '@material-ui/icons';
 import { DatasetSelector } from '../../../context/chartDataStateSlice';
 import Chart from '../../DataDrawer/Chart';
 import { ChartConfig } from '../../../config/types';
@@ -38,6 +40,9 @@ function DataViewer({ classes }: DatasetProps) {
       {open && (
         <Grid item className={classes.container}>
           <Paper className={classes.paper}>
+            <IconButton size="small" onClick={() => setOpen(false)}>
+              <Close fontSize="small" />
+            </IconButton>
             <Chart title="" config={config} data={dataset} />
           </Paper>
         </Grid>
@@ -54,7 +59,7 @@ const styles = (theme: Theme) =>
     },
     paper: {
       padding: 8,
-      width: 560,
+      width: 480,
     },
     title: {
       color: theme.palette.text.secondary,

--- a/src/components/MapView/DataViewer/index.tsx
+++ b/src/components/MapView/DataViewer/index.tsx
@@ -54,7 +54,7 @@ const styles = (theme: Theme) =>
     },
     paper: {
       padding: 8,
-      width: 480,
+      width: 560,
     },
     title: {
       color: theme.palette.text.secondary,

--- a/src/components/MapView/DataViewer/index.tsx
+++ b/src/components/MapView/DataViewer/index.tsx
@@ -16,8 +16,14 @@ import {
 } from '../../../context/chartDataStateSlice';
 import Chart from '../../DataDrawer/Chart';
 import { ChartConfig } from '../../../config/types';
+import { isLoading } from '../../../context/mapStateSlice/selectors';
+import { isLoading as areDatesLoading } from '../../../context/serverStateSlice';
 
 function DataViewer({ classes }: DatasetProps) {
+  const layersLoading = useSelector(isLoading);
+  const datesLoading = useSelector(areDatesLoading);
+  const loading = layersLoading || datesLoading;
+
   const dataset = useSelector(DatasetSelector);
   const title = useSelector(PointTitleSelector);
   const [open, setOpen] = useState(false);
@@ -41,7 +47,7 @@ function DataViewer({ classes }: DatasetProps) {
 
   return (
     <>
-      {open && (
+      {open && !loading && (
         <Grid item className={classes.container}>
           <Paper className={classes.paper}>
             <IconButton size="small" onClick={() => setOpen(false)}>

--- a/src/components/MapView/DataViewer/index.tsx
+++ b/src/components/MapView/DataViewer/index.tsx
@@ -10,12 +10,16 @@ import {
   IconButton,
 } from '@material-ui/core';
 import { Close } from '@material-ui/icons';
-import { DatasetSelector } from '../../../context/chartDataStateSlice';
+import {
+  DatasetSelector,
+  PointTitleSelector,
+} from '../../../context/chartDataStateSlice';
 import Chart from '../../DataDrawer/Chart';
 import { ChartConfig } from '../../../config/types';
 
 function DataViewer({ classes }: DatasetProps) {
   const dataset = useSelector(DatasetSelector);
+  const title = useSelector(PointTitleSelector);
   const [open, setOpen] = useState(false);
 
   useEffect(() => {
@@ -43,7 +47,7 @@ function DataViewer({ classes }: DatasetProps) {
             <IconButton size="small" onClick={() => setOpen(false)}>
               <Close fontSize="small" />
             </IconButton>
-            <Chart title="" config={config} data={dataset} />
+            <Chart title={title || ''} config={config} data={dataset} />
           </Paper>
         </Grid>
       )}

--- a/src/components/MapView/DataViewer/index.tsx
+++ b/src/components/MapView/DataViewer/index.tsx
@@ -2,15 +2,15 @@ import React, { useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import {
   createStyles,
-  Dialog,
-  DialogTitle,
   Theme,
+  Grid,
+  Paper,
   WithStyles,
   withStyles,
 } from '@material-ui/core';
-import { DatasetSelector } from '../../context/chartDataStateSlice';
-import Chart from '../DataDrawer/Chart';
-import { ChartConfig } from '../../config/types';
+import { DatasetSelector } from '../../../context/chartDataStateSlice';
+import Chart from '../../DataDrawer/Chart';
+import { ChartConfig } from '../../../config/types';
 
 function DataViewer({ classes }: DatasetProps) {
   const dataset = useSelector(DatasetSelector);
@@ -34,28 +34,27 @@ function DataViewer({ classes }: DatasetProps) {
   };
 
   return (
-    <Dialog
-      maxWidth="xl"
-      open={open}
-      keepMounted
-      onClose={() => setOpen(false)}
-      aria-labelledby="dialog-preview"
-    >
-      <DialogTitle className={classes.title} id="dialog-preview">
-        Data Viewer
-      </DialogTitle>
-      <div className={classes.modal}>
-        <Chart title="Example plot" config={config} data={dataset} />
-      </div>
-    </Dialog>
+    <>
+      {open && (
+        <Grid item className={classes.container}>
+          <Paper className={classes.paper}>
+            <Chart title="Example plot" config={config} data={dataset} />
+          </Paper>
+        </Grid>
+      )}
+    </>
   );
 }
 
 const styles = (theme: Theme) =>
   createStyles({
-    modal: {
-      width: '50vw',
-      height: '50vh',
+    container: {
+      textAlign: 'right',
+      marginTop: 8,
+    },
+    paper: {
+      padding: 8,
+      width: 480,
     },
     title: {
       color: theme.palette.text.secondary,

--- a/src/components/MapView/DataViewer/index.tsx
+++ b/src/components/MapView/DataViewer/index.tsx
@@ -38,7 +38,7 @@ function DataViewer({ classes }: DatasetProps) {
       {open && (
         <Grid item className={classes.container}>
           <Paper className={classes.paper}>
-            <Chart title="Example plot" config={config} data={dataset} />
+            <Chart title="" config={config} data={dataset} />
           </Paper>
         </Grid>
       )}

--- a/src/components/MapView/Layers/BoundaryLayer/index.tsx
+++ b/src/components/MapView/Layers/BoundaryLayer/index.tsx
@@ -10,8 +10,12 @@ import {
   loadDataset,
   DatasetParams,
 } from '../../../../context/layers/boundary';
-import { layerDataSelector } from '../../../../context/mapStateSlice/selectors';
+import {
+  mapSelector,
+  layerDataSelector,
+} from '../../../../context/mapStateSlice/selectors';
 import { toggleSelectedBoundary } from '../../../../context/mapSelectionLayerStateSlice';
+import { onlyBoundaryLayerOnPoint } from '../../../../utils/map_utils';
 
 function onToggleHover(cursor: string, targetMap: MapboxGL.Map) {
   // eslint-disable-next-line no-param-reassign, fp/no-mutation
@@ -20,6 +24,8 @@ function onToggleHover(cursor: string, targetMap: MapboxGL.Map) {
 
 function BoundaryLayer({ layer }: { layer: BoundaryLayerProps }) {
   const dispatch = useDispatch();
+
+  const map = useSelector(mapSelector);
   const boundaryLayer = useSelector(layerDataSelector(layer.id)) as
     | LayerData<BoundaryLayerProps>
     | undefined;
@@ -71,7 +77,19 @@ function BoundaryLayer({ layer }: { layer: BoundaryLayerProps }) {
           : undefined
       }
       fillOnMouseLeave={(evt: any) => onToggleHover('', evt.target)}
-      fillOnClick={layer.id === 'admin_boundaries' ? onClickFunc : undefined}
+      fillOnClick={
+        layer.id === 'admin_boundaries'
+          ? (evt: any) => {
+              if (!map) {
+                return;
+              }
+
+              if (onlyBoundaryLayerOnPoint(map, evt.point)) {
+                onClickFunc(evt);
+              }
+            }
+          : undefined
+      }
     />
   );
 }

--- a/src/components/MapView/Layers/BoundaryLayer/index.tsx
+++ b/src/components/MapView/Layers/BoundaryLayer/index.tsx
@@ -9,7 +9,7 @@ import { LayerData } from '../../../../context/layers/layer-data';
 import {
   loadDataset,
   DatasetParams,
-} from '../../../../context/layers/boundary';
+} from '../../../../context/chartDataStateSlice';
 import {
   mapSelector,
   layerDataSelector,

--- a/src/components/MapView/Layers/PointDataLayer/index.tsx
+++ b/src/components/MapView/Layers/PointDataLayer/index.tsx
@@ -14,6 +14,10 @@ import {
 import { layerDataSelector } from '../../../../context/mapStateSlice/selectors';
 import { useDefaultDate } from '../../../../utils/useDefaultDate';
 import { getFeatureInfoPropsData } from '../../utils';
+import {
+  loadEWS1294Dataset,
+  PointDatasetParams,
+} from '../../../../context/layers/point_data';
 
 // Point Data, takes any GeoJSON of points and shows it.
 function PointDataLayer({ layer }: { layer: PointDataLayerProps }) {
@@ -45,34 +49,47 @@ function PointDataLayer({ layer }: { layer: PointDataLayerProps }) {
     },
   };
 
+  const onHoverHandler = (evt: any) => {
+    // by default add `measure` to the tooltip
+    dispatch(
+      addPopupData({
+        [layer.title]: {
+          data: get(evt.features[0], `properties.${layer.measure}`, 'No Data'),
+          coordinates: evt.lngLat,
+        },
+      }),
+    );
+
+    // then add feature_info_props as extra fields to the tooltip
+    dispatch(
+      addPopupData(getFeatureInfoPropsData(layer.featureInfoProps || {}, evt)),
+    );
+  };
+
+  const onClickHandler = (evt: any) => {
+    // get the `external_id`
+    const externalId = get(evt.features[0].properties, 'external_id');
+
+    // form url
+    const url = `http://sms.ews1294.info/api/v1/sensors/sensor_event?external_id=${externalId}`;
+    // form a url for 7 days of the specified sensor
+    // dispatch loadDataset with datasetparams
+    // toggleSelected point/boundary
+    const pointDatasetParams: PointDatasetParams = {
+      url:
+        'http://sms.ews1294.info/api/v1/sensors/sensor_event?external_id=TEPv4.0-013&start=2022-01-25&end=2022-01-31',
+    };
+    dispatch(loadEWS1294Dataset(pointDatasetParams));
+  };
+
   return (
     <GeoJSONLayer
-      before="boundaries-line"
       id={`layer-${layer.id}`}
       data={data}
       circleLayout={circleLayout}
       circlePaint={circlePaint}
-      circleOnClick={async (evt: any) => {
-        // by default add `measure` to the tooltip
-        dispatch(
-          addPopupData({
-            [layer.title]: {
-              data: get(
-                evt.features[0],
-                `properties.${layer.measure}`,
-                'No Data',
-              ),
-              coordinates: evt.lngLat,
-            },
-          }),
-        );
-        // then add feature_info_props as extra fields to the tooltip
-        dispatch(
-          addPopupData(
-            getFeatureInfoPropsData(layer.featureInfoProps || {}, evt),
-          ),
-        );
-      }}
+      circleOnMouseMove={onHoverHandler}
+      circleOnClick={onClickHandler}
     />
   );
 }

--- a/src/components/MapView/Layers/PointDataLayer/index.tsx
+++ b/src/components/MapView/Layers/PointDataLayer/index.tsx
@@ -15,7 +15,10 @@ import { layerDataSelector } from '../../../../context/mapStateSlice/selectors';
 import { useDefaultDate } from '../../../../utils/useDefaultDate';
 import { getFeatureInfoPropsData } from '../../utils';
 import { TableRowType } from '../../../../context/tableStateSlice';
-import { addEwsDataset } from '../../../../context/chartDataStateSlice';
+import {
+  addEwsDataset,
+  addPointTitle,
+} from '../../../../context/chartDataStateSlice';
 
 // Point Data, takes any GeoJSON of points and shows it.
 function PointDataLayer({ layer }: { layer: PointDataLayerProps }) {
@@ -40,6 +43,7 @@ function PointDataLayer({ layer }: { layer: PointDataLayerProps }) {
 
   const circleLayout: MapboxGL.CircleLayout = { visibility: 'visible' };
   const circlePaint: MapboxGL.CirclePaint = {
+    'circle-radius': 10,
     'circle-opacity': layer.opacity || 0.3,
     'circle-color': {
       property: layer.measure,
@@ -93,6 +97,10 @@ function PointDataLayer({ layer }: { layer: PointDataLayerProps }) {
       rows,
     );
 
+    const pointName = get(properties, 'name');
+    const externalId = get(properties, 'external_id');
+    const title = `River level: ${pointName} - ${externalId}`;
+    dispatch(addPointTitle(title));
     dispatch(addEwsDataset({ rows: allRows, columns }));
   };
 

--- a/src/components/MapView/Layers/PointDataLayer/index.tsx
+++ b/src/components/MapView/Layers/PointDataLayer/index.tsx
@@ -14,10 +14,7 @@ import {
 import { layerDataSelector } from '../../../../context/mapStateSlice/selectors';
 import { useDefaultDate } from '../../../../utils/useDefaultDate';
 import { getFeatureInfoPropsData } from '../../utils';
-import {
-  loadEWS1294Dataset,
-  PointDatasetParams,
-} from '../../../../context/layers/point_data';
+import { addEwsDataset } from '../../../../context/chartDataStateSlice';
 
 // Point Data, takes any GeoJSON of points and shows it.
 function PointDataLayer({ layer }: { layer: PointDataLayerProps }) {
@@ -67,9 +64,8 @@ function PointDataLayer({ layer }: { layer: PointDataLayerProps }) {
   };
 
   const onClickHandler = (evt: any) => {
-    const url = evt.features[0].properties.daily_rows;
-    const pointDatasetParams: PointDatasetParams = { url };
-    dispatch(loadEWS1294Dataset(pointDatasetParams));
+    const pointDataset = JSON.parse(evt.features[0].properties.daily_rows);
+    dispatch(addEwsDataset(pointDataset));
   };
 
   return (

--- a/src/components/MapView/Layers/PointDataLayer/index.tsx
+++ b/src/components/MapView/Layers/PointDataLayer/index.tsx
@@ -66,7 +66,12 @@ function PointDataLayer({ layer }: { layer: PointDataLayerProps }) {
 
   const onClickHandler = (evt: any) => {
     const { properties } = evt.features[0];
-    const pointDataset = JSON.parse(get(properties, 'daily_rows'));
+    const dailyRows = get(properties, 'daily_rows');
+    if (!dailyRows) {
+      return;
+    }
+
+    const pointDataset = JSON.parse(dailyRows);
     const triggerLevels = JSON.parse(get(properties, 'trigger_levels'));
     const { rows, columns } = pointDataset;
     const allRows = Object.keys(triggerLevels).reduce(

--- a/src/components/MapView/Layers/PointDataLayer/index.tsx
+++ b/src/components/MapView/Layers/PointDataLayer/index.tsx
@@ -67,18 +67,17 @@ function PointDataLayer({ layer }: { layer: PointDataLayerProps }) {
   };
 
   const onClickHandler = (evt: any) => {
-    // get the `external_id`
+    const today = new Date();
+    const weekAgo = new Date(today.getTime() - 7 * 24 * 60 * 60 * 1000);
+    const start = `${weekAgo.getFullYear()}-${
+      weekAgo.getMonth() + 1
+    }-${weekAgo.getDate()}`;
+    const end = `${today.getFullYear()}-${
+      today.getMonth() + 1
+    }-${today.getDate()}`;
     const externalId = get(evt.features[0].properties, 'external_id');
-
-    // form url
-    const url = `http://sms.ews1294.info/api/v1/sensors/sensor_event?external_id=${externalId}`;
-    // form a url for 7 days of the specified sensor
-    // dispatch loadDataset with datasetparams
-    // toggleSelected point/boundary
-    const pointDatasetParams: PointDatasetParams = {
-      url:
-        'http://sms.ews1294.info/api/v1/sensors/sensor_event?external_id=TEPv4.0-013&start=2022-01-25&end=2022-01-31',
-    };
+    const url = `http://sms.ews1294.info/api/v1/sensors/sensor_event?external_id=${externalId}&start=${start}&end=${end}`;
+    const pointDatasetParams: PointDatasetParams = { url };
     dispatch(loadEWS1294Dataset(pointDatasetParams));
   };
 

--- a/src/components/MapView/Layers/PointDataLayer/index.tsx
+++ b/src/components/MapView/Layers/PointDataLayer/index.tsx
@@ -67,16 +67,7 @@ function PointDataLayer({ layer }: { layer: PointDataLayerProps }) {
   };
 
   const onClickHandler = (evt: any) => {
-    const today = new Date();
-    const weekAgo = new Date(today.getTime() - 7 * 24 * 60 * 60 * 1000);
-    const start = `${weekAgo.getFullYear()}-${
-      weekAgo.getMonth() + 1
-    }-${weekAgo.getDate()}`;
-    const end = `${today.getFullYear()}-${
-      today.getMonth() + 1
-    }-${today.getDate()}`;
-    const externalId = get(evt.features[0].properties, 'external_id');
-    const url = `http://sms.ews1294.info/api/v1/sensors/sensor_event?external_id=${externalId}&start=${start}&end=${end}`;
+    const url = evt.features[0].properties.daily_rows;
     const pointDatasetParams: PointDatasetParams = { url };
     dispatch(loadEWS1294Dataset(pointDatasetParams));
   };

--- a/src/components/MapView/Layers/PointDataLayer/index.tsx
+++ b/src/components/MapView/Layers/PointDataLayer/index.tsx
@@ -14,6 +14,7 @@ import {
 import { layerDataSelector } from '../../../../context/mapStateSlice/selectors';
 import { useDefaultDate } from '../../../../utils/useDefaultDate';
 import { getFeatureInfoPropsData } from '../../utils';
+import { TableRowType } from '../../../../context/tableStateSlice';
 import { addEwsDataset } from '../../../../context/chartDataStateSlice';
 
 // Point Data, takes any GeoJSON of points and shows it.
@@ -64,8 +65,30 @@ function PointDataLayer({ layer }: { layer: PointDataLayerProps }) {
   };
 
   const onClickHandler = (evt: any) => {
-    const pointDataset = JSON.parse(evt.features[0].properties.daily_rows);
-    dispatch(addEwsDataset(pointDataset));
+    const { properties } = evt.features[0];
+    const pointDataset = JSON.parse(get(properties, 'daily_rows'));
+    const triggerLevels = JSON.parse(get(properties, 'trigger_levels'));
+    const { rows, columns } = pointDataset;
+    const allRows = Object.keys(triggerLevels).reduce(
+      (acc: TableRowType[], val: string | number) => {
+        const levelData = columns.reduce(
+          (
+            accumulator: TableRowType,
+            value: string | number,
+            index: number,
+          ) => {
+            const levelKey = `level${index}`;
+            return { ...accumulator, [levelKey]: triggerLevels[val] };
+          },
+          { level: val },
+        );
+
+        return [...acc, levelData];
+      },
+      rows,
+    );
+
+    dispatch(addEwsDataset({ rows: allRows, columns }));
   };
 
   return (

--- a/src/components/MapView/Layers/PointDataLayer/index.tsx
+++ b/src/components/MapView/Layers/PointDataLayer/index.tsx
@@ -78,6 +78,18 @@ function PointDataLayer({ layer }: { layer: PointDataLayerProps }) {
     const pointDataset = JSON.parse(dailyRows);
     const triggerLevels = JSON.parse(get(properties, 'trigger_levels'));
     const { rows, columns } = pointDataset;
+    // Dataset object are not ordered sort dates
+    const sortedRows = rows.map((row: TableRowType, index: number) => {
+      if (index === 0) {
+        return Object.fromEntries(
+          /* eslint-disable fp/no-mutating-methods */
+          Object.entries(row).sort(
+            ([, a], [, b]) => new Date(a).getTime() - new Date(b).getTime(),
+          ),
+        );
+      }
+      return row;
+    });
     const allRows = Object.keys(triggerLevels).reduce(
       (acc: TableRowType[], val: string | number) => {
         const levelData = columns.reduce(
@@ -94,7 +106,7 @@ function PointDataLayer({ layer }: { layer: PointDataLayerProps }) {
 
         return [...acc, levelData];
       },
-      rows,
+      sortedRows,
     );
 
     const pointName = get(properties, 'name');

--- a/src/components/MapView/Legends/__snapshots__/index.test.tsx.snap
+++ b/src/components/MapView/Legends/__snapshots__/index.test.tsx.snap
@@ -5,24 +5,6 @@ exports[`renders as expected 1`] = `
   <div
     class="MuiGrid-root Legends-container-1 MuiGrid-item"
   >
-    <mock-button
-      color="primary"
-      variant="contained"
-    >
-      <mock-visibilityoff
-        fontsize="small"
-      />
-      <mock-hidden
-        smdown="true"
-      >
-        <mock-typography
-          classname="Legends-label-2"
-          variant="body2"
-        >
-          Legend
-        </mock-typography>
-      </mock-hidden>
-    </mock-button>
     <mock-list
       classname="Legends-list-3"
     />

--- a/src/components/MapView/Legends/index.tsx
+++ b/src/components/MapView/Legends/index.tsx
@@ -5,7 +5,6 @@ import {
   createStyles,
   Divider,
   Grid,
-  Hidden,
   List,
   ListItem,
   Paper,
@@ -14,7 +13,6 @@ import {
   WithStyles,
   withStyles,
 } from '@material-ui/core';
-import { Visibility, VisibilityOff } from '@material-ui/icons';
 
 import { useDispatch, useSelector } from 'react-redux';
 import { Extent } from '../Layers/raster-utils';
@@ -32,6 +30,7 @@ import {
   analysisResultSelector,
   isAnalysisLayerActiveSelector,
 } from '../../../context/analysisResultStateSlice';
+import { legendsVisibleSelector } from '../../../context/legendsStateSlice';
 
 import {
   BaselineLayerResult,
@@ -74,11 +73,11 @@ function LegendImpactResult({ result }: { result: BaselineLayerResult }) {
 }
 
 function Legends({ classes, layers, extent }: LegendsProps) {
-  const [open, setOpen] = useState(true);
   const isAnalysisLayerActive = useSelector(isAnalysisLayerActiveSelector);
   const analysisResult = useSelector(analysisResultSelector);
   const features = analysisResult?.featureCollection.features;
   const hasData = features ? features.length > 0 : false;
+  const isVisible = useSelector(legendsVisibleSelector);
 
   const handleAnalysisDownload = (e: React.ChangeEvent<{}>): void => {
     e.preventDefault();
@@ -156,23 +155,7 @@ function Legends({ classes, layers, extent }: LegendsProps) {
 
   return (
     <Grid item className={classes.container}>
-      <Button
-        variant="contained"
-        color="primary"
-        onClick={() => setOpen(!open)}
-      >
-        {open ? (
-          <VisibilityOff fontSize="small" />
-        ) : (
-          <Visibility fontSize="small" />
-        )}
-        <Hidden smDown>
-          <Typography className={classes.label} variant="body2">
-            Legend
-          </Typography>
-        </Hidden>
-      </Button>
-      {open && <List className={classes.list}>{legendItems}</List>}
+      {isVisible && <List className={classes.list}>{legendItems}</List>}
     </Grid>
   );
 }

--- a/src/components/MapView/Legends/index.tsx
+++ b/src/components/MapView/Legends/index.tsx
@@ -302,7 +302,7 @@ const styles = () =>
     list: {
       overflowX: 'hidden',
       overflowY: 'auto',
-      maxHeight: '70vh',
+      maxHeight: '60vh',
       position: 'absolute',
       right: '16px',
     },

--- a/src/components/MapView/LegendsVisibilityButton/index.tsx
+++ b/src/components/MapView/LegendsVisibilityButton/index.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import {
+  Grid,
+  Button,
+  Hidden,
+  Typography,
+  Theme,
+  createStyles,
+  WithStyles,
+  withStyles,
+} from '@material-ui/core';
+import { Visibility, VisibilityOff } from '@material-ui/icons';
+import {
+  toggleVisible,
+  legendsVisibleSelector,
+} from '../../../context/legendsStateSlice';
+
+const LegendsVisibilityButton = ({ classes }: LegendsVisibilityButtonProps) => {
+  const dispatch = useDispatch();
+  const isVisible = useSelector(legendsVisibleSelector);
+
+  return (
+    <Grid item>
+      <Button
+        variant="contained"
+        color="primary"
+        onClick={() => dispatch(toggleVisible())}
+      >
+        {isVisible ? (
+          <VisibilityOff fontSize="small" />
+        ) : (
+          <Visibility fontSize="small" />
+        )}
+        <Hidden smDown>
+          <Typography className={classes.label} variant="body2">
+            Legend
+          </Typography>
+        </Hidden>
+      </Button>
+    </Grid>
+  );
+};
+
+const styles = (theme: Theme) =>
+  createStyles({
+    label: {
+      marginLeft: '10px',
+    },
+    title: {
+      color: theme.palette.text.secondary,
+    },
+  });
+
+export interface LegendsVisibilityButtonProps
+  extends WithStyles<typeof styles> {}
+
+export default withStyles(styles)(LegendsVisibilityButton);

--- a/src/components/MapView/__snapshots__/index.test.tsx.snap
+++ b/src/components/MapView/__snapshots__/index.test.tsx.snap
@@ -29,10 +29,41 @@ exports[`renders as expected 1`] = `
         <div
           class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1"
         >
-          <mock-download />
-          <mock-legends
-            layers="[object Object],[object Object],[object Object]"
-          />
+          <div
+            class="MuiGrid-root MuiGrid-item"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 MuiGrid-justify-xs-flex-end"
+            >
+              <mock-download />
+              <div
+                class="MuiGrid-root MuiGrid-item"
+              >
+                <mock-button
+                  color="primary"
+                  variant="contained"
+                >
+                  <mock-visibilityoff
+                    fontsize="small"
+                  />
+                  <mock-hidden
+                    smdown="true"
+                  >
+                    <mock-typography
+                      classname="LegendsVisibilityButton-label-4"
+                      variant="body2"
+                    >
+                      Legend
+                    </mock-typography>
+                  </mock-hidden>
+                </mock-button>
+              </div>
+            </div>
+            <mock-datadrawer />
+            <mock-legends
+              layers="[object Object],[object Object],[object Object]"
+            />
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/MapView/index.test.tsx
+++ b/src/components/MapView/index.test.tsx
@@ -14,6 +14,7 @@ jest.mock('./Legends', () => 'mock-Legends');
 jest.mock('./DateSelector', () => 'mock-DateSelector');
 jest.mock('./Analyser', () => 'mock-Analyser');
 jest.mock('./Download', () => 'mock-Download');
+jest.mock('./DataViewer', () => 'mock-DataDrawer');
 
 jest.mock('react-router-dom', () => ({
   useHistory: () => ({

--- a/src/components/MapView/index.tsx
+++ b/src/components/MapView/index.tsx
@@ -24,6 +24,7 @@ import type { Feature, MultiPolygon } from '@turf/helpers';
 import MapTooltip from './MapTooltip';
 import Legends from './Legends';
 import Download from './Download';
+import LegendsVisibilityButton from './LegendsVisibilityButton';
 // layers
 import {
   AdminLevelDataLayer,
@@ -447,8 +448,13 @@ function MapView({ classes }: MapViewProps) {
         </Grid>
         <Grid item>
           <Grid container spacing={1}>
-            <Download />
-            <Legends layers={selectedLayers} extent={adminBoundariesExtent} />
+            <Grid item>
+              <Grid container spacing={1}>
+                <Download />
+                <LegendsVisibilityButton />
+              </Grid>
+              <Legends layers={selectedLayers} extent={adminBoundariesExtent} />
+            </Grid>
           </Grid>
         </Grid>
       </Grid>

--- a/src/components/MapView/index.tsx
+++ b/src/components/MapView/index.tsx
@@ -25,6 +25,7 @@ import MapTooltip from './MapTooltip';
 import Legends from './Legends';
 import Download from './Download';
 import LegendsVisibilityButton from './LegendsVisibilityButton';
+import DataViewer from './DataViewer';
 // layers
 import {
   AdminLevelDataLayer,
@@ -449,10 +450,11 @@ function MapView({ classes }: MapViewProps) {
         <Grid item>
           <Grid container spacing={1}>
             <Grid item>
-              <Grid container spacing={1}>
+              <Grid container spacing={1} justify="flex-end">
                 <Download />
                 <LegendsVisibilityButton />
               </Grid>
+              <DataViewer />
               <Legends layers={selectedLayers} extent={adminBoundariesExtent} />
             </Grid>
           </Grid>

--- a/src/config/cambodia/layers.json
+++ b/src/config/cambodia/layers.json
@@ -396,7 +396,7 @@
     "opacity": 0,
     "legend_text": "",
     "legend": []
-  }, 
+  },
   "adamts_tracks": {
     "title": "Tropical storm - track",
     "type": "wms",
@@ -419,10 +419,10 @@
     "date_interval": "days",
     "opacity": 1.0,
     "legend_text": "Flood water detected from Sentinel-1 data and a permanent water mask from JRC. Source: SERVIR Mekong HYDRAFloods",
-    "legend": [      
+    "legend": [
       { "value": "1 - flooded", "color": "#a50f15" }
     ]
-  },    
+  },
   "hydra_s2": {
     "title": "Potential flooding (Sentinel-2)",
     "type": "wms",
@@ -431,10 +431,10 @@
     "date_interval": "days",
     "opacity": 1.0,
     "legend_text": "Flood water detected from Sentinel-2 data and a permanent water mask from JRC. Source: SERVIR Mekong HYDRAFloods",
-    "legend": [      
+    "legend": [
       { "value": "1 - flooded", "color": "#a50f15" }
     ]
-  },    
+  },
   "hydra_l8": {
     "title": "Potential flooding (Landsat)",
     "type": "wms",
@@ -443,10 +443,10 @@
     "date_interval": "days",
     "opacity": 1.0,
     "legend_text": "Flood water detected from Landsat-8 data and a permanent water mask from JRC. Source: SERVIR Mekong HYDRAFloods",
-    "legend": [      
+    "legend": [
       { "value": "1 - flooded", "color": "#a50f15" }
     ]
-  },    
+  },
   "forecast": {
     "title": "10-day precipitation forecast",
     "type": "wms",

--- a/src/config/cambodia/layers.json
+++ b/src/config/cambodia/layers.json
@@ -524,5 +524,37 @@
       {"value": "100 - 500", "color": "#feb24c"},
       {"value": "500 or more", "color": "#f03b20"}
     ]
-  }  
+  },
+  "river_level": {
+    "title": "River level status",
+    "type": "point_data",
+    "data": "http://localhost/ews/data",
+    "date_url": "http://localhost/ews/data?onlyDates=true",
+    "feature_info_props": {
+      "external_id": {
+        "type": "string",
+        "label": "External ID"
+      },
+      "name": {
+        "type": "string",
+        "label": "Name"
+      },
+      "water_height": {
+        "type": "string",
+        "label": "Water height"
+      },
+      "level_median": {
+        "type": "number",
+        "label": "Water level"
+      }
+    },
+    "opacity": 1,
+    "measure": "level_status",
+    "legend_text": "This layer shows river water level in millimeters (mm). It is reported from People in Need (PIN) automated river water gauge.",
+    "legend": [
+      {"label": "0 - Normal", "value": 0, "color": "#31a354"},
+      {"label": "1 - Warning", "value": 1, "color": "#fdae6b"},
+      {"label": "2 - Severe Warning", "value": 2, "color": "#e34a33"}
+    ]
+  }
 }

--- a/src/config/cambodia/layers.json
+++ b/src/config/cambodia/layers.json
@@ -543,9 +543,9 @@
         "type": "string",
         "label": "Water height"
       },
-      "level_median": {
+      "level_mean": {
         "type": "number",
-        "label": "Water level"
+        "label": "Mean water level"
       }
     },
     "opacity": 1,

--- a/src/config/cambodia/prism.json
+++ b/src/config/cambodia/prism.json
@@ -24,6 +24,7 @@
     "categories": {
       "hazards": {
         "floods": [
+          "river_level",
           "hydra_s1",
           "hydra_s2",
           "hydra_l8"
@@ -44,7 +45,7 @@
           "poverty": ["idpoor"]
       },
       "exposure": {
-        "field_reports": ["river_level", "disaster_report"]
-    }
+        "field_reports": ["disaster_report"]
+       }
   }
 }

--- a/src/config/cambodia/prism.json
+++ b/src/config/cambodia/prism.json
@@ -44,7 +44,7 @@
           "poverty": ["idpoor"]
       },
       "exposure": {
-        "field_reports": ["disaster_report"]
+        "field_reports": ["river_level", "disaster_report"]
     }
   }
 }

--- a/src/context/chartDataStateSlice.ts
+++ b/src/context/chartDataStateSlice.ts
@@ -1,5 +1,4 @@
 import moment from 'moment';
-import { get } from 'lodash';
 import { createSlice, PayloadAction, createAsyncThunk } from '@reduxjs/toolkit';
 import * as Papa from 'papaparse';
 import type { CreateAsyncThunkTypes, RootState } from './store';
@@ -53,10 +52,12 @@ export const datasetResultStateSlice = createSlice({
         Object.fromEntries(
           Object.keys(rows[0]).map(k => [
             k,
-            moment(rows[0][k]).local().format('HH:MM:ss'),
+            k === 'level'
+              ? rows[0][k]
+              : moment(rows[0][k]).local().format('HH:MM:ss'),
           ]),
         ),
-        rows[1],
+        ...rows.slice(1, rows.length),
       ];
 
       return { ...rest, data: { rows: formattedRows, columns } };

--- a/src/context/chartDataStateSlice.ts
+++ b/src/context/chartDataStateSlice.ts
@@ -6,6 +6,7 @@ import { TableData } from './tableStateSlice';
 
 type DatasetState = {
   data?: TableData;
+  title?: string;
 };
 
 const initialState: DatasetState = {};
@@ -62,6 +63,9 @@ export const datasetResultStateSlice = createSlice({
 
       return { ...rest, data: { rows: formattedRows, columns } };
     },
+    addPointTitle: ({ ...rest }, { payload }: PayloadAction<string>) => {
+      return { ...rest, title: payload };
+    },
   },
   extraReducers: builder => {
     builder.addCase(
@@ -76,8 +80,10 @@ export const datasetResultStateSlice = createSlice({
 
 export const DatasetSelector = (state: RootState): TableData | undefined =>
   state.datasetState.data;
+export const PointTitleSelector = (state: RootState): string | undefined =>
+  state.datasetState.title;
 
 // Setters
-export const { addEwsDataset } = datasetResultStateSlice.actions;
+export const { addEwsDataset, addPointTitle } = datasetResultStateSlice.actions;
 
 export default datasetResultStateSlice.reducer;

--- a/src/context/chartDataStateSlice.ts
+++ b/src/context/chartDataStateSlice.ts
@@ -1,0 +1,67 @@
+import { createSlice, PayloadAction, createAsyncThunk } from '@reduxjs/toolkit';
+import * as Papa from 'papaparse';
+import type { CreateAsyncThunkTypes, RootState } from './store';
+import { TableData } from './tableStateSlice';
+
+type DatasetState = {
+  data?: TableData;
+};
+
+const initialState: DatasetState = {};
+
+export type DatasetParams = {
+  id: string;
+  filepath: string;
+};
+
+export const loadDataset = createAsyncThunk<
+  TableData,
+  DatasetParams,
+  CreateAsyncThunkTypes
+>('datasetState/loadDataset', async (params: DatasetParams) => {
+  const url = process.env.PUBLIC_URL + params.filepath;
+
+  return new Promise<TableData>((resolve, reject) =>
+    Papa.parse(url, {
+      header: true,
+      download: true,
+      complete: results => {
+        const row = results.data.find(item => item.Admin2_Code === params.id);
+
+        return resolve({
+          rows: [...results.data.slice(0, 1), row],
+          columns: Object.keys(row),
+        });
+      },
+      error: error => reject(error),
+    }),
+  );
+});
+
+export const datasetResultStateSlice = createSlice({
+  name: 'DatasetResultSlice',
+  initialState,
+  reducers: {
+    addEwsDataset: (
+      { ...rest },
+      { payload }: PayloadAction<TableData>,
+    ): DatasetState => ({ ...rest, data: payload }),
+  },
+  extraReducers: builder => {
+    builder.addCase(
+      loadDataset.fulfilled,
+      ({ ...rest }, { payload }: PayloadAction<TableData>): DatasetState => ({
+        ...rest,
+        data: payload,
+      }),
+    );
+  },
+});
+
+export const DatasetSelector = (state: RootState): TableData | undefined =>
+  state.datasetState.data;
+
+// Setters
+export const { addEwsDataset } = datasetResultStateSlice.actions;
+
+export default datasetResultStateSlice.reducer;

--- a/src/context/chartDataStateSlice.ts
+++ b/src/context/chartDataStateSlice.ts
@@ -55,7 +55,7 @@ export const datasetResultStateSlice = createSlice({
             k,
             k === 'level'
               ? rows[0][k]
-              : moment(rows[0][k]).local().format('HH:MM:ss'),
+              : moment(rows[0][k]).local().format('DD/mm/YYYY HH:MM'),
           ]),
         ),
         ...rows.slice(1, rows.length),

--- a/src/context/chartDataStateSlice.ts
+++ b/src/context/chartDataStateSlice.ts
@@ -1,3 +1,5 @@
+import moment from 'moment';
+import { get } from 'lodash';
 import { createSlice, PayloadAction, createAsyncThunk } from '@reduxjs/toolkit';
 import * as Papa from 'papaparse';
 import type { CreateAsyncThunkTypes, RootState } from './store';
@@ -45,7 +47,20 @@ export const datasetResultStateSlice = createSlice({
     addEwsDataset: (
       { ...rest },
       { payload }: PayloadAction<TableData>,
-    ): DatasetState => ({ ...rest, data: payload }),
+    ): DatasetState => {
+      const { rows, columns } = payload;
+      const formattedRows = [
+        Object.fromEntries(
+          Object.keys(rows[0]).map(k => [
+            k,
+            moment(rows[0][k]).local().format('HH:MM:ss'),
+          ]),
+        ),
+        rows[1],
+      ];
+
+      return { ...rest, data: { rows: formattedRows, columns } };
+    },
   },
   extraReducers: builder => {
     builder.addCase(

--- a/src/context/layers/boundary.ts
+++ b/src/context/layers/boundary.ts
@@ -1,10 +1,6 @@
-import { createSlice, PayloadAction, createAsyncThunk } from '@reduxjs/toolkit';
-import * as Papa from 'papaparse';
 import { FeatureCollection } from 'geojson';
 import type { LayerDataParams, LazyLoader } from './layer-data';
 import { BoundaryLayerProps } from '../../config/types';
-import type { CreateAsyncThunkTypes, RootState } from '../store';
-import { TableData } from '../tableStateSlice';
 
 export interface BoundaryLayerData extends FeatureCollection {}
 
@@ -16,58 +12,3 @@ export const fetchBoundaryLayerData: LazyLoader<BoundaryLayerProps> = () => asyn
 
   return (await fetch(path)).json();
 };
-
-type DatasetState = {
-  data?: TableData;
-};
-
-const initialState: DatasetState = {};
-
-export type DatasetParams = {
-  id: string;
-  filepath: string;
-};
-
-export const loadDataset = createAsyncThunk<
-  TableData,
-  DatasetParams,
-  CreateAsyncThunkTypes
->('datasetState/loadDataset', async (params: DatasetParams) => {
-  const url = process.env.PUBLIC_URL + params.filepath;
-
-  return new Promise<TableData>((resolve, reject) =>
-    Papa.parse(url, {
-      header: true,
-      download: true,
-      complete: results => {
-        const row = results.data.find(item => item.Admin2_Code === params.id);
-
-        return resolve({
-          rows: [...results.data.slice(0, 1), row],
-          columns: Object.keys(row),
-        });
-      },
-      error: error => reject(error),
-    }),
-  );
-});
-
-export const datasetResultStateSlice = createSlice({
-  name: 'DatasetResultSlice',
-  initialState,
-  reducers: {},
-  extraReducers: builder => {
-    builder.addCase(
-      loadDataset.fulfilled,
-      ({ ...rest }, { payload }: PayloadAction<TableData>): DatasetState => ({
-        ...rest,
-        data: payload,
-      }),
-    );
-  },
-});
-
-export const DatasetSelector = (state: RootState): TableData | undefined =>
-  state.datasetState.data;
-
-export default datasetResultStateSlice.reducer;

--- a/src/context/layers/point_data.ts
+++ b/src/context/layers/point_data.ts
@@ -1,8 +1,11 @@
+import { createSlice, PayloadAction, createAsyncThunk } from '@reduxjs/toolkit';
 import { camelCase } from 'lodash';
 import GeoJSON from 'geojson';
 import moment from 'moment';
 import type { LazyLoader } from './layer-data';
 import { PointDataLayerProps } from '../../config/types';
+import type { CreateAsyncThunkTypes, RootState } from '../store';
+import { TableData } from '../tableStateSlice';
 
 declare module 'geojson' {
   export const version: string;
@@ -82,3 +85,67 @@ export const fetchPointLayerData: LazyLoader<PointDataLayerProps> = () => async 
   }
   return GeoJSON.parse(data, { Point: ['lat', 'lon'] });
 };
+
+interface PointDatasetState {
+  data?: TableData;
+}
+
+const initialState: PointDatasetState = {};
+
+export type PointDatasetParams = {
+  url: string;
+};
+
+export const loadEWS1294Dataset = createAsyncThunk<
+  TableData,
+  PointDatasetParams,
+  CreateAsyncThunkTypes
+>('datasetState/loadDataset', async (params: PointDatasetParams) => {
+  (await fetch(params.url)).json();
+  return {
+    rows: [
+      {
+        external_id: 'External ID',
+        d1: '29/01/22',
+        d2: '30/01/22',
+        d4: '31/01/22',
+        d5: '01/02/22',
+        d6: '02/02/22',
+        d7: '03/02/22',
+      },
+      {
+        external_id: 'TEPv4.0-001',
+        d1: '3920',
+        d2: '1821',
+        d4: '2290',
+        d5: '873',
+        d6: '298',
+        d7: '2222',
+      },
+    ],
+    columns: ['external_id', 'd1', 'd2', 'd3', 'd4', 'd5', 'd6', 'd7'],
+  };
+});
+
+export const pointDatasetResultStateSlice = createSlice({
+  name: 'PointDatasetResultSlice',
+  initialState,
+  reducers: {},
+  extraReducers: builder => {
+    builder.addCase(
+      loadEWS1294Dataset.fulfilled,
+      (
+        { ...rest },
+        { payload }: PayloadAction<TableData>,
+      ): PointDatasetState => ({
+        ...rest,
+        data: payload,
+      }),
+    );
+  },
+});
+
+export const PointDatasetSelector = (state: RootState): TableData | undefined =>
+  state.pointDatasetState.data;
+
+export default pointDatasetResultStateSlice.reducer;

--- a/src/context/layers/point_data.ts
+++ b/src/context/layers/point_data.ts
@@ -101,7 +101,8 @@ export const loadEWS1294Dataset = createAsyncThunk<
   PointDatasetParams,
   CreateAsyncThunkTypes
 >('datasetState/loadDataset', async (params: PointDatasetParams) => {
-  (await fetch(params.url)).json();
+  const data = await (await fetch(params.url)).json();
+  console.log('--> --> ', data);
   return {
     rows: [
       {

--- a/src/context/layers/point_data.ts
+++ b/src/context/layers/point_data.ts
@@ -101,31 +101,7 @@ export const loadEWS1294Dataset = createAsyncThunk<
   PointDatasetParams,
   CreateAsyncThunkTypes
 >('datasetState/loadDataset', async (params: PointDatasetParams) => {
-  const data = await (await fetch(params.url)).json();
-  console.log('--> --> ', data);
-  return {
-    rows: [
-      {
-        external_id: 'External ID',
-        d1: '29/01/22',
-        d2: '30/01/22',
-        d4: '31/01/22',
-        d5: '01/02/22',
-        d6: '02/02/22',
-        d7: '03/02/22',
-      },
-      {
-        external_id: 'TEPv4.0-001',
-        d1: '3920',
-        d2: '1821',
-        d4: '2290',
-        d5: '873',
-        d6: '298',
-        d7: '2222',
-      },
-    ],
-    columns: ['external_id', 'd1', 'd2', 'd3', 'd4', 'd5', 'd6', 'd7'],
-  };
+  return JSON.parse(params.url);
 });
 
 export const pointDatasetResultStateSlice = createSlice({

--- a/src/context/layers/point_data.ts
+++ b/src/context/layers/point_data.ts
@@ -1,11 +1,8 @@
-import { createSlice, PayloadAction, createAsyncThunk } from '@reduxjs/toolkit';
 import { camelCase } from 'lodash';
 import GeoJSON from 'geojson';
 import moment from 'moment';
 import type { LazyLoader } from './layer-data';
 import { PointDataLayerProps } from '../../config/types';
-import type { CreateAsyncThunkTypes, RootState } from '../store';
-import { TableData } from '../tableStateSlice';
 
 declare module 'geojson' {
   export const version: string;
@@ -85,44 +82,3 @@ export const fetchPointLayerData: LazyLoader<PointDataLayerProps> = () => async 
   }
   return GeoJSON.parse(data, { Point: ['lat', 'lon'] });
 };
-
-interface PointDatasetState {
-  data?: TableData;
-}
-
-const initialState: PointDatasetState = {};
-
-export type PointDatasetParams = {
-  url: string;
-};
-
-export const loadEWS1294Dataset = createAsyncThunk<
-  TableData,
-  PointDatasetParams,
-  CreateAsyncThunkTypes
->('datasetState/loadDataset', async (params: PointDatasetParams) => {
-  return JSON.parse(params.url);
-});
-
-export const pointDatasetResultStateSlice = createSlice({
-  name: 'PointDatasetResultSlice',
-  initialState,
-  reducers: {},
-  extraReducers: builder => {
-    builder.addCase(
-      loadEWS1294Dataset.fulfilled,
-      (
-        { ...rest },
-        { payload }: PayloadAction<TableData>,
-      ): PointDatasetState => ({
-        ...rest,
-        data: payload,
-      }),
-    );
-  },
-});
-
-export const PointDatasetSelector = (state: RootState): TableData | undefined =>
-  state.pointDatasetState.data;
-
-export default pointDatasetResultStateSlice.reducer;

--- a/src/context/legendsStateSlice.ts
+++ b/src/context/legendsStateSlice.ts
@@ -1,0 +1,33 @@
+import { createSlice } from '@reduxjs/toolkit';
+import type { RootState } from './store';
+
+export interface LegendsState {
+  visible: boolean;
+}
+
+const initialState: LegendsState = {
+  visible: true,
+};
+
+export const legendsStateSlice = createSlice({
+  name: 'legendsState',
+  initialState,
+  reducers: {
+    toggleVisible: state => ({
+      ...state,
+      visible: !state.visible,
+    }),
+  },
+});
+
+// Getters
+export const legendsSelector = (state: RootState): LegendsState =>
+  state.legendsState;
+export const legendsVisibleSelector = (
+  state: RootState,
+): LegendsState['visible'] => state.legendsState.visible;
+
+// Setters
+export const { toggleVisible } = legendsStateSlice.actions;
+
+export default legendsStateSlice.reducer;

--- a/src/context/store.ts
+++ b/src/context/store.ts
@@ -13,6 +13,7 @@ import notificationStateReduce, {
 import analysisResultStateReduce from './analysisResultStateSlice';
 import mapSelectionLayerStateReduce from './mapSelectionLayerStateSlice';
 import datasetResultStateReduce from './chartDataStateSlice';
+import legendsStateReduce from './legendsStateSlice';
 
 const reducer = combineReducers({
   mapState: mapStateReduce,
@@ -23,6 +24,7 @@ const reducer = combineReducers({
   notificationState: notificationStateReduce,
   mapSelectionLayerStateSlice: mapSelectionLayerStateReduce,
   datasetState: datasetResultStateReduce,
+  legendsState: legendsStateReduce,
 });
 
 export const store = configureStore({

--- a/src/context/store.ts
+++ b/src/context/store.ts
@@ -12,8 +12,7 @@ import notificationStateReduce, {
 } from './notificationStateSlice';
 import analysisResultStateReduce from './analysisResultStateSlice';
 import mapSelectionLayerStateReduce from './mapSelectionLayerStateSlice';
-import datasetResultStateReduce from './layers/boundary';
-import pointDatasetResultStateReduce from './layers/point_data';
+import datasetResultStateReduce from './chartDataStateSlice';
 
 const reducer = combineReducers({
   mapState: mapStateReduce,
@@ -24,7 +23,6 @@ const reducer = combineReducers({
   notificationState: notificationStateReduce,
   mapSelectionLayerStateSlice: mapSelectionLayerStateReduce,
   datasetState: datasetResultStateReduce,
-  pointDatasetState: pointDatasetResultStateReduce,
 });
 
 export const store = configureStore({

--- a/src/context/store.ts
+++ b/src/context/store.ts
@@ -13,6 +13,7 @@ import notificationStateReduce, {
 import analysisResultStateReduce from './analysisResultStateSlice';
 import mapSelectionLayerStateReduce from './mapSelectionLayerStateSlice';
 import datasetResultStateReduce from './layers/boundary';
+import pointDatasetResultStateReduce from './layers/point_data';
 
 const reducer = combineReducers({
   mapState: mapStateReduce,
@@ -23,6 +24,7 @@ const reducer = combineReducers({
   notificationState: notificationStateReduce,
   mapSelectionLayerStateSlice: mapSelectionLayerStateReduce,
   datasetState: datasetResultStateReduce,
+  pointDatasetState: pointDatasetResultStateReduce,
 });
 
 export const store = configureStore({

--- a/src/utils/map_utils.ts
+++ b/src/utils/map_utils.ts
@@ -1,0 +1,14 @@
+import { Map as MapBoxMap } from 'mapbox-gl';
+
+export function onlyBoundaryLayerOnPoint(
+  map: MapBoxMap,
+  point: [number, number],
+) {
+  const features = map.queryRenderedFeatures(point);
+  // `layer-` is a prefix for all `layer` sources and consequently `id`
+  // TODO: will have to use a constant instead e.g. NON_BOUNDARY_LAYER_PREFIX
+  const nonBoundaryLayerFeatures = features.filter(f =>
+    f.source.includes('layer-'),
+  );
+  return nonBoundaryLayerFeatures.length === 0;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3695,9 +3695,9 @@ chardet@^0.7.0:
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
 chart.js@^2.9.3:
-  version "2.9.3"
-  resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-2.9.3.tgz#ae3884114dafd381bc600f5b35a189138aac1ef7"
-  integrity sha512-+2jlOobSk52c1VU6fzkh3UwqHMdSlgH1xFv9FKMqHiNCpXsGPQa/+81AFa+i3jZ253Mq9aAycPwDjnn1XbRNNw==
+  version "2.9.4"
+  resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-2.9.4.tgz#0827f9563faffb2dc5c06562f8eb10337d5b9684"
+  integrity sha512-B07aAzxcrikjAPyV+01j7BmOpxtQETxTSlQ26BEYJ+3iUkbNKaOJ/nDbT6JjyqYxseM0ON12COHYdU2cTIjC7A==
   dependencies:
     chartjs-color "^2.1.0"
     moment "^2.10.2"


### PR DESCRIPTION
Closes: #351
Deploy: ~https://cambodia-ews-data.surge.sh~

TODO:
- [x] Create `ews/data` endpoint in `api-flask` to process `locations` and `datapoint` APIs into PRISM ready data
- [x] Display `propinfo` on hover of `point_data`
- [x] Disable previous click event on `point_data` to only allow the dedicated click event for datapoints
- [x] Show  today's levels in a chart onclick

How-to Configure:
- [x] Run `api-flask` locally to expose `localhost/ews/data` endpoint
- [x] Configure `river level` details into `layer.json` and `prism.json` - Already done

Features:
Handle the logic of processing sensor locations and get censors data points
Cache the endpoint to avoid `internal server errors` specified [here](https://github.com/WFP-VAM/prism-frontend/issues/351#issuecomment-1024383188)

<img width="1840" alt="Screenshot 2022-02-14 at 12 40 02" src="https://user-images.githubusercontent.com/1290048/153857807-5aaaace8-7896-4d59-8643-2e745b5ea8f3.png">

