### PR TITLE
Add admin parent name to analysis table

### DIFF
--- a/src/components/MapView/Layers/BoundaryLayer/index.tsx
+++ b/src/components/MapView/Layers/BoundaryLayer/index.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { get } from 'lodash';
 import { GeoJSONLayer } from 'react-mapbox-gl';
 import * as MapboxGL from 'mapbox-gl';
 import { showPopup } from '../../../../context/tooltipStateSlice';

--- a/src/components/MapView/Layers/BoundaryLayer/index.tsx
+++ b/src/components/MapView/Layers/BoundaryLayer/index.tsx
@@ -8,7 +8,7 @@ import { LayerData } from '../../../../context/layers/layer-data';
 import { layerDataSelector } from '../../../../context/mapStateSlice/selectors';
 import { toggleSelectedBoundary } from '../../../../context/mapSelectionLayerStateSlice';
 import { isPrimaryBoundaryLayer } from '../../../../config/utils';
-import { getLocationName } from '../../../../utils/name-utils';
+import { getFullLocationName } from '../../../../utils/name-utils';
 
 function onToggleHover(cursor: string, targetMap: MapboxGL.Map) {
   // eslint-disable-next-line no-param-reassign, fp/no-mutation
@@ -30,7 +30,7 @@ function BoundaryLayer({ layer }: { layer: BoundaryLayerProps }) {
 
   const onClickFunc = (evt: any) => {
     const coordinates = evt.lngLat;
-    const locationName = getLocationName(layer, evt.features[0]);
+    const locationName = getFullLocationName(layer, evt.features[0]);
     dispatch(showPopup({ coordinates, locationName }));
     // send the selection to the map selection layer. No-op if selection mode isn't on.
     dispatch(

--- a/src/components/MapView/Layers/BoundaryLayer/index.tsx
+++ b/src/components/MapView/Layers/BoundaryLayer/index.tsx
@@ -9,6 +9,7 @@ import { LayerData } from '../../../../context/layers/layer-data';
 import { layerDataSelector } from '../../../../context/mapStateSlice/selectors';
 import { toggleSelectedBoundary } from '../../../../context/mapSelectionLayerStateSlice';
 import { isPrimaryBoundaryLayer } from '../../../../config/utils';
+import { getLocationName } from '../../../../utils/name-utils';
 
 function onToggleHover(cursor: string, targetMap: MapboxGL.Map) {
   // eslint-disable-next-line no-param-reassign, fp/no-mutation
@@ -30,9 +31,7 @@ function BoundaryLayer({ layer }: { layer: BoundaryLayerProps }) {
 
   const onClickFunc = (evt: any) => {
     const coordinates = evt.lngLat;
-    const locationName = layer.adminLevelNames
-      .map(level => get(evt.features[0], ['properties', level], '') as string)
-      .join(', ');
+    const locationName = getLocationName(layer, evt.features[0]);
     dispatch(showPopup({ coordinates, locationName }));
     // send the selection to the map selection layer. No-op if selection mode isn't on.
     dispatch(

--- a/src/context/analysisResultStateSlice.ts
+++ b/src/context/analysisResultStateSlice.ts
@@ -126,7 +126,9 @@ function generateTableFromApiData(
     );
 
     const name: string =
-      featureBoundary?.properties?.[adminLevelName] || 'No Name';
+      adminLayer.adminLevelNames
+        .map(level => get(featureBoundary, ['properties', level], '') as string)
+        .join(', ') || 'No Name';
     const localName: string =
       featureBoundary?.properties?.[adminLevelLocalName] || 'No Name';
 

--- a/src/context/analysisResultStateSlice.ts
+++ b/src/context/analysisResultStateSlice.ts
@@ -30,6 +30,7 @@ import {
   ExposedPopulationResult,
   scaleFeatureStat,
 } from '../utils/analysis-utils';
+import { getFullLocationName } from '../utils/name-utils';
 import { getWCSLayerUrl } from './layers/wms';
 import { getBoundaryLayerSingleton, LayerDefinitions } from '../config/utils';
 import { Extent } from '../components/MapView/Layers/raster-utils';
@@ -38,7 +39,6 @@ import { LayerData, LayerDataParams, loadLayerData } from './layers/layer-data';
 import { DataRecord, AdminLevelDataLayerData } from './layers/admin_level_data';
 import { BoundaryLayerData } from './layers/boundary';
 import { isLocalhost } from '../serviceWorker';
-import { getLocationName } from '../utils/name-utils';
 
 const ANALYSIS_API_URL = 'https://prism-api.ovio.org/stats'; // TODO both needs to be stored somewhere
 
@@ -126,7 +126,7 @@ function generateTableFromApiData(
       feature => feature.properties?.[adminLevelName] === row[adminLevelName],
     );
 
-    const name: string = getLocationName(adminLayer, featureBoundary);
+    const name = getFullLocationName(adminLayer, featureBoundary);
     const localName: string =
       featureBoundary?.properties?.[adminLevelLocalName] || 'No Name';
 

--- a/src/context/analysisResultStateSlice.ts
+++ b/src/context/analysisResultStateSlice.ts
@@ -38,6 +38,7 @@ import { LayerData, LayerDataParams, loadLayerData } from './layers/layer-data';
 import { DataRecord, AdminLevelDataLayerData } from './layers/admin_level_data';
 import { BoundaryLayerData } from './layers/boundary';
 import { isLocalhost } from '../serviceWorker';
+import { getLocationName } from '../utils/name-utils';
 
 const ANALYSIS_API_URL = 'https://prism-api.ovio.org/stats'; // TODO both needs to be stored somewhere
 
@@ -125,10 +126,7 @@ function generateTableFromApiData(
       feature => feature.properties?.[adminLevelName] === row[adminLevelName],
     );
 
-    const name: string =
-      adminLayer.adminLevelNames
-        .map(level => get(featureBoundary, ['properties', level], '') as string)
-        .join(', ') || 'No Name';
+    const name: string = getLocationName(adminLayer, featureBoundary);
     const localName: string =
       featureBoundary?.properties?.[adminLevelLocalName] || 'No Name';
 

--- a/src/utils/name-utils.ts
+++ b/src/utils/name-utils.ts
@@ -11,9 +11,7 @@ import { BoundaryLayerProps } from '../config/types';
 
 export function getFullLocationName(
   layer: BoundaryLayerProps,
-  featureBoundary:
-    | Feature<GeoJSON.Geometry, GeoJSON.GeoJsonProperties>
-    | undefined,
+  featureBoundary?: Feature<GeoJSON.Geometry, GeoJSON.GeoJsonProperties>,
 ): string {
   return (
     layer.adminLevelNames

--- a/src/utils/name-utils.ts
+++ b/src/utils/name-utils.ts
@@ -1,0 +1,13 @@
+import { get } from 'lodash';
+import { BoundaryLayerProps } from '../config/types';
+
+export function getLocationName(
+  layer: BoundaryLayerProps,
+  featureBoundary: any,
+): string {
+  return (
+    layer.adminLevelNames
+      .map(level => get(featureBoundary, ['properties', level], '') as string)
+      .join(', ') || 'No Name'
+  );
+}

--- a/src/utils/name-utils.ts
+++ b/src/utils/name-utils.ts
@@ -1,9 +1,19 @@
 import { get } from 'lodash';
+import { Feature } from '@turf/helpers';
 import { BoundaryLayerProps } from '../config/types';
 
-export function getLocationName(
+/**
+ * Format full location name in ascending admin levels
+ * @param layer admin layer, both props and data
+ * @param featureBoundary geospatial features of the location, contains names of different admin layers
+ * @returns a string containing location name in ascending admin levels i.e level 1 name, level 2 name, etc
+ */
+
+export function getFullLocationName(
   layer: BoundaryLayerProps,
-  featureBoundary: any,
+  featureBoundary:
+    | Feature<GeoJSON.Geometry, GeoJSON.GeoJsonProperties>
+    | undefined,
 ): string {
   return (
     layer.adminLevelNames


### PR DESCRIPTION
This closes #356 
deploy: http://prism-issue-356.surge.sh/
modified the Name column in analysis table to include parent admin level's names. This also makes the name matches location name on tooltip
![image](https://user-images.githubusercontent.com/30374401/156087093-4f3b783a-8b53-4e3f-a0e3-7f7ebb6b38c3.png)
