### PR TITLE
Add a sort option in 'run analysis' results

### DIFF
--- a/src/components/MapView/Analyser/AnalysisTable/index.tsx
+++ b/src/components/MapView/Analyser/AnalysisTable/index.tsx
@@ -38,7 +38,7 @@ function AnalysisTable({ classes, tableData, columns }: AnalysisTableProps) {
     setPage(0);
   };
 
-  const handleChangeOrderBy = (newSortColumn: string) => {
+  const handleChangeOrderBy = (newSortColumn: Column['id']) => {
     const isAsc = sortColumn === newSortColumn && sortDirection === 'asc';
     setSortColumn(newSortColumn);
     setSortDirection(isAsc ? 'desc' : 'asc');
@@ -52,7 +52,10 @@ function AnalysisTable({ classes, tableData, columns }: AnalysisTableProps) {
               {columns.map(column => (
                 <TableCell key={column.id} className={classes.tableHead}>
                   <TableSortLabel
-                    classes={{ root: classes.sortLabel }}
+                    classes={{
+                      root: classes.tabelSortLabelRoot,
+                      icon: classes.tabelSortLabelIcon,
+                    }}
                     active={sortColumn === column.id}
                     direction={sortColumn === column.id ? sortDirection : 'asc'}
                     onClick={() => handleChangeOrderBy(column.id)}
@@ -128,10 +131,18 @@ const styles = (theme: Theme) =>
     innerAnalysisButton: {
       backgroundColor: '#3d474a',
     },
-    sortLabel: {
+    tabelSortLabelIcon: {
+      color: theme.palette.text.primary,
+      opacity: 1,
+      '&:hover': {
+        opacity: 0.5,
+      },
+    },
+    tabelSortLabelRoot: {
       color: theme.palette.text.primary,
       '&:hover': {
-        color: theme.palette.grey[100],
+        color: theme.palette.text.primary,
+        opacity: 0.5,
       },
     },
   });

--- a/src/components/MapView/Analyser/AnalysisTable/index.tsx
+++ b/src/components/MapView/Analyser/AnalysisTable/index.tsx
@@ -9,7 +9,6 @@ import {
   TablePagination,
   TableRow,
   TableSortLabel,
-  Theme,
   withStyles,
   WithStyles,
 } from '@material-ui/core';
@@ -52,10 +51,6 @@ function AnalysisTable({ classes, tableData, columns }: AnalysisTableProps) {
               {columns.map(column => (
                 <TableCell key={column.id} className={classes.tableHead}>
                   <TableSortLabel
-                    classes={{
-                      root: classes.tabelSortLabelRoot,
-                      icon: classes.tabelSortLabelIcon,
-                    }}
                     active={sortColumn === column.id}
                     direction={sortColumn === column.id ? sortDirection : 'asc'}
                     onClick={() => handleChangeOrderBy(column.id)}
@@ -118,7 +113,7 @@ function AnalysisTable({ classes, tableData, columns }: AnalysisTableProps) {
   );
 }
 
-const styles = (theme: Theme) =>
+const styles = () =>
   createStyles({
     tableContainer: {
       border: '2px solid',
@@ -130,20 +125,6 @@ const styles = (theme: Theme) =>
     },
     innerAnalysisButton: {
       backgroundColor: '#3d474a',
-    },
-    tabelSortLabelIcon: {
-      color: theme.palette.text.primary,
-      opacity: 1,
-      '&:hover': {
-        opacity: 0.5,
-      },
-    },
-    tabelSortLabelRoot: {
-      color: theme.palette.text.primary,
-      '&:hover': {
-        color: theme.palette.text.primary,
-        opacity: 0.5,
-      },
     },
   });
 

--- a/src/components/MapView/Analyser/AnalysisTable/index.tsx
+++ b/src/components/MapView/Analyser/AnalysisTable/index.tsx
@@ -9,6 +9,7 @@ import {
   TablePagination,
   TableRow,
   TableSortLabel,
+  Theme,
   withStyles,
   WithStyles,
 } from '@material-ui/core';
@@ -51,6 +52,7 @@ function AnalysisTable({ classes, tableData, columns }: AnalysisTableProps) {
               {columns.map(column => (
                 <TableCell key={column.id} className={classes.tableHead}>
                   <TableSortLabel
+                    classes={{ root: classes.sortLabel }}
                     active={sortColumn === column.id}
                     direction={sortColumn === column.id ? sortDirection : 'asc'}
                     onClick={() => handleChangeOrderBy(column.id)}
@@ -113,7 +115,7 @@ function AnalysisTable({ classes, tableData, columns }: AnalysisTableProps) {
   );
 }
 
-const styles = () =>
+const styles = (theme: Theme) =>
   createStyles({
     tableContainer: {
       border: '2px solid',
@@ -125,6 +127,12 @@ const styles = () =>
     },
     innerAnalysisButton: {
       backgroundColor: '#3d474a',
+    },
+    sortLabel: {
+      color: theme.palette.text.primary,
+      '&:hover': {
+        color: theme.palette.grey[100],
+      },
     },
   });
 

--- a/src/components/MapView/Analyser/AnalysisTable/index.tsx
+++ b/src/components/MapView/Analyser/AnalysisTable/index.tsx
@@ -22,7 +22,7 @@ import { Column } from '../../../../utils/analysis-utils';
 function AnalysisTable({ classes, tableData, columns }: AnalysisTableProps) {
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(10);
-  const [sortColumn, setSortColumn] = useState('');
+  const [sortColumn, setSortColumn] = useState<Column['id']>();
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
 
   const dispatch = useDispatch();

--- a/src/components/MapView/Analyser/AnalysisTable/index.tsx
+++ b/src/components/MapView/Analyser/AnalysisTable/index.tsx
@@ -22,7 +22,7 @@ function AnalysisTable({ classes, tableData, columns }: AnalysisTableProps) {
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(10);
   const [sortColumn, setSortColumn] = useState<Column['id']>();
-  const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
+  const [isAscending, setIsAscending] = useState(true);
 
   const dispatch = useDispatch();
 
@@ -38,9 +38,9 @@ function AnalysisTable({ classes, tableData, columns }: AnalysisTableProps) {
   };
 
   const handleChangeOrderBy = (newSortColumn: Column['id']) => {
-    const isAsc = sortColumn === newSortColumn && sortDirection === 'asc';
+    const newIsAsc = !(sortColumn === newSortColumn && isAscending);
     setSortColumn(newSortColumn);
-    setSortDirection(isAsc ? 'desc' : 'asc');
+    setIsAscending(newIsAsc);
   };
   return (
     <div>
@@ -52,7 +52,9 @@ function AnalysisTable({ classes, tableData, columns }: AnalysisTableProps) {
                 <TableCell key={column.id} className={classes.tableHead}>
                   <TableSortLabel
                     active={sortColumn === column.id}
-                    direction={sortColumn === column.id ? sortDirection : 'asc'}
+                    direction={
+                      sortColumn === column.id && !isAscending ? 'desc' : 'asc'
+                    }
                     onClick={() => handleChangeOrderBy(column.id)}
                   >
                     {column.label}
@@ -62,7 +64,7 @@ function AnalysisTable({ classes, tableData, columns }: AnalysisTableProps) {
             </TableRow>
           </TableHead>
           <TableBody>
-            {orderBy(tableData, sortColumn, sortDirection)
+            {orderBy(tableData, sortColumn, isAscending ? 'asc' : 'desc')
               .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
               .map(row => {
                 return (

--- a/src/components/MapView/Analyser/AnalysisTable/index.tsx
+++ b/src/components/MapView/Analyser/AnalysisTable/index.tsx
@@ -8,9 +8,11 @@ import {
   TableHead,
   TablePagination,
   TableRow,
+  TableSortLabel,
   withStyles,
   WithStyles,
 } from '@material-ui/core';
+import { orderBy } from 'lodash';
 import { useDispatch } from 'react-redux';
 import { TableRow as AnalysisTableRow } from '../../../../context/analysisResultStateSlice';
 import { showPopup } from '../../../../context/tooltipStateSlice';
@@ -19,6 +21,8 @@ import { Column } from '../../../../utils/analysis-utils';
 function AnalysisTable({ classes, tableData, columns }: AnalysisTableProps) {
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(10);
+  const [sortColumn, setSortColumn] = useState('');
+  const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
 
   const dispatch = useDispatch();
 
@@ -33,6 +37,11 @@ function AnalysisTable({ classes, tableData, columns }: AnalysisTableProps) {
     setPage(0);
   };
 
+  const handleChangeOrderBy = (newSortColumn: string) => {
+    const isAsc = sortColumn === newSortColumn && sortDirection === 'asc';
+    setSortColumn(newSortColumn);
+    setSortDirection(isAsc ? 'desc' : 'asc');
+  };
   return (
     <div>
       <TableContainer className={classes.tableContainer}>
@@ -41,13 +50,19 @@ function AnalysisTable({ classes, tableData, columns }: AnalysisTableProps) {
             <TableRow>
               {columns.map(column => (
                 <TableCell key={column.id} className={classes.tableHead}>
-                  {column.label}
+                  <TableSortLabel
+                    active={sortColumn === column.id}
+                    direction={sortColumn === column.id ? sortDirection : 'asc'}
+                    onClick={() => handleChangeOrderBy(column.id)}
+                  >
+                    {column.label}
+                  </TableSortLabel>
                 </TableCell>
               ))}
             </TableRow>
           </TableHead>
           <TableBody>
-            {tableData
+            {orderBy(tableData, sortColumn, sortDirection)
               .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
               .map(row => {
                 return (

--- a/src/muiTheme.tsx
+++ b/src/muiTheme.tsx
@@ -110,6 +110,28 @@ const theme: any = createMuiTheme({
         color: 'white',
       },
     },
+    MuiTableSortLabel: {
+      root: {
+        color: white,
+        '&:hover': {
+          color: white,
+          opacity: 0.5,
+        },
+        '&$active': {
+          '&& $icon': {
+            opacity: 1,
+            color: white,
+          },
+        },
+      },
+      icon: {
+        color: white,
+        opacity: 0.2,
+        '&:hover': {
+          opacity: 0.5,
+        },
+      },
+    },
   },
 });
 


### PR DESCRIPTION
Closes #357 
Deploy: http://prism-357.surge.sh/
Currently the analysis table returns the results from the API, not sure how they are sorted.
Added the option to sort results asc/desc by each column header. 
![image](https://user-images.githubusercontent.com/30374401/156082953-e31316ea-5386-4c76-8005-644edf3a6e22.png)
