### PR TITLE
Fix Swagger bug with long line in sample parameters

### DIFF
--- a/api-flask/app/main.py
+++ b/api-flask/app/main.py
@@ -36,7 +36,12 @@ app.config['PROPAGATE_EXCEPTIONS'] = True
 app.debug = True
 CORS(app)
 
-api = Api(app)
+api = Api(
+    app,
+    title='PRISM Geospatial API by WFP',
+    description='A geospatial API enabling aggregation and intersection calculations '
+                'between rasters and polygons.'
+)
 
 # For more configuration options, check out the documentation
 # Caching durations are in seconds.

--- a/api-flask/app/sample_requests.py
+++ b/api-flask/app/sample_requests.py
@@ -3,11 +3,11 @@ from flask_restx import fields
 
 
 stats_data = {
-     'geotiff_url': """https://odc.ovio.org/?service=WCS&request=GetCoverage&version=1.0.0
-      &coverage=r1h_dekad&crs=EPSG%3A4326&bbox=92.2%2C9.7%2C101.2%2C28.5&width=1098&height=
-      2304&format=GeoTIFF&time=2022-04-11""",
-     'zones_url': """https://prism-admin-boundaries.s3.us-east-2.amazonaws.com/mmr_admin_b
-      oundaries.json""",
+     'geotiff_url': ("https://odc.ovio.org/?service=WCS&request=GetCoverage&version=1.0.0",
+        "&coverage=r1h_dekad&crs=EPSG%3A4326&bbox=92.2%2C9.7%2C101.2%2C28.5&width=1098",
+        "&height=2304&format=GeoTIFF&time=2022-04-11"),
+     'zones_url': ("https://prism-admin-boundaries.s3.us-east-2.amazonaws.com/",
+        "mmr_admin_boundaries.json"),
      'group_by': 'TS'
 }
 
@@ -22,8 +22,9 @@ alert_data = {
         'baseUrl': 'https://odc.ovio.org/',
         'dateInterval': 'days',
         'opacity': 0.7,
-        'legendText': """Monthly precipitation anomaly compared to the long term average. Derived
-         from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps""",
+        'legendText': ("Monthly precipitation anomaly compared to the long term average.",
+            " Derived from CHIRPS (UCSB Climate Hazards Group).",
+            " https://www.chc.ucsb.edu/data/chirps"),
         'legend': [
             {
                 'label': '-0',

--- a/api-flask/app/sample_requests.py
+++ b/api-flask/app/sample_requests.py
@@ -3,11 +3,11 @@ from flask_restx import fields
 
 
 stats_data = {
-     'geotiff_url': ("https://odc.ovio.org/?service=WCS&request=GetCoverage&version=1.0.0",
-        "&coverage=r1h_dekad&crs=EPSG%3A4326&bbox=92.2%2C9.7%2C101.2%2C28.5&width=1098",
-        "&height=2304&format=GeoTIFF&time=2022-04-11"),
-     'zones_url': ("https://prism-admin-boundaries.s3.us-east-2.amazonaws.com/",
-        "mmr_admin_boundaries.json"),
+     'geotiff_url': "https://odc.ovio.org/?service=WCS&request=GetCoverage&version=1.0.0"\
+                    "&coverage=r1h_dekad&crs=EPSG%3A4326&bbox=92.2%2C9.7%2C101.2%2C28.5&width=1098"\
+                    "&height=2304&format=GeoTIFF&time=2022-04-11",
+     'zones_url': "https://prism-admin-boundaries.s3.us-east-2.amazonaws.com/"\
+                  "mmr_admin_boundaries.json",
      'group_by': 'TS'
 }
 
@@ -22,9 +22,9 @@ alert_data = {
         'baseUrl': 'https://odc.ovio.org/',
         'dateInterval': 'days',
         'opacity': 0.7,
-        'legendText': ("Monthly precipitation anomaly compared to the long term average.",
-            " Derived from CHIRPS (UCSB Climate Hazards Group).",
-            " https://www.chc.ucsb.edu/data/chirps"),
+        'legendText': "Monthly precipitation anomaly compared to the long term average."\
+                      " Derived from CHIRPS (UCSB Climate Hazards Group)."\
+                      " https://www.chc.ucsb.edu/data/chirps",
         'legend': [
             {
                 'label': '-0',

--- a/api-flask/app/sample_requests.py
+++ b/api-flask/app/sample_requests.py
@@ -3,11 +3,11 @@ from flask_restx import fields
 
 
 stats_data = {
-     'geotiff_url': "https://odc.ovio.org/?service=WCS&request=GetCoverage&version=1.0.0"\
-                    "&coverage=r1h_dekad&crs=EPSG%3A4326&bbox=92.2%2C9.7%2C101.2%2C28.5&width=1098"\
-                    "&height=2304&format=GeoTIFF&time=2022-04-11",
-     'zones_url': "https://prism-admin-boundaries.s3.us-east-2.amazonaws.com/"\
-                  "mmr_admin_boundaries.json",
+     'geotiff_url': 'https://odc.ovio.org/?service=WCS&request=GetCoverage&version=1.0.0'
+                    '&coverage=r1h_dekad&crs=EPSG%3A4326&bbox=92.2%2C9.7%2C101.2%2C28.5&width=1098'
+                    '&height=2304&format=GeoTIFF&time=2022-04-11',
+     'zones_url': 'https://prism-admin-boundaries.s3.us-east-2.amazonaws.com/'
+                  'mmr_admin_boundaries.json',
      'group_by': 'TS'
 }
 
@@ -22,9 +22,9 @@ alert_data = {
         'baseUrl': 'https://odc.ovio.org/',
         'dateInterval': 'days',
         'opacity': 0.7,
-        'legendText': "Monthly precipitation anomaly compared to the long term average."\
-                      " Derived from CHIRPS (UCSB Climate Hazards Group)."\
-                      " https://www.chc.ucsb.edu/data/chirps",
+        'legendText': 'Monthly precipitation anomaly compared to the long term average.'
+                      ' Derived from CHIRPS (UCSB Climate Hazards Group).'
+                      ' https://www.chc.ucsb.edu/data/chirps',
         'legend': [
             {
                 'label': '-0',


### PR DESCRIPTION
There was an issue with long sample request parameters. This PR ensures that they are considered as long strings and no 
"\n" gets inserted.

Before:
<img width="1319" alt="Screen Shot 2022-04-14 at 5 15 19 PM" src="https://user-images.githubusercontent.com/16843267/163479767-81df7d7c-463d-4a29-a741-7aedfcb90ee0.png">
