### PR TITLE
KOBO - make geofield and group parsing more flexible

### DIFF
--- a/api-flask/app/kobo.py
+++ b/api-flask/app/kobo.py
@@ -63,9 +63,14 @@ def parse_form_field(value: str, field_type: str):
         return dtparser(value).astimezone(timezone.utc)
     if field_type == 'geopoint':
         try:
-            lat, lon, _, _ = value.split(' ')
+            if isinstance(value, str):
+                lat, lon, _, _ = value.split(' ')
+            elif isinstance(value, list):
+                [lat, lon] = value
+            else:
+                lat, lon = None, None
             return {'lat': float(lat), 'lon': float(lon)}
-        except (TypeError, AttributeError):
+        except TypeError:
             logger.warning('geopoint %s coud not be parsed to {lat,lon}', value)
             return {}
     return value

--- a/api-flask/app/kobo.py
+++ b/api-flask/app/kobo.py
@@ -71,7 +71,7 @@ def parse_form_field(value: str, field_type: str):
                 lat, lon = None, None
             return {'lat': float(lat), 'lon': float(lon)}
         except TypeError:
-            logger.warning('geopoint %s coud not be parsed to {lat,lon}', value)
+            logger.debug('geopoint %s coud not be parsed to {lat,lon}', value)
             return {}
     return value
 

--- a/api-flask/app/kobo.py
+++ b/api-flask/app/kobo.py
@@ -105,9 +105,9 @@ def parse_form_response(form_dict: Dict[str, str], form_fields: Dict[str, str], 
         if key.endswith(geom_field)
     ][0]
 
-    geom_field_type = labels.get(geom_field)
-
-    latlon_dict = parse_form_field(geom_value_string, geom_field_type or 'geopoint')
+    # Some forms do not have geom_field properly setup. So we default to
+    # 'geopoint' here and handle edge cases in parse_form_field.
+    latlon_dict = parse_form_field(geom_value_string, labels.get(geom_field, 'geopoint'))
 
     status = form_dict.get('_validation_status').get('label', None)
     form_data = {**form_data, **latlon_dict, 'date': datetime_value, 'status': status}

--- a/api-flask/app/kobo.py
+++ b/api-flask/app/kobo.py
@@ -63,8 +63,12 @@ def parse_form_field(value: str, field_type: str):
     elif field_type in ('datetime', 'date'):
         return dtparser(value).astimezone(timezone.utc)
     elif field_type == 'geopoint':
-        lat, lon, _, _ = value.split(' ')
-        return {'lat': float(lat), 'lon': float(lon)}
+        try:
+            lat, lon, _, _ = value.split(' ')
+            return {'lat': float(lat), 'lon': float(lon)}
+        except TypeError:
+            logger.warning(value)
+            return {}
     else:
         return value
 
@@ -98,17 +102,14 @@ def parse_form_response(form_dict: Dict[str, str], form_fields: Dict[str, str], 
     datetime_value = parse_form_field(datetime_value_string, labels.get(datetime_field))
 
     geom_field = form_fields.get('geom', 'DoesNotExist')
-    geom_values = [
+    geom_value_string = [
         value for key, value in form_dict.items()
         if key.endswith(geom_field)
     ][0]
 
     geom_field_type = labels.get(geom_field)
-    
-    if geom_field_type is None:
-        latlon_dict = {}
-    else:
-        latlon_dict = parse_form_field(geom_values, geom_field_type)
+
+    latlon_dict = parse_form_field(geom_value_string, geom_field_type or "geopoint")
 
     status = form_dict.get('_validation_status').get('label', None)
     form_data = {**form_data, **latlon_dict, 'date': datetime_value, 'status': status}
@@ -187,7 +188,7 @@ def get_form_responses(begin_datetime, end_datetime):
     auth, form_fields = get_kobo_params()
 
     form_responses, form_labels = get_responses_from_kobo(auth, form_fields.get('name'))
-    
+
     forms = [parse_form_response(f, form_fields, form_labels) for f in form_responses]
 
     filtered_forms = []


### PR DESCRIPTION
This quick fix resolves #446.

The error is because when kobo form return an empty lat/lon value and when the `gemo_field_type` is empty, the `parse_form_response` function cannot map the result into a dictionary of latitude and longitude points

This is a temporary fix, but looks like the process of parsing json data from kobo form at the moment is very complex/varies case by case. @ericboucher @wadhwamatic, do you have any idea how we can make it a bit more generalized? 

How to test:
1. run the API locally
2. Update kh_incident_report in `config\cambodia\layers.json` with:
```"form_name": "ទម្រង់ ឧបទ្ទវហេតុ"```
or
```"form_name": "NCDM_Live_Form"```
3. Change `data` and `date_url` into:
```
"data": "http://localhost/kobo/forms",
"date_url": "http://localhost/kobo/forms",
```
3. Run PRISM app with REACT_APP_COUNTRY='cambodia'