### PR TITLE
Update number with commas in case we have more than 3 decimals

### DIFF
--- a/src/components/MapView/utils.ts
+++ b/src/components/MapView/utils.ts
@@ -20,12 +20,16 @@ import {
 import { ExposedPopulationResult } from '../../utils/analysis-utils';
 import { TableData } from '../../context/tableStateSlice';
 
+function numberWithCommas(numberString: string) {
+  const parts = numberString.split('.');
+  // eslint-disable-next-line fp/no-mutation
+  parts[0] = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+  return parts.join('.');
+}
+
 export function getRoundedData(data: number, decimals: number = 3): string {
   return data
-    ? parseFloat(data.toFixed(decimals))
-        .toString()
-        // add commas
-        .replace(/\B(?=(\d{3})+(?!\d))/g, ',')
+    ? numberWithCommas(parseFloat(data.toFixed(decimals)).toString())
     : 'No Data';
 }
 

--- a/src/components/MapView/utils.ts
+++ b/src/components/MapView/utils.ts
@@ -20,17 +20,8 @@ import {
 import { ExposedPopulationResult } from '../../utils/analysis-utils';
 import { TableData } from '../../context/tableStateSlice';
 
-function numberWithCommas(numberString: string) {
-  const parts = numberString.split('.');
-  // eslint-disable-next-line fp/no-mutation
-  parts[0] = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, ',');
-  return parts.join('.');
-}
-
 export function getRoundedData(data: number, decimals: number = 3): string {
-  return data
-    ? numberWithCommas(parseFloat(data.toFixed(decimals)).toString())
-    : 'No Data';
+  return data ? parseFloat(data.toFixed(decimals)).toLocaleString() : 'No Data';
 }
 
 export const getActiveFeatureInfoLayers = (map: Map): WMSLayerProps[] => {


### PR DESCRIPTION
The current regex would not work well for more than 3 decimals.

Using `toLocaleString` instead as commas is not the default in all countries. In prevision of #382 