### PR TITLE
Update the WCS config and labels for LST amplitude layer in all deployments

### DIFF
--- a/src/config/cambodia/layers.json
+++ b/src/config/cambodia/layers.json
@@ -1438,45 +1438,45 @@
     "type": "wms",
     "server_layer_name": "myd11a2_taa_dekad",
     "base_url": "https://odc.ovio.org/",
+    "wcsConfig": {
+      "scale": 0.02,
+      "offset": 0,
+      "pixelResolution": 64
+    },
     "date_interval": "days",
     "opacity": 0.7,
-    "legend_text": "LEGEND",
+    "legend_text": "Land Surface Temperature Amplitude refers to the difference between the maximum and minimum temperature in degrees Celsius",
     "legend": [
       {
-        "label": "-0",
-        "color": "#ffffff",
-        "alpha": 0
-      },
-      {
-        "label": "50",
+        "label": "1°",
         "color": "#ffffd9"
       },
       {
-        "label": "200",
+        "label": "4°",
         "color": "#e8f6b1"
       },
       {
-        "label": "400",
+        "label": "8°",
         "color": "#b2e1b6"
       },
       {
-        "label": "600",
+        "label": "12°",
         "color": "#64c3bf"
       },
       {
-        "label": "800",
+        "label": "16°",
         "color": "#2ca1c2"
       },
       {
-        "label": "1000",
+        "label": "20°",
         "color": "#216daf"
       },
       {
-        "label": "1200",
+        "label": "24°",
         "color": "#253a97"
       },
       {
-        "label": "1400",
+        "label": "28°",
         "color": "#081d58"
       }
     ]

--- a/src/config/cuba/layers.json
+++ b/src/config/cuba/layers.json
@@ -1387,40 +1387,45 @@
     "type": "wms",
     "server_layer_name": "myd11a2_taa_dekad",
     "base_url": "https://odc.ovio.org/",
+    "wcsConfig": {
+      "scale": 0.02,
+      "offset": 0,
+      "pixelResolution": 64
+    },
     "date_interval": "days",
     "opacity": 0.7,
-    "legend_text": "LEGEND",
+    "legend_text": "Land Surface Temperature Amplitude refers to the difference between the maximum and minimum temperature in degrees Celsius",
     "legend": [
       {
-        "label": "50",
+        "label": "1°",
         "color": "#ffffd9"
       },
       {
-        "label": "200",
+        "label": "4°",
         "color": "#e8f6b1"
       },
       {
-        "label": "400",
+        "label": "8°",
         "color": "#b2e1b6"
       },
       {
-        "label": "600",
+        "label": "12°",
         "color": "#64c3bf"
       },
       {
-        "label": "800",
+        "label": "16°",
         "color": "#2ca1c2"
       },
       {
-        "label": "1000",
+        "label": "20°",
         "color": "#216daf"
       },
       {
-        "label": "1200",
+        "label": "24°",
         "color": "#253a97"
       },
       {
-        "label": "1400",
+        "label": "28°",
         "color": "#081d58"
       }
     ]

--- a/src/config/global/layers.json
+++ b/src/config/global/layers.json
@@ -255,19 +255,47 @@
     "type": "wms",
     "server_layer_name": "myd11a2_taa_dekad",
     "base_url": "https://odc.ovio.org/",
+    "wcsConfig": {
+      "scale": 0.02,
+      "offset": 0,
+      "pixelResolution": 64
+    },
     "date_interval": "days",
     "opacity": 0.7,
-    "legend_text": "LEGEND",
+    "legend_text": "Land Surface Temperature Amplitude refers to the difference between the maximum and minimum temperature in degrees Celsius",
     "legend": [
-      { "value": -0, "color": "#ffffff", "alpha": 0 },
-      { "value": 50, "color": "#ffffd9" },
-      { "value": 200, "color": "#e8f6b1" },
-      { "value": 400, "color": "#b2e1b6" },
-      { "value": 600, "color": "#64c3bf" },
-      { "value": 800, "color": "#2ca1c2" },
-      { "value": 1000, "color": "#216daf" },
-      { "value": 1200, "color": "#253a97" },
-      { "value": 1400, "color": "#081d58" }
+      {
+        "label": "1°",
+        "color": "#ffffd9"
+      },
+      {
+        "label": "4°",
+        "color": "#e8f6b1"
+      },
+      {
+        "label": "8°",
+        "color": "#b2e1b6"
+      },
+      {
+        "label": "12°",
+        "color": "#64c3bf"
+      },
+      {
+        "label": "16°",
+        "color": "#2ca1c2"
+      },
+      {
+        "label": "20°",
+        "color": "#216daf"
+      },
+      {
+        "label": "24°",
+        "color": "#253a97"
+      },
+      {
+        "label": "28°",
+        "color": "#081d58"
+      }
     ]
   },
   "lst_daytime": {

--- a/src/config/kyrgyzstan/layers.json
+++ b/src/config/kyrgyzstan/layers.json
@@ -288,19 +288,47 @@
     "type": "wms",
     "server_layer_name": "myd11a2_taa_dekad",
     "base_url": "https://odc.ovio.org/",
+    "wcsConfig": {
+      "scale": 0.02,
+      "offset": 0,
+      "pixelResolution": 64
+    },
     "date_interval": "days",
     "opacity": 0.7,
-    "legend_text": "LEGEND",
+    "legend_text": "Land Surface Temperature Amplitude refers to the difference between the maximum and minimum temperature in degrees Celsius",
     "legend": [
-      { "value": -0, "color": "#ffffff", "alpha": 0 },
-      { "value": 50, "color": "#ffffd9" },
-      { "value": 200, "color": "#e8f6b1" },
-      { "value": 400, "color": "#b2e1b6" },
-      { "value": 600, "color": "#64c3bf" },
-      { "value": 800, "color": "#2ca1c2" },
-      { "value": 1000, "color": "#216daf" },
-      { "value": 1200, "color": "#253a97" },
-      { "value": 1400, "color": "#081d58" }
+      {
+        "label": "1°",
+        "color": "#ffffd9"
+      },
+      {
+        "label": "4°",
+        "color": "#e8f6b1"
+      },
+      {
+        "label": "8°",
+        "color": "#b2e1b6"
+      },
+      {
+        "label": "12°",
+        "color": "#64c3bf"
+      },
+      {
+        "label": "16°",
+        "color": "#2ca1c2"
+      },
+      {
+        "label": "20°",
+        "color": "#216daf"
+      },
+      {
+        "label": "24°",
+        "color": "#253a97"
+      },
+      {
+        "label": "28°",
+        "color": "#081d58"
+      }
     ]
   },
   "lst_daytime": {

--- a/src/config/mozambique/layers.json
+++ b/src/config/mozambique/layers.json
@@ -4,8 +4,12 @@
     "path": "../data/mozambique/moz_bnd_adm1_WFP.json",
     "opacity": 0.8,
     "admin_code": "source_id",
-    "admin_level_names": ["adm1_name"],
-    "admin_level_local_names": ["adm1_name"],
+    "admin_level_names": [
+      "adm1_name"
+    ],
+    "admin_level_local_names": [
+      "adm1_name"
+    ],
     "styles:": {
       "fill": {
         "fill-opacity": 0
@@ -22,8 +26,14 @@
     "path": "../data/mozambique/moz_bnd_adm2_WFP.json",
     "opacity": 0.8,
     "admin_code": "source_id",
-    "admin_level_names": ["adm1_name", "adm2_name"],
-    "admin_level_local_names": ["adm1_name", "adm2_name"],
+    "admin_level_names": [
+      "adm1_name",
+      "adm2_name"
+    ],
+    "admin_level_local_names": [
+      "adm1_name",
+      "adm2_name"
+    ],
     "styles:": {
       "fill": {
         "fill-opacity": 0
@@ -47,19 +57,59 @@
     "opacity": 0.7,
     "legend_text": "CHIRPS rainfall global dekad",
     "legend": [
-      { "value": "-0", "color": "#ffffff", "alpha": 0 },
-      { "value": "1", "color": "#ffffff" },
-      { "value": "20", "color": "#faf5e6" },
-      { "value": "40", "color": "#faf3d2" },
-      { "value": "60", "color": "#dae3a1" },
-      { "value": "80", "color": "#a0c787" },
-      { "value": "100", "color": "#68ab79" },
-      { "value": "125", "color": "#9beafa" },
-      { "value": "150", "color": "#00b1de" },
-      { "value": "200", "color": "#005ae6" },
-      { "value": "250", "color": "#0000c8" },
-      { "value": "300", "color": "#a000fa" },
-      { "value": "350", "color": "#fa78fa" }
+      {
+        "value": "-0",
+        "color": "#ffffff",
+        "alpha": 0
+      },
+      {
+        "value": "1",
+        "color": "#ffffff"
+      },
+      {
+        "value": "20",
+        "color": "#faf5e6"
+      },
+      {
+        "value": "40",
+        "color": "#faf3d2"
+      },
+      {
+        "value": "60",
+        "color": "#dae3a1"
+      },
+      {
+        "value": "80",
+        "color": "#a0c787"
+      },
+      {
+        "value": "100",
+        "color": "#68ab79"
+      },
+      {
+        "value": "125",
+        "color": "#9beafa"
+      },
+      {
+        "value": "150",
+        "color": "#00b1de"
+      },
+      {
+        "value": "200",
+        "color": "#005ae6"
+      },
+      {
+        "value": "250",
+        "color": "#0000c8"
+      },
+      {
+        "value": "300",
+        "color": "#a000fa"
+      },
+      {
+        "value": "350",
+        "color": "#fa78fa"
+      }
     ]
   },
   "rain_anomaly_dekad": {
@@ -356,18 +406,55 @@
     "opacity": 0.7,
     "legend_text": "CHIRPS 1 month dekadal rainfall aggregations (mm)",
     "legend": [
-      { "value": "-0", "color": "#ffffff", "alpha": "0" },
-      { "value": "50", "color": "#faf3d2" },
-      { "value": "100", "color": "#dae3a1" },
-      { "value": "150", "color": "#a0c787" },
-      { "value": "200", "color": "#68ab79" },
-      { "value": "250", "color": "#9beafa" },
-      { "value": "300", "color": "#00b1de" },
-      { "value": "400", "color": "#005ae6" },
-      { "value": "500", "color": "#0000c8" },
-      { "value": "600", "color": "#a000fa" },
-      { "value": "800", "color": "#fa78fa" },
-      { "value": "> 800", "color": "#ffc4ee" }
+      {
+        "value": "-0",
+        "color": "#ffffff",
+        "alpha": "0"
+      },
+      {
+        "value": "50",
+        "color": "#faf3d2"
+      },
+      {
+        "value": "100",
+        "color": "#dae3a1"
+      },
+      {
+        "value": "150",
+        "color": "#a0c787"
+      },
+      {
+        "value": "200",
+        "color": "#68ab79"
+      },
+      {
+        "value": "250",
+        "color": "#9beafa"
+      },
+      {
+        "value": "300",
+        "color": "#00b1de"
+      },
+      {
+        "value": "400",
+        "color": "#005ae6"
+      },
+      {
+        "value": "500",
+        "color": "#0000c8"
+      },
+      {
+        "value": "600",
+        "color": "#a000fa"
+      },
+      {
+        "value": "800",
+        "color": "#fa78fa"
+      },
+      {
+        "value": "> 800",
+        "color": "#ffc4ee"
+      }
     ]
   },
   "rainfall_agg_2month": {
@@ -382,18 +469,55 @@
     "opacity": 0.7,
     "legend_text": "CHIRPS 2 month dekadal rainfall aggregations (mm)",
     "legend": [
-      { "value": "-0", "color": "#ffffff", "alpha": "0" },
-      { "value": "50", "color": "#faf3d2" },
-      { "value": "100", "color": "#dae3a1" },
-      { "value": "150", "color": "#a0c787" },
-      { "value": "200", "color": "#68ab79" },
-      { "value": "250", "color": "#9beafa" },
-      { "value": "300", "color": "#00b1de" },
-      { "value": "400", "color": "#005ae6" },
-      { "value": "500", "color": "#0000c8" },
-      { "value": "600", "color": "#a000fa" },
-      { "value": "800", "color": "#fa78fa" },
-      { "value": "> 800", "color": "#ffc4ee" }
+      {
+        "value": "-0",
+        "color": "#ffffff",
+        "alpha": "0"
+      },
+      {
+        "value": "50",
+        "color": "#faf3d2"
+      },
+      {
+        "value": "100",
+        "color": "#dae3a1"
+      },
+      {
+        "value": "150",
+        "color": "#a0c787"
+      },
+      {
+        "value": "200",
+        "color": "#68ab79"
+      },
+      {
+        "value": "250",
+        "color": "#9beafa"
+      },
+      {
+        "value": "300",
+        "color": "#00b1de"
+      },
+      {
+        "value": "400",
+        "color": "#005ae6"
+      },
+      {
+        "value": "500",
+        "color": "#0000c8"
+      },
+      {
+        "value": "600",
+        "color": "#a000fa"
+      },
+      {
+        "value": "800",
+        "color": "#fa78fa"
+      },
+      {
+        "value": "> 800",
+        "color": "#ffc4ee"
+      }
     ]
   },
   "rainfall_agg_3month": {
@@ -408,18 +532,55 @@
     "opacity": 0.7,
     "legend_text": "CHIRPS 3 month dekadal rainfall aggregations",
     "legend": [
-      { "value": "-0", "color": "#ffffff", "alpha": "0" },
-      { "value": "50", "color": "#faf3d2" },
-      { "value": "100", "color": "#dae3a1" },
-      { "value": "150", "color": "#a0c787" },
-      { "value": "200", "color": "#68ab79" },
-      { "value": "250", "color": "#9beafa" },
-      { "value": "300", "color": "#00b1de" },
-      { "value": "400", "color": "#005ae6" },
-      { "value": "500", "color": "#0000c8" },
-      { "value": "600", "color": "#a000fa" },
-      { "value": "800", "color": "#fa78fa" },
-      { "value": "> 800", "color": "#ffc4ee" }
+      {
+        "value": "-0",
+        "color": "#ffffff",
+        "alpha": "0"
+      },
+      {
+        "value": "50",
+        "color": "#faf3d2"
+      },
+      {
+        "value": "100",
+        "color": "#dae3a1"
+      },
+      {
+        "value": "150",
+        "color": "#a0c787"
+      },
+      {
+        "value": "200",
+        "color": "#68ab79"
+      },
+      {
+        "value": "250",
+        "color": "#9beafa"
+      },
+      {
+        "value": "300",
+        "color": "#00b1de"
+      },
+      {
+        "value": "400",
+        "color": "#005ae6"
+      },
+      {
+        "value": "500",
+        "color": "#0000c8"
+      },
+      {
+        "value": "600",
+        "color": "#a000fa"
+      },
+      {
+        "value": "800",
+        "color": "#fa78fa"
+      },
+      {
+        "value": "> 800",
+        "color": "#ffc4ee"
+      }
     ]
   },
   "rainfall_agg_6month": {
@@ -434,18 +595,55 @@
     "opacity": 0.7,
     "legend_text": "CHIRPS 6 month dekadal rainfall aggregations",
     "legend": [
-      { "value": "-0", "color": "#ffffff", "alpha": "0" },
-      { "value": "50", "color": "#faf3d2" },
-      { "value": "100", "color": "#dae3a1" },
-      { "value": "150", "color": "#a0c787" },
-      { "value": "200", "color": "#68ab79" },
-      { "value": "250", "color": "#9beafa" },
-      { "value": "300", "color": "#00b1de" },
-      { "value": "400", "color": "#005ae6" },
-      { "value": "500", "color": "#0000c8" },
-      { "value": "600", "color": "#a000fa" },
-      { "value": "800", "color": "#fa78fa" },
-      { "value": "> 800", "color": "#ffc4ee" }
+      {
+        "value": "-0",
+        "color": "#ffffff",
+        "alpha": "0"
+      },
+      {
+        "value": "50",
+        "color": "#faf3d2"
+      },
+      {
+        "value": "100",
+        "color": "#dae3a1"
+      },
+      {
+        "value": "150",
+        "color": "#a0c787"
+      },
+      {
+        "value": "200",
+        "color": "#68ab79"
+      },
+      {
+        "value": "250",
+        "color": "#9beafa"
+      },
+      {
+        "value": "300",
+        "color": "#00b1de"
+      },
+      {
+        "value": "400",
+        "color": "#005ae6"
+      },
+      {
+        "value": "500",
+        "color": "#0000c8"
+      },
+      {
+        "value": "600",
+        "color": "#a000fa"
+      },
+      {
+        "value": "800",
+        "color": "#fa78fa"
+      },
+      {
+        "value": "> 800",
+        "color": "#ffc4ee"
+      }
     ]
   },
   "rainfall_agg_9month": {
@@ -460,18 +658,55 @@
     "opacity": 0.7,
     "legend_text": "CHIRPS 9 month dekadal rainfall aggregations",
     "legend": [
-      { "value": "-0", "color": "#ffffff", "alpha": "0" },
-      { "value": "50", "color": "#faf3d2" },
-      { "value": "100", "color": "#dae3a1" },
-      { "value": "150", "color": "#a0c787" },
-      { "value": "200", "color": "#68ab79" },
-      { "value": "250", "color": "#9beafa" },
-      { "value": "300", "color": "#00b1de" },
-      { "value": "400", "color": "#005ae6" },
-      { "value": "500", "color": "#0000c8" },
-      { "value": "600", "color": "#a000fa" },
-      { "value": "800", "color": "#fa78fa" },
-      { "value": "> 800", "color": "#ffc4ee" }
+      {
+        "value": "-0",
+        "color": "#ffffff",
+        "alpha": "0"
+      },
+      {
+        "value": "50",
+        "color": "#faf3d2"
+      },
+      {
+        "value": "100",
+        "color": "#dae3a1"
+      },
+      {
+        "value": "150",
+        "color": "#a0c787"
+      },
+      {
+        "value": "200",
+        "color": "#68ab79"
+      },
+      {
+        "value": "250",
+        "color": "#9beafa"
+      },
+      {
+        "value": "300",
+        "color": "#00b1de"
+      },
+      {
+        "value": "400",
+        "color": "#005ae6"
+      },
+      {
+        "value": "500",
+        "color": "#0000c8"
+      },
+      {
+        "value": "600",
+        "color": "#a000fa"
+      },
+      {
+        "value": "800",
+        "color": "#fa78fa"
+      },
+      {
+        "value": "> 800",
+        "color": "#ffc4ee"
+      }
     ]
   },
   "rainfall_agg_1year": {
@@ -486,18 +721,55 @@
     "opacity": 0.7,
     "legend_text": "CHIRPS 1 year dekadal rainfall aggregations",
     "legend": [
-      { "value": -0, "color": "#ffffff", "alpha": 0 },
-      { "value": 50, "color": "#faf3d2" },
-      { "value": 100, "color": "#dae3a1" },
-      { "value": 200, "color": "#a0c787" },
-      { "value": 300, "color": "#68ab79" },
-      { "value": 400, "color": "#9beafa" },
-      { "value": 500, "color": "#00b1de" },
-      { "value": 600, "color": "#005ae6" },
-      { "value": 800, "color": "#0000c8" },
-      { "value": 1000, "color": "#a000fa" },
-      { "value": 1500, "color": "#fa78fa" },
-      { "value": 2000, "color": "#ffc4ee" }
+      {
+        "value": -0,
+        "color": "#ffffff",
+        "alpha": 0
+      },
+      {
+        "value": 50,
+        "color": "#faf3d2"
+      },
+      {
+        "value": 100,
+        "color": "#dae3a1"
+      },
+      {
+        "value": 200,
+        "color": "#a0c787"
+      },
+      {
+        "value": 300,
+        "color": "#68ab79"
+      },
+      {
+        "value": 400,
+        "color": "#9beafa"
+      },
+      {
+        "value": 500,
+        "color": "#00b1de"
+      },
+      {
+        "value": 600,
+        "color": "#005ae6"
+      },
+      {
+        "value": 800,
+        "color": "#0000c8"
+      },
+      {
+        "value": 1000,
+        "color": "#a000fa"
+      },
+      {
+        "value": 1500,
+        "color": "#fa78fa"
+      },
+      {
+        "value": 2000,
+        "color": "#ffc4ee"
+      }
     ]
   },
   "days_dry": {
@@ -509,16 +781,46 @@
     "opacity": 0.7,
     "legend_text": "Number of consecutive days with less than 2 mm precipitation in the last 30 days",
     "legend": [
-      { "value": 0, "color": "#fff9c7" },
-      { "value": 1, "color": "#ffeea9" },
-      { "value": 4, "color": "#fede86" },
-      { "value": 6, "color": "#fec754" },
-      { "value": 10, "color": "#fea937" },
-      { "value": 14, "color": "#f88a21" },
-      { "value": 18, "color": "#e96d13" },
-      { "value": 22, "color": "#d15205" },
-      { "value": 25, "color": "#b03f03" },
-      { "value": 30, "color": "#8b3005" }
+      {
+        "value": 0,
+        "color": "#fff9c7"
+      },
+      {
+        "value": 1,
+        "color": "#ffeea9"
+      },
+      {
+        "value": 4,
+        "color": "#fede86"
+      },
+      {
+        "value": 6,
+        "color": "#fec754"
+      },
+      {
+        "value": 10,
+        "color": "#fea937"
+      },
+      {
+        "value": 14,
+        "color": "#f88a21"
+      },
+      {
+        "value": 18,
+        "color": "#e96d13"
+      },
+      {
+        "value": 22,
+        "color": "#d15205"
+      },
+      {
+        "value": 25,
+        "color": "#b03f03"
+      },
+      {
+        "value": 30,
+        "color": "#8b3005"
+      }
     ]
   },
   "streak_dry_days": {
@@ -530,16 +832,46 @@
     "opacity": 0.7,
     "legend_text": "Longest number of consecutive days with less than 2 mm precipitation in the last 30 days",
     "legend": [
-      { "value": 0, "color": "#fff9c7" },
-      { "value": 1, "color": "#ffeea9" },
-      { "value": 4, "color": "#fede86" },
-      { "value": 6, "color": "#fec754" },
-      { "value": 10, "color": "#fea937" },
-      { "value": 14, "color": "#f88a21" },
-      { "value": 18, "color": "#e96d13" },
-      { "value": 22, "color": "#d15205" },
-      { "value": 25, "color": "#b03f03" },
-      { "value": 30, "color": "#8b3005" }
+      {
+        "value": 0,
+        "color": "#fff9c7"
+      },
+      {
+        "value": 1,
+        "color": "#ffeea9"
+      },
+      {
+        "value": 4,
+        "color": "#fede86"
+      },
+      {
+        "value": 6,
+        "color": "#fec754"
+      },
+      {
+        "value": 10,
+        "color": "#fea937"
+      },
+      {
+        "value": 14,
+        "color": "#f88a21"
+      },
+      {
+        "value": 18,
+        "color": "#e96d13"
+      },
+      {
+        "value": 22,
+        "color": "#d15205"
+      },
+      {
+        "value": 25,
+        "color": "#b03f03"
+      },
+      {
+        "value": 30,
+        "color": "#8b3005"
+      }
     ]
   },
   "days_heavy_rain": {
@@ -551,16 +883,46 @@
     "opacity": 0.7,
     "legend_text": "Total number of heavy rain days (rainfall > 75th percentile) within last 30 days of dekad",
     "legend": [
-      { "value": 0, "color": "#f2fabc" },
-      { "value": 1, "color": "#dcf1b2" },
-      { "value": 4, "color": "#bbe4b5" },
-      { "value": 6, "color": "#85cfba" },
-      { "value": 10, "color": "#57bec1" },
-      { "value": 14, "color": "#34a9c3" },
-      { "value": 18, "color": "#1d8dbe" },
-      { "value": 22, "color": "#2166ac" },
-      { "value": 25, "color": "#24479d" },
-      { "value": 30, "color": "#1d2e83" }
+      {
+        "value": 0,
+        "color": "#f2fabc"
+      },
+      {
+        "value": 1,
+        "color": "#dcf1b2"
+      },
+      {
+        "value": 4,
+        "color": "#bbe4b5"
+      },
+      {
+        "value": 6,
+        "color": "#85cfba"
+      },
+      {
+        "value": 10,
+        "color": "#57bec1"
+      },
+      {
+        "value": 14,
+        "color": "#34a9c3"
+      },
+      {
+        "value": 18,
+        "color": "#1d8dbe"
+      },
+      {
+        "value": 22,
+        "color": "#2166ac"
+      },
+      {
+        "value": 25,
+        "color": "#24479d"
+      },
+      {
+        "value": 30,
+        "color": "#1d2e83"
+      }
     ]
   },
   "days_intense_rain": {
@@ -572,16 +934,46 @@
     "opacity": 0.7,
     "legend_text": "Total number of heavy rain days (rainfall > 90th percentile) within last 30 days of dekad",
     "legend": [
-      { "value": 0, "color": "#f2fabc" },
-      { "value": 1, "color": "#dcf1b2" },
-      { "value": 4, "color": "#bbe4b5" },
-      { "value": 6, "color": "#85cfba" },
-      { "value": 10, "color": "#57bec1" },
-      { "value": 14, "color": "#34a9c3" },
-      { "value": 18, "color": "#1d8dbe" },
-      { "value": 22, "color": "#2166ac" },
-      { "value": 25, "color": "#24479d" },
-      { "value": 30, "color": "#1d2e83" }
+      {
+        "value": 0,
+        "color": "#f2fabc"
+      },
+      {
+        "value": 1,
+        "color": "#dcf1b2"
+      },
+      {
+        "value": 4,
+        "color": "#bbe4b5"
+      },
+      {
+        "value": 6,
+        "color": "#85cfba"
+      },
+      {
+        "value": 10,
+        "color": "#57bec1"
+      },
+      {
+        "value": 14,
+        "color": "#34a9c3"
+      },
+      {
+        "value": 18,
+        "color": "#1d8dbe"
+      },
+      {
+        "value": 22,
+        "color": "#2166ac"
+      },
+      {
+        "value": 25,
+        "color": "#24479d"
+      },
+      {
+        "value": 30,
+        "color": "#1d2e83"
+      }
     ]
   },
   "days_extreme_rain": {
@@ -593,16 +985,46 @@
     "opacity": 0.7,
     "legend_text": "Total number of heavy rain days (rainfall > 95th percentile) within last 30 days of dekad",
     "legend": [
-      { "value": 0, "color": "#f2fabc" },
-      { "value": 1, "color": "#dcf1b2" },
-      { "value": 4, "color": "#bbe4b5" },
-      { "value": 6, "color": "#85cfba" },
-      { "value": 10, "color": "#57bec1" },
-      { "value": 14, "color": "#34a9c3" },
-      { "value": 18, "color": "#1d8dbe" },
-      { "value": 22, "color": "#2166ac" },
-      { "value": 25, "color": "#24479d" },
-      { "value": 30, "color": "#1d2e83" }
+      {
+        "value": 0,
+        "color": "#f2fabc"
+      },
+      {
+        "value": 1,
+        "color": "#dcf1b2"
+      },
+      {
+        "value": 4,
+        "color": "#bbe4b5"
+      },
+      {
+        "value": 6,
+        "color": "#85cfba"
+      },
+      {
+        "value": 10,
+        "color": "#57bec1"
+      },
+      {
+        "value": 14,
+        "color": "#34a9c3"
+      },
+      {
+        "value": 18,
+        "color": "#1d8dbe"
+      },
+      {
+        "value": 22,
+        "color": "#2166ac"
+      },
+      {
+        "value": 25,
+        "color": "#24479d"
+      },
+      {
+        "value": 30,
+        "color": "#1d2e83"
+      }
     ]
   },
   "streak_heavy_rain": {
@@ -614,17 +1036,51 @@
     "opacity": 0.7,
     "legend_text": "Longest consecutive number of heavy rain days (rainfall > 75th percentile) within last 30 days of dekad",
     "legend": [
-      { "value": 0, "color": "#f2fabc" },
-      { "value": 1, "color": "#dcf1b2" },
-      { "value": 4, "color": "#bbe4b5" },
-      { "value": 6, "color": "#85cfba" },
-      { "value": 10, "color": "#57bec1" },
-      { "value": 14, "color": "#34a9c3" },
-      { "value": 18, "color": "#1d8dbe" },
-      { "value": 22, "color": "#2166ac" },
-      { "value": 25, "color": "#24479d" },
-      { "value": 30, "color": "#1d2e83" },
-      { "value": "255 - no value", "color": "#ffffff", "alpha": 0 }
+      {
+        "value": 0,
+        "color": "#f2fabc"
+      },
+      {
+        "value": 1,
+        "color": "#dcf1b2"
+      },
+      {
+        "value": 4,
+        "color": "#bbe4b5"
+      },
+      {
+        "value": 6,
+        "color": "#85cfba"
+      },
+      {
+        "value": 10,
+        "color": "#57bec1"
+      },
+      {
+        "value": 14,
+        "color": "#34a9c3"
+      },
+      {
+        "value": 18,
+        "color": "#1d8dbe"
+      },
+      {
+        "value": 22,
+        "color": "#2166ac"
+      },
+      {
+        "value": 25,
+        "color": "#24479d"
+      },
+      {
+        "value": 30,
+        "color": "#1d2e83"
+      },
+      {
+        "value": "255 - no value",
+        "color": "#ffffff",
+        "alpha": 0
+      }
     ]
   },
   "ndvi_dekad_5": {
@@ -743,15 +1199,42 @@
     "opacity": 0.7,
     "legend_text": "NDVI Anomaly compared to LTA",
     "legend": [
-      { "value": 50, "color": "#732600" },
-      { "value": 70, "color": "#f06405" },
-      { "value": 80, "color": "#f5af28" },
-      { "value": 90, "color": "#e6dc96" },
-      { "value": 110, "color": "#f5f5f5" },
-      { "value": 120, "color": "#cbff1f" },
-      { "value": 130, "color": "#00f200" },
-      { "value": 150, "color": "#008f00" },
-      { "value": 200, "color": "#004d00" }
+      {
+        "value": 50,
+        "color": "#732600"
+      },
+      {
+        "value": 70,
+        "color": "#f06405"
+      },
+      {
+        "value": 80,
+        "color": "#f5af28"
+      },
+      {
+        "value": 90,
+        "color": "#e6dc96"
+      },
+      {
+        "value": 110,
+        "color": "#f5f5f5"
+      },
+      {
+        "value": 120,
+        "color": "#cbff1f"
+      },
+      {
+        "value": 130,
+        "color": "#00f200"
+      },
+      {
+        "value": 150,
+        "color": "#008f00"
+      },
+      {
+        "value": 200,
+        "color": "#004d00"
+      }
     ]
   },
   "ndvi_dekad_anomaly_1": {
@@ -766,15 +1249,42 @@
     "opacity": 0.7,
     "legend_text": "NDVI Anomaly compared to LTA",
     "legend": [
-      { "value": 50, "color": "#732600" },
-      { "value": 70, "color": "#f06405" },
-      { "value": 80, "color": "#f5af28" },
-      { "value": 90, "color": "#e6dc96" },
-      { "value": 110, "color": "#f5f5f5" },
-      { "value": 120, "color": "#cbff1f" },
-      { "value": 130, "color": "#00f200" },
-      { "value": 150, "color": "#008f00" },
-      { "value": 200, "color": "#004d00" }
+      {
+        "value": 50,
+        "color": "#732600"
+      },
+      {
+        "value": 70,
+        "color": "#f06405"
+      },
+      {
+        "value": 80,
+        "color": "#f5af28"
+      },
+      {
+        "value": 90,
+        "color": "#e6dc96"
+      },
+      {
+        "value": 110,
+        "color": "#f5f5f5"
+      },
+      {
+        "value": 120,
+        "color": "#cbff1f"
+      },
+      {
+        "value": 130,
+        "color": "#00f200"
+      },
+      {
+        "value": 150,
+        "color": "#008f00"
+      },
+      {
+        "value": 200,
+        "color": "#004d00"
+      }
     ]
   },
   "lst_amplitude": {
@@ -782,19 +1292,47 @@
     "type": "wms",
     "server_layer_name": "myd11a2_taa_dekad",
     "base_url": "https://odc.ovio.org/",
+    "wcsConfig": {
+      "scale": 0.02,
+      "offset": 0,
+      "pixelResolution": 64
+    },
     "date_interval": "days",
     "opacity": 0.7,
-    "legend_text": "LEGEND",
+    "legend_text": "Land Surface Temperature Amplitude refers to the difference between the maximum and minimum temperature in degrees Celsius",
     "legend": [
-      { "value": -0, "color": "#ffffff", "alpha": 0 },
-      { "value": 50, "color": "#ffffd9" },
-      { "value": 200, "color": "#e8f6b1" },
-      { "value": 400, "color": "#b2e1b6" },
-      { "value": 600, "color": "#64c3bf" },
-      { "value": 800, "color": "#2ca1c2" },
-      { "value": 1000, "color": "#216daf" },
-      { "value": 1200, "color": "#253a97" },
-      { "value": 1400, "color": "#081d58" }
+      {
+        "label": "1°",
+        "color": "#ffffd9"
+      },
+      {
+        "label": "4°",
+        "color": "#e8f6b1"
+      },
+      {
+        "label": "8°",
+        "color": "#b2e1b6"
+      },
+      {
+        "label": "12°",
+        "color": "#64c3bf"
+      },
+      {
+        "label": "16°",
+        "color": "#2ca1c2"
+      },
+      {
+        "label": "20°",
+        "color": "#216daf"
+      },
+      {
+        "label": "24°",
+        "color": "#253a97"
+      },
+      {
+        "label": "28°",
+        "color": "#081d58"
+      }
     ]
   },
   "lst_daytime_5": {
@@ -814,17 +1352,50 @@
       "styles": "lst_day"
     },
     "legend": [
-      { "value": 0, "color": "#f0f9ba" },
-      { "value": 5, "color": "#edeba4" },
-      { "value": 10, "color": "#ebdd8f" },
-      { "value": 15, "color": "#eace7c" },
-      { "value": 20, "color": "#e9bf6a" },
-      { "value": 25, "color": "#e9af59" },
-      { "value": 30, "color": "#e99e4c" },
-      { "value": 35, "color": "#e98d41" },
-      { "value": 40, "color": "#e87a3a" },
-      { "value": 45, "color": "#e76636" },
-      { "value": 50, "color": "#e54f35" }
+      {
+        "value": 0,
+        "color": "#f0f9ba"
+      },
+      {
+        "value": 5,
+        "color": "#edeba4"
+      },
+      {
+        "value": 10,
+        "color": "#ebdd8f"
+      },
+      {
+        "value": 15,
+        "color": "#eace7c"
+      },
+      {
+        "value": 20,
+        "color": "#e9bf6a"
+      },
+      {
+        "value": 25,
+        "color": "#e9af59"
+      },
+      {
+        "value": 30,
+        "color": "#e99e4c"
+      },
+      {
+        "value": 35,
+        "color": "#e98d41"
+      },
+      {
+        "value": 40,
+        "color": "#e87a3a"
+      },
+      {
+        "value": 45,
+        "color": "#e76636"
+      },
+      {
+        "value": 50,
+        "color": "#e54f35"
+      }
     ]
   },
   "lst_daytime_1": {
@@ -844,17 +1415,50 @@
       "styles": "lst_day"
     },
     "legend": [
-      { "value": 0, "color": "#f0f9ba" },
-      { "value": 5, "color": "#edeba4" },
-      { "value": 10, "color": "#ebdd8f" },
-      { "value": 15, "color": "#eace7c" },
-      { "value": 20, "color": "#e9bf6a" },
-      { "value": 25, "color": "#e9af59" },
-      { "value": 30, "color": "#e99e4c" },
-      { "value": 35, "color": "#e98d41" },
-      { "value": 40, "color": "#e87a3a" },
-      { "value": 45, "color": "#e76636" },
-      { "value": 50, "color": "#e54f35" }
+      {
+        "value": 0,
+        "color": "#f0f9ba"
+      },
+      {
+        "value": 5,
+        "color": "#edeba4"
+      },
+      {
+        "value": 10,
+        "color": "#ebdd8f"
+      },
+      {
+        "value": 15,
+        "color": "#eace7c"
+      },
+      {
+        "value": 20,
+        "color": "#e9bf6a"
+      },
+      {
+        "value": 25,
+        "color": "#e9af59"
+      },
+      {
+        "value": 30,
+        "color": "#e99e4c"
+      },
+      {
+        "value": 35,
+        "color": "#e98d41"
+      },
+      {
+        "value": 40,
+        "color": "#e87a3a"
+      },
+      {
+        "value": 45,
+        "color": "#e76636"
+      },
+      {
+        "value": 50,
+        "color": "#e54f35"
+      }
     ]
   },
   "ast_max": {
@@ -869,19 +1473,58 @@
       "styles": "txb"
     },
     "legend": [
-      { "value": 20, "color": "#2b83ba" },
-      { "value": 22, "color": "#59a4b2" },
-      { "value": 24, "color": "#88c5aa" },
-      { "value": 26, "color": "#b3e0a7" },
-      { "value": 28, "color": "#d2edb0" },
-      { "value": 30, "color": "#f0f9ba" },
-      { "value": 32, "color": "#fff1ae" },
-      { "value": 34, "color": "#fed38c" },
-      { "value": 36, "color": "#feb669" },
-      { "value": 38, "color": "#f3854e" },
-      { "value": 40, "color": "#e54f35" },
-      { "value": 42, "color": "#d7191c" },
-      { "value": 44, "color": "#ad0003" }
+      {
+        "value": 20,
+        "color": "#2b83ba"
+      },
+      {
+        "value": 22,
+        "color": "#59a4b2"
+      },
+      {
+        "value": 24,
+        "color": "#88c5aa"
+      },
+      {
+        "value": 26,
+        "color": "#b3e0a7"
+      },
+      {
+        "value": 28,
+        "color": "#d2edb0"
+      },
+      {
+        "value": 30,
+        "color": "#f0f9ba"
+      },
+      {
+        "value": 32,
+        "color": "#fff1ae"
+      },
+      {
+        "value": 34,
+        "color": "#fed38c"
+      },
+      {
+        "value": 36,
+        "color": "#feb669"
+      },
+      {
+        "value": 38,
+        "color": "#f3854e"
+      },
+      {
+        "value": 40,
+        "color": "#e54f35"
+      },
+      {
+        "value": 42,
+        "color": "#d7191c"
+      },
+      {
+        "value": 44,
+        "color": "#ad0003"
+      }
     ]
   },
   "ast_max_anomaly": {
@@ -896,15 +1539,42 @@
       "styles": "txd"
     },
     "legend": [
-      { "value": -300.0, "color": "#000004" },
-      { "value": -200.0, "color": "#210c4a" },
-      { "value": -100.0, "color": "#57106e" },
-      { "value": -50.0, "color": "#8a226a" },
-      { "value": 50.0, "color": "#bc3754" },
-      { "value": 100.0, "color": "#e45a31" },
-      { "value": 200.0, "color": "#f98e09" },
-      { "value": 300.0, "color": "#f9cb35" },
-      { "value": 500.0, "color": "#fcffa4" }
+      {
+        "value": -300.0,
+        "color": "#000004"
+      },
+      {
+        "value": -200.0,
+        "color": "#210c4a"
+      },
+      {
+        "value": -100.0,
+        "color": "#57106e"
+      },
+      {
+        "value": -50.0,
+        "color": "#8a226a"
+      },
+      {
+        "value": 50.0,
+        "color": "#bc3754"
+      },
+      {
+        "value": 100.0,
+        "color": "#e45a31"
+      },
+      {
+        "value": 200.0,
+        "color": "#f98e09"
+      },
+      {
+        "value": 300.0,
+        "color": "#f9cb35"
+      },
+      {
+        "value": 500.0,
+        "color": "#fcffa4"
+      }
     ]
   },
   "lst_daytime_blended": {
@@ -921,19 +1591,58 @@
     "opacity": 0.7,
     "legend_text": "Local station data from INAM blended with MODIS daytime land surface temperature estimates",
     "legend": [
-      { "value": 20, "color": "#2b83ba" },
-      { "value": 22, "color": "#59a4b2" },
-      { "value": 24, "color": "#88c5aa" },
-      { "value": 26, "color": "#b3e0a7" },
-      { "value": 28, "color": "#d2edb0" },
-      { "value": 30, "color": "#f0f9ba" },
-      { "value": 32, "color": "#fff1ae" },
-      { "value": 34, "color": "#fed38c" },
-      { "value": 36, "color": "#feb669" },
-      { "value": 38, "color": "#f3854e" },
-      { "value": 40, "color": "#e54f35" },
-      { "value": 42, "color": "#d7191c" },
-      { "value": 44, "color": "#ad0003" }
+      {
+        "value": 20,
+        "color": "#2b83ba"
+      },
+      {
+        "value": 22,
+        "color": "#59a4b2"
+      },
+      {
+        "value": 24,
+        "color": "#88c5aa"
+      },
+      {
+        "value": 26,
+        "color": "#b3e0a7"
+      },
+      {
+        "value": 28,
+        "color": "#d2edb0"
+      },
+      {
+        "value": 30,
+        "color": "#f0f9ba"
+      },
+      {
+        "value": 32,
+        "color": "#fff1ae"
+      },
+      {
+        "value": 34,
+        "color": "#fed38c"
+      },
+      {
+        "value": 36,
+        "color": "#feb669"
+      },
+      {
+        "value": 38,
+        "color": "#f3854e"
+      },
+      {
+        "value": 40,
+        "color": "#e54f35"
+      },
+      {
+        "value": 42,
+        "color": "#d7191c"
+      },
+      {
+        "value": 44,
+        "color": "#ad0003"
+      }
     ]
   },
   "lst_day_anomaly_5": {
@@ -948,15 +1657,42 @@
     },
     "legend_text": "LEGEND",
     "legend": [
-      { "value": -300.0, "color": "#000004" },
-      { "value": -200.0, "color": "#210c4a" },
-      { "value": -100.0, "color": "#57106e" },
-      { "value": -50.0, "color": "#8a226a" },
-      { "value": 50.0, "color": "#bc3754" },
-      { "value": 100.0, "color": "#e45a31" },
-      { "value": 200.0, "color": "#f98e09" },
-      { "value": 300.0, "color": "#f9cb35" },
-      { "value": 500.0, "color": "#fcffa4" }
+      {
+        "value": -300.0,
+        "color": "#000004"
+      },
+      {
+        "value": -200.0,
+        "color": "#210c4a"
+      },
+      {
+        "value": -100.0,
+        "color": "#57106e"
+      },
+      {
+        "value": -50.0,
+        "color": "#8a226a"
+      },
+      {
+        "value": 50.0,
+        "color": "#bc3754"
+      },
+      {
+        "value": 100.0,
+        "color": "#e45a31"
+      },
+      {
+        "value": 200.0,
+        "color": "#f98e09"
+      },
+      {
+        "value": 300.0,
+        "color": "#f9cb35"
+      },
+      {
+        "value": 500.0,
+        "color": "#fcffa4"
+      }
     ]
   },
   "lst_day_anomaly_1": {
@@ -971,15 +1707,42 @@
     },
     "legend_text": "LEGEND",
     "legend": [
-      { "value": -300.0, "color": "#000004" },
-      { "value": -200.0, "color": "#210c4a" },
-      { "value": -100.0, "color": "#57106e" },
-      { "value": -50.0, "color": "#8a226a" },
-      { "value": 50.0, "color": "#bc3754" },
-      { "value": 100.0, "color": "#e45a31" },
-      { "value": 200.0, "color": "#f98e09" },
-      { "value": 300.0, "color": "#f9cb35" },
-      { "value": 500.0, "color": "#fcffa4" }
+      {
+        "value": -300.0,
+        "color": "#000004"
+      },
+      {
+        "value": -200.0,
+        "color": "#210c4a"
+      },
+      {
+        "value": -100.0,
+        "color": "#57106e"
+      },
+      {
+        "value": -50.0,
+        "color": "#8a226a"
+      },
+      {
+        "value": 50.0,
+        "color": "#bc3754"
+      },
+      {
+        "value": 100.0,
+        "color": "#e45a31"
+      },
+      {
+        "value": 200.0,
+        "color": "#f98e09"
+      },
+      {
+        "value": 300.0,
+        "color": "#f9cb35"
+      },
+      {
+        "value": 500.0,
+        "color": "#fcffa4"
+      }
     ]
   },
   "lst_day_anomaly_blended": {
@@ -991,15 +1754,42 @@
     "opacity": 0.7,
     "legend_text": "Temperature anomaly based on long term average compared to local station data from INAM blended with MODIS daytime land surface temperature estimates",
     "legend": [
-      { "value": -300.0, "color": "#000004" },
-      { "value": -200.0, "color": "#210c4a" },
-      { "value": -100.0, "color": "#57106e" },
-      { "value": -50.0, "color": "#8a226a" },
-      { "value": 50.0, "color": "#bc3754" },
-      { "value": 100.0, "color": "#e45a31" },
-      { "value": 200.0, "color": "#f98e09" },
-      { "value": 300.0, "color": "#f9cb35" },
-      { "value": 500.0, "color": "#fcffa4" }
+      {
+        "value": -300.0,
+        "color": "#000004"
+      },
+      {
+        "value": -200.0,
+        "color": "#210c4a"
+      },
+      {
+        "value": -100.0,
+        "color": "#57106e"
+      },
+      {
+        "value": -50.0,
+        "color": "#8a226a"
+      },
+      {
+        "value": 50.0,
+        "color": "#bc3754"
+      },
+      {
+        "value": 100.0,
+        "color": "#e45a31"
+      },
+      {
+        "value": 200.0,
+        "color": "#f98e09"
+      },
+      {
+        "value": 300.0,
+        "color": "#f9cb35"
+      },
+      {
+        "value": 500.0,
+        "color": "#fcffa4"
+      }
     ]
   },
   "precip_blended_dekad": {
@@ -1014,19 +1804,59 @@
     "opacity": 0.7,
     "legend_text": "Local station data from INAM blended with CHIRP rainfall estimates",
     "legend": [
-      { "value": "-0", "color": "#ffffff", "alpha": 0 },
-      { "value": "1", "color": "#ffffff" },
-      { "value": "20", "color": "#faf5e6" },
-      { "value": "40", "color": "#faf3d2" },
-      { "value": "60", "color": "#dae3a1" },
-      { "value": "80", "color": "#a0c787" },
-      { "value": "100", "color": "#68ab79" },
-      { "value": "125", "color": "#9beafa" },
-      { "value": "150", "color": "#00b1de" },
-      { "value": "200", "color": "#005ae6" },
-      { "value": "250", "color": "#0000c8" },
-      { "value": "300", "color": "#a000fa" },
-      { "value": "350", "color": "#fa78fa" }
+      {
+        "value": "-0",
+        "color": "#ffffff",
+        "alpha": 0
+      },
+      {
+        "value": "1",
+        "color": "#ffffff"
+      },
+      {
+        "value": "20",
+        "color": "#faf5e6"
+      },
+      {
+        "value": "40",
+        "color": "#faf3d2"
+      },
+      {
+        "value": "60",
+        "color": "#dae3a1"
+      },
+      {
+        "value": "80",
+        "color": "#a0c787"
+      },
+      {
+        "value": "100",
+        "color": "#68ab79"
+      },
+      {
+        "value": "125",
+        "color": "#9beafa"
+      },
+      {
+        "value": "150",
+        "color": "#00b1de"
+      },
+      {
+        "value": "200",
+        "color": "#005ae6"
+      },
+      {
+        "value": "250",
+        "color": "#0000c8"
+      },
+      {
+        "value": "300",
+        "color": "#a000fa"
+      },
+      {
+        "value": "350",
+        "color": "#fa78fa"
+      }
     ]
   },
   "precip_blended_dekad_anomaly": {
@@ -1041,15 +1871,42 @@
     "opacity": 0.7,
     "legend_text": "Rainfall anomaly based on long term averaged from local station data from INAM blended with CHIRP rainfall estimates",
     "legend": [
-      { "value": "1%", "color": "#d79b0b" },
-      { "value": "60%", "color": "#e1b344" },
-      { "value": "80%", "color": "#ebcb7d" },
-      { "value": "90%", "color": "#f5e3b6" },
-      { "value": "110%", "color": "#f2f2f2" },
-      { "value": "120%", "color": "#b5e7fe" },
-      { "value": "140%", "color": "#7dd4fd" },
-      { "value": "180%", "color": "#45c1fc" },
-      { "value": "> 180%", "color": "#0fb0fb" }
+      {
+        "value": "1%",
+        "color": "#d79b0b"
+      },
+      {
+        "value": "60%",
+        "color": "#e1b344"
+      },
+      {
+        "value": "80%",
+        "color": "#ebcb7d"
+      },
+      {
+        "value": "90%",
+        "color": "#f5e3b6"
+      },
+      {
+        "value": "110%",
+        "color": "#f2f2f2"
+      },
+      {
+        "value": "120%",
+        "color": "#b5e7fe"
+      },
+      {
+        "value": "140%",
+        "color": "#7dd4fd"
+      },
+      {
+        "value": "180%",
+        "color": "#45c1fc"
+      },
+      {
+        "value": "> 180%",
+        "color": "#0fb0fb"
+      }
     ]
   },
   "precip_blended_dekad_agg": {
@@ -1064,17 +1921,50 @@
     },
     "legend_text": "Monthly aggregate rainfall based on local station data from INAM blended with CHIRP estimates",
     "legend": [
-      { "value": "50", "color": "#faf3d2" },
-      { "value": "100", "color": "#dae3a1" },
-      { "value": "150", "color": "#a0c787" },
-      { "value": "200", "color": "#68ab79" },
-      { "value": "250", "color": "#9beafa" },
-      { "value": "300", "color": "#00b1de" },
-      { "value": "400", "color": "#005ae6" },
-      { "value": "500", "color": "#0000c8" },
-      { "value": "600", "color": "#a000fa" },
-      { "value": "800", "color": "#fa78fa" },
-      { "value": "> 800", "color": "#ffc4ee" }
+      {
+        "value": "50",
+        "color": "#faf3d2"
+      },
+      {
+        "value": "100",
+        "color": "#dae3a1"
+      },
+      {
+        "value": "150",
+        "color": "#a0c787"
+      },
+      {
+        "value": "200",
+        "color": "#68ab79"
+      },
+      {
+        "value": "250",
+        "color": "#9beafa"
+      },
+      {
+        "value": "300",
+        "color": "#00b1de"
+      },
+      {
+        "value": "400",
+        "color": "#005ae6"
+      },
+      {
+        "value": "500",
+        "color": "#0000c8"
+      },
+      {
+        "value": "600",
+        "color": "#a000fa"
+      },
+      {
+        "value": "800",
+        "color": "#fa78fa"
+      },
+      {
+        "value": "> 800",
+        "color": "#ffc4ee"
+      }
     ]
   },
   "spi_1m": {

--- a/src/config/mozambique/prism.json
+++ b/src/config/mozambique/prism.json
@@ -13,7 +13,8 @@
   "serversUrls": {
     "wms": [
       "https://odc.ovio.org/wms",
-      "https://geonode.wfp.org/geoserver/prism/wms"
+      "https://geonode.wfp.org/geoserver/prism/wms",
+      "https://ows.digitalearth.africa/wms"
     ]
   },
   "map": {
@@ -63,7 +64,8 @@
         "lst_daytime_blended",
         "lst_day_anomaly_blended",
         "lst_daytime_5",
-        "lst_day_anomaly_5"
+        "lst_day_anomaly_5",
+        "lst_amplitude"
       ]
     },
     "tropical_storms": {

--- a/src/config/myanmar/layers.json
+++ b/src/config/myanmar/layers.json
@@ -528,21 +528,48 @@
     "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
     "type": "wms",
     "server_layer_name": "myd11a2_taa_dekad",
-    "content_path": "data/myanmar/contents.md#land-surface-temperature-amplitude",
     "base_url": "https://odc.ovio.org/",
+    "wcsConfig": {
+      "scale": 0.02,
+      "offset": 0,
+      "pixelResolution": 64
+    },
     "date_interval": "days",
     "opacity": 0.7,
-    "legend_text": "LEGEND",
+    "legend_text": "Land Surface Temperature Amplitude refers to the difference between the maximum and minimum temperature in degrees Celsius",
     "legend": [
-      { "label": "-0", "color": "#ffffff", "alpha": 0 },
-      { "label": "50", "color": "#ffffd9" },
-      { "label": "200", "color": "#e8f6b1" },
-      { "label": "400", "color": "#b2e1b6" },
-      { "label": "600", "color": "#64c3bf" },
-      { "label": "800", "color": "#2ca1c2" },
-      { "label": "1000", "color": "#216daf" },
-      { "label": "1200", "color": "#253a97" },
-      { "label": "1400", "color": "#081d58" }
+      {
+        "label": "1°",
+        "color": "#ffffd9"
+      },
+      {
+        "label": "4°",
+        "color": "#e8f6b1"
+      },
+      {
+        "label": "8°",
+        "color": "#b2e1b6"
+      },
+      {
+        "label": "12°",
+        "color": "#64c3bf"
+      },
+      {
+        "label": "16°",
+        "color": "#2ca1c2"
+      },
+      {
+        "label": "20°",
+        "color": "#216daf"
+      },
+      {
+        "label": "24°",
+        "color": "#253a97"
+      },
+      {
+        "label": "28°",
+        "color": "#081d58"
+      }
     ]
   },
   "lst_daytime": {

--- a/src/config/namibia/layers.json
+++ b/src/config/namibia/layers.json
@@ -764,19 +764,47 @@
     "type": "wms",
     "server_layer_name": "myd11a2_taa_dekad",
     "base_url": "https://odc.ovio.org/",
+    "wcsConfig": {
+      "scale": 0.02,
+      "offset": 0,
+      "pixelResolution": 64
+    },
     "date_interval": "days",
     "opacity": 0.7,
-    "legend_text": "LEGEND",
+    "legend_text": "Land Surface Temperature Amplitude refers to the difference between the maximum and minimum temperature in degrees Celsius",
     "legend": [
-      { "value": -0, "color": "#ffffff", "alpha": 0 },
-      { "value": 50, "color": "#ffffd9" },
-      { "value": 200, "color": "#e8f6b1" },
-      { "value": 400, "color": "#b2e1b6" },
-      { "value": 600, "color": "#64c3bf" },
-      { "value": 800, "color": "#2ca1c2" },
-      { "value": 1000, "color": "#216daf" },
-      { "value": 1200, "color": "#253a97" },
-      { "value": 1400, "color": "#081d58" }
+      {
+        "label": "1°",
+        "color": "#ffffd9"
+      },
+      {
+        "label": "4°",
+        "color": "#e8f6b1"
+      },
+      {
+        "label": "8°",
+        "color": "#b2e1b6"
+      },
+      {
+        "label": "12°",
+        "color": "#64c3bf"
+      },
+      {
+        "label": "16°",
+        "color": "#2ca1c2"
+      },
+      {
+        "label": "20°",
+        "color": "#216daf"
+      },
+      {
+        "label": "24°",
+        "color": "#253a97"
+      },
+      {
+        "label": "28°",
+        "color": "#081d58"
+      }
     ]
   },
   "lst_daytime_5": {

--- a/src/config/rbd/layers.json
+++ b/src/config/rbd/layers.json
@@ -1382,45 +1382,45 @@
     "type": "wms",
     "server_layer_name": "myd11a2_taa_dekad",
     "base_url": "https://odc.ovio.org/",
+    "wcsConfig": {
+      "scale": 0.02,
+      "offset": 0,
+      "pixelResolution": 64
+    },
     "date_interval": "days",
     "opacity": 0.7,
-    "legend_text": "LEGEND",
+    "legend_text": "Land Surface Temperature Amplitude refers to the difference between the maximum and minimum temperature in degrees Celsius",
     "legend": [
       {
-        "label": "-0",
-        "color": "#ffffff",
-        "alpha": 0
-      },
-      {
-        "label": "50",
+        "label": "1°",
         "color": "#ffffd9"
       },
       {
-        "label": "200",
+        "label": "4°",
         "color": "#e8f6b1"
       },
       {
-        "label": "400",
+        "label": "8°",
         "color": "#b2e1b6"
       },
       {
-        "label": "600",
+        "label": "12°",
         "color": "#64c3bf"
       },
       {
-        "label": "800",
+        "label": "16°",
         "color": "#2ca1c2"
       },
       {
-        "label": "1000",
+        "label": "20°",
         "color": "#216daf"
       },
       {
-        "label": "1200",
+        "label": "24°",
         "color": "#253a97"
       },
       {
-        "label": "1400",
+        "label": "28°",
         "color": "#081d58"
       }
     ]

--- a/src/config/sierraleone/layers.json
+++ b/src/config/sierraleone/layers.json
@@ -1369,40 +1369,45 @@
     "type": "wms",
     "server_layer_name": "myd11a2_taa_dekad",
     "base_url": "https://odc.ovio.org/",
+    "wcsConfig": {
+      "scale": 0.02,
+      "offset": 0,
+      "pixelResolution": 64
+    },
     "date_interval": "days",
     "opacity": 0.7,
-    "legend_text": "LEGEND",
+    "legend_text": "Land Surface Temperature Amplitude refers to the difference between the maximum and minimum temperature in degrees Celsius",
     "legend": [
       {
-        "label": "50",
+        "label": "1°",
         "color": "#ffffd9"
       },
       {
-        "label": "200",
+        "label": "4°",
         "color": "#e8f6b1"
       },
       {
-        "label": "400",
+        "label": "8°",
         "color": "#b2e1b6"
       },
       {
-        "label": "600",
+        "label": "12°",
         "color": "#64c3bf"
       },
       {
-        "label": "800",
+        "label": "16°",
         "color": "#2ca1c2"
       },
       {
-        "label": "1000",
+        "label": "20°",
         "color": "#216daf"
       },
       {
-        "label": "1200",
+        "label": "24°",
         "color": "#253a97"
       },
       {
-        "label": "1400",
+        "label": "28°",
         "color": "#081d58"
       }
     ]

--- a/src/config/srilanka/layers.json
+++ b/src/config/srilanka/layers.json
@@ -1405,40 +1405,45 @@
     "type": "wms",
     "server_layer_name": "myd11a2_taa_dekad",
     "base_url": "https://odc.ovio.org/",
+    "wcsConfig": {
+      "scale": 0.02,
+      "offset": 0,
+      "pixelResolution": 64
+    },
     "date_interval": "days",
     "opacity": 0.7,
-    "legend_text": "LEGEND",
+    "legend_text": "Land Surface Temperature Amplitude refers to the difference between the maximum and minimum temperature in degrees Celsius",
     "legend": [
       {
-        "label": "50",
+        "label": "1°",
         "color": "#ffffd9"
       },
       {
-        "label": "200",
+        "label": "4°",
         "color": "#e8f6b1"
       },
       {
-        "label": "400",
+        "label": "8°",
         "color": "#b2e1b6"
       },
       {
-        "label": "600",
+        "label": "12°",
         "color": "#64c3bf"
       },
       {
-        "label": "800",
+        "label": "16°",
         "color": "#2ca1c2"
       },
       {
-        "label": "1000",
+        "label": "20°",
         "color": "#216daf"
       },
       {
-        "label": "1200",
+        "label": "24°",
         "color": "#253a97"
       },
       {
-        "label": "1400",
+        "label": "28°",
         "color": "#081d58"
       }
     ]

--- a/src/config/tajikistan/layers.json
+++ b/src/config/tajikistan/layers.json
@@ -256,19 +256,47 @@
     "type": "wms",
     "server_layer_name": "myd11a2_taa_dekad",
     "base_url": "https://odc.ovio.org/",
+    "wcsConfig": {
+      "scale": 0.02,
+      "offset": 0,
+      "pixelResolution": 64
+    },
     "date_interval": "days",
     "opacity": 0.7,
-    "legend_text": "LEGEND",
+    "legend_text": "Land Surface Temperature Amplitude refers to the difference between the maximum and minimum temperature in degrees Celsius",
     "legend": [
-      { "value": -0, "color": "#ffffff", "alpha": 0 },
-      { "value": 50, "color": "#ffffd9" },
-      { "value": 200, "color": "#e8f6b1" },
-      { "value": 400, "color": "#b2e1b6" },
-      { "value": 600, "color": "#64c3bf" },
-      { "value": 800, "color": "#2ca1c2" },
-      { "value": 1000, "color": "#216daf" },
-      { "value": 1200, "color": "#253a97" },
-      { "value": 1400, "color": "#081d58" }
+      {
+        "label": "1°",
+        "color": "#ffffd9"
+      },
+      {
+        "label": "4°",
+        "color": "#e8f6b1"
+      },
+      {
+        "label": "8°",
+        "color": "#b2e1b6"
+      },
+      {
+        "label": "12°",
+        "color": "#64c3bf"
+      },
+      {
+        "label": "16°",
+        "color": "#2ca1c2"
+      },
+      {
+        "label": "20°",
+        "color": "#216daf"
+      },
+      {
+        "label": "24°",
+        "color": "#253a97"
+      },
+      {
+        "label": "28°",
+        "color": "#081d58"
+      }
     ]
   },
   "lst_daytime": {

--- a/src/config/zimbabwe/layers.json
+++ b/src/config/zimbabwe/layers.json
@@ -1387,40 +1387,45 @@
     "type": "wms",
     "server_layer_name": "myd11a2_taa_dekad",
     "base_url": "https://odc.ovio.org/",
+    "wcsConfig": {
+      "scale": 0.02,
+      "offset": 0,
+      "pixelResolution": 64
+    },
     "date_interval": "days",
     "opacity": 0.7,
-    "legend_text": "LEGEND",
+    "legend_text": "Land Surface Temperature Amplitude refers to the difference between the maximum and minimum temperature in degrees Celsius",
     "legend": [
       {
-        "label": "50",
+        "label": "1°",
         "color": "#ffffd9"
       },
       {
-        "label": "200",
+        "label": "4°",
         "color": "#e8f6b1"
       },
       {
-        "label": "400",
+        "label": "8°",
         "color": "#b2e1b6"
       },
       {
-        "label": "600",
+        "label": "12°",
         "color": "#64c3bf"
       },
       {
-        "label": "800",
+        "label": "16°",
         "color": "#2ca1c2"
       },
       {
-        "label": "1000",
+        "label": "20°",
         "color": "#216daf"
       },
       {
-        "label": "1200",
+        "label": "24°",
         "color": "#253a97"
       },
       {
-        "label": "1400",
+        "label": "28°",
         "color": "#081d58"
       }
     ]


### PR DESCRIPTION
This PR fixes missing WCS config information for the land surface temperature amplitude layer in all deployments. It also updates the legend labels and legend text