### PR TITLE
remove rounding for tooltip value

### DIFF
--- a/src/components/DataDrawer/DataTable/DataTableRow/index.tsx
+++ b/src/components/DataDrawer/DataTable/DataTableRow/index.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
+import { isNumber } from 'lodash';
 import { TableRow, TableCell } from '@material-ui/core';
 import { TableRowType } from '../../../../context/tableStateSlice';
+import { getRoundedData } from '../../../MapView/utils';
 
 export interface TableRowProps {
   className?: string;
@@ -12,7 +14,9 @@ const DataTableRow = ({ className, columns, rowData }: TableRowProps) => (
   <TableRow>
     {columns.map(column => {
       const colValue = rowData ? rowData[column] : column;
-      const formattedColValue = colValue.toLocaleString();
+      const formattedColValue = isNumber(colValue)
+        ? getRoundedData(colValue)
+        : colValue.toLocaleString();
       return (
         <TableCell className={className} key={column}>
           {' '}

--- a/src/components/MapView/Layers/AnalysisLayer/index.tsx
+++ b/src/components/MapView/Layers/AnalysisLayer/index.tsx
@@ -76,12 +76,10 @@ function AnalysisLayer() {
         dispatch(
           addPopupData({
             [analysisData.getStatTitle()]: {
-              data: Math.round(
-                get(
-                  evt.features[0],
-                  ['properties', analysisData.statistic],
-                  'No Data',
-                ),
+              data: get(
+                evt.features[0],
+                ['properties', analysisData.statistic],
+                'No Data',
               ).toLocaleString('en-US'),
               coordinates,
             },

--- a/src/components/MapView/Layers/AnalysisLayer/index.tsx
+++ b/src/components/MapView/Layers/AnalysisLayer/index.tsx
@@ -24,7 +24,7 @@ import {
 } from '../../../../config/utils';
 
 function getRoundedData(data: number): string {
-  return data ? data.toFixed(3) : 'No Data';
+  return data ? data.toFixed(2) : 'No Data';
 }
 
 function AnalysisLayer() {

--- a/src/components/MapView/Layers/AnalysisLayer/index.tsx
+++ b/src/components/MapView/Layers/AnalysisLayer/index.tsx
@@ -22,10 +22,7 @@ import {
   getBoundaryLayerSingleton,
   LayerDefinitions,
 } from '../../../../config/utils';
-
-function getRoundedData(data: number): string {
-  return data ? data.toFixed(2) : 'No Data';
-}
+import { getRoundedData } from '../../utils';
 
 function AnalysisLayer() {
   // TODO maybe in the future we can try add this to LayerType so we don't need exclusive code in Legends and MapView to make this display correctly

--- a/src/components/MapView/Layers/AnalysisLayer/index.tsx
+++ b/src/components/MapView/Layers/AnalysisLayer/index.tsx
@@ -23,6 +23,10 @@ import {
   LayerDefinitions,
 } from '../../../../config/utils';
 
+function getRoundedData(data: number): string {
+  return data ? data.toFixed(3) : 'No Data';
+}
+
 function AnalysisLayer() {
   // TODO maybe in the future we can try add this to LayerType so we don't need exclusive code in Legends and MapView to make this display correctly
   // Currently it is quite difficult due to how JSON focused the typing is. We would have to refactor it to also accept layers generated on-the-spot
@@ -76,11 +80,9 @@ function AnalysisLayer() {
         dispatch(
           addPopupData({
             [analysisData.getStatTitle()]: {
-              data: get(
-                evt.features[0],
-                ['properties', analysisData.statistic],
-                'No Data',
-              ).toLocaleString('en-US'),
+              data: getRoundedData(
+                get(evt.features[0], ['properties', analysisData.statistic]),
+              ),
               coordinates,
             },
           }),
@@ -90,7 +92,7 @@ function AnalysisLayer() {
           dispatch(
             addPopupData({
               [analysisData.getBaselineLayer().title]: {
-                data: get(evt.features[0], 'properties.data', 'No Data'),
+                data: getRoundedData(get(evt.features[0], 'properties.data')),
                 coordinates,
               },
             }),
@@ -101,10 +103,8 @@ function AnalysisLayer() {
           dispatch(
             addPopupData({
               [analysisData.key]: {
-                data: get(
-                  evt.features[0],
-                  `properties.${analysisData.key}`,
-                  'No Data',
+                data: getRoundedData(
+                  get(evt.features[0], `properties.${analysisData.key}`),
                 ),
                 coordinates,
               },

--- a/src/components/MapView/Layers/ImpactLayer/index.tsx
+++ b/src/components/MapView/Layers/ImpactLayer/index.tsx
@@ -22,7 +22,7 @@ import {
   layerDataSelector,
   mapSelector,
 } from '../../../../context/mapStateSlice/selectors';
-import { getFeatureInfoPropsData } from '../../utils';
+import { getFeatureInfoPropsData, getRoundedData } from '../../utils';
 
 const linePaint: LinePaint = {
   'line-color': 'grey',
@@ -33,7 +33,7 @@ const linePaint: LinePaint = {
 function getHazardData(evt: any, operation: string) {
   const data = get(evt.features[0].properties, operation || 'median', null);
 
-  return data ? data.toFixed(2) : 'No Data';
+  return getRoundedData(data);
 }
 
 const ImpactLayer = ({ classes, layer }: ComponentProps) => {

--- a/src/components/MapView/utils.ts
+++ b/src/components/MapView/utils.ts
@@ -21,7 +21,12 @@ import { ExposedPopulationResult } from '../../utils/analysis-utils';
 import { TableData } from '../../context/tableStateSlice';
 
 export function getRoundedData(data: number, decimals: number = 3): string {
-  return data ? parseFloat(data.toFixed(decimals)).toString() : 'No Data';
+  return data
+    ? parseFloat(data.toFixed(decimals))
+        .toString()
+        // add commas
+        .replace(/\B(?<!\.\d*)(?=(\d{3})+(?!\d))/g, ',')
+    : 'No Data';
 }
 
 export const getActiveFeatureInfoLayers = (map: Map): WMSLayerProps[] => {

--- a/src/components/MapView/utils.ts
+++ b/src/components/MapView/utils.ts
@@ -20,6 +20,10 @@ import {
 import { ExposedPopulationResult } from '../../utils/analysis-utils';
 import { TableData } from '../../context/tableStateSlice';
 
+export function getRoundedData(data: number, decimals: number = 3): string {
+  return data ? data.toFixed(decimals).toLocaleString() : 'No Data';
+}
+
 export const getActiveFeatureInfoLayers = (map: Map): WMSLayerProps[] => {
   const matchStr = 'layer-';
   const layerIds =

--- a/src/components/MapView/utils.ts
+++ b/src/components/MapView/utils.ts
@@ -21,7 +21,7 @@ import { ExposedPopulationResult } from '../../utils/analysis-utils';
 import { TableData } from '../../context/tableStateSlice';
 
 export function getRoundedData(data: number, decimals: number = 3): string {
-  return data ? data.toFixed(decimals).toLocaleString() : 'No Data';
+  return data ? parseFloat(data.toFixed(decimals)).toString() : 'No Data';
 }
 
 export const getActiveFeatureInfoLayers = (map: Map): WMSLayerProps[] => {


### PR DESCRIPTION
This closes #368 
Deploy: http://prism-368.surge.sh/
Remove rounding for tooltip values so that they match the values displayed in analysis table.

However, it can be ugly when the values have many decimal points, so should we round to 2dp instead?