### PR TITLE
Reset pagination on sort in analysis results

### DIFF
--- a/src/components/MapView/Analyser/AnalysisTable/index.tsx
+++ b/src/components/MapView/Analyser/AnalysisTable/index.tsx
@@ -39,6 +39,7 @@ function AnalysisTable({ classes, tableData, columns }: AnalysisTableProps) {
 
   const handleChangeOrderBy = (newSortColumn: Column['id']) => {
     const newIsAsc = !(sortColumn === newSortColumn && isAscending);
+    setPage(0);
     setSortColumn(newSortColumn);
     setIsAscending(newIsAsc);
   };


### PR DESCRIPTION
This PR fixes issue in #391.
Deploy link: http://prism-reset-pagination-onsort.surge.sh/
When the sorted column or sort direction is changed, table's pagination is reset to 0.