### PR TITLE
frontend EWS data

### DIFF
--- a/src/components/MapView/Layers/styles.ts
+++ b/src/components/MapView/Layers/styles.ts
@@ -7,6 +7,7 @@ export const circlePaint = (
   { opacity, legend }: CommonLayerProps,
   property: string = 'data',
 ): MapboxGL.CirclePaint => ({
+  'circle-radius': 8,
   'circle-opacity': opacity || 0.3,
   'circle-color': {
     property,

--- a/src/config/cambodia/layers.json
+++ b/src/config/cambodia/layers.json
@@ -1644,6 +1644,42 @@
     "legend_text": "",
     "base_url": "https://geonode.wfp.org/geoserver"
   },
+  "ews_remote": {
+    "title": "EWS sensor data",
+    "processing": "ews",
+    "type": "point_data",
+    "data": "",
+    "date_url": "",
+    "opacity": 0.8,
+    "data_field": "max",
+    "legend_text": "Sensor height",
+    "legend": [
+      {
+        "value": "200",
+        "color": "#7ab1c0"
+      },
+      {
+        "value": "250",
+        "color": "#9fc3b3"
+      },
+      {
+        "value": "300",
+        "color": "#d9e79a"
+      },
+      {
+        "value": "350",
+        "color": "#f3f88e"
+      },
+      {
+        "value": "400",
+        "color": "#f0d779"
+      },
+      {
+        "value": "1000",
+        "color": "#fdae61"
+      }
+    ]
+  },
   "kh_incident_report": {
     "title": "Disaster impact report",
     "type": "point_data",

--- a/src/config/cambodia/prism.json
+++ b/src/config/cambodia/prism.json
@@ -61,7 +61,8 @@
         "days_heavy_rain",
         "days_intense_rain",
         "days_extreme_rain",
-        "streak_heavy_rain"
+        "streak_heavy_rain",
+        "ews_remote"
       ]
     },
     "vegetation": {

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -390,6 +390,10 @@ export class ImpactLayerProps extends CommonLayerProps {
   api?: StatsApi;
 }
 
+export enum PointDataProcessing {
+  EWS = 'ews',
+}
+
 export class PointDataLayerProps extends CommonLayerProps {
   type: 'point_data';
   data: string;
@@ -420,6 +424,9 @@ export class PointDataLayerProps extends CommonLayerProps {
 
   @optional
   boundary?: LayerKey;
+
+  @optional
+  processing?: PointDataProcessing;
 }
 
 export type RequiredKeys<T> = {
@@ -524,4 +531,15 @@ export interface RequestFeatureInfo extends FeatureInfoType {
 
 type AdminLevelDisplayType = {
   adminCode: string;
+};
+
+export type PointData = {
+  lat: number;
+  lon: number;
+  date: number; // in unix time.
+  [key: string]: any;
+};
+
+export type PointLayerData = {
+  features: PointData[];
 };

--- a/src/context/layers/layer-data.ts
+++ b/src/context/layers/layer-data.ts
@@ -1,5 +1,9 @@
 import { createAsyncThunk, AsyncThunk } from '@reduxjs/toolkit';
-import { DiscriminateUnion, LayerType } from '../../config/types';
+import {
+  DiscriminateUnion,
+  LayerType,
+  PointLayerData,
+} from '../../config/types';
 import { Extent } from '../../components/MapView/Layers/raster-utils';
 
 import {
@@ -7,7 +11,7 @@ import {
   AdminLevelDataLayerData,
 } from './admin_level_data';
 import { fetchWCSLayerData, WMSLayerData } from './wms';
-import { fetchPointLayerData, PointLayerData } from './point_data';
+import { fetchPointLayerData } from './point_data';
 import { BoundaryLayerData, fetchBoundaryLayerData } from './boundary';
 import { fetchImpactLayerData, ImpactLayerData } from './impact';
 

--- a/src/utils/ews-utils.ts
+++ b/src/utils/ews-utils.ts
@@ -1,0 +1,111 @@
+import { FeatureCollection, Point } from 'geojson';
+import moment from 'moment';
+import { PointData } from '../config/types';
+
+const BASE_URL = 'http://sms.ews1294.info/api/v1';
+
+type statsEWS = {
+  max: number | null;
+  mean: number | null;
+  min: number | null;
+};
+
+/* eslint-disable camelcase */
+type EWSSensorData = {
+  location_id: number;
+  value: [string, number];
+};
+/* eslint-enable camelcase */
+
+export const createEWSDatesArray = (): number[] => {
+  const datesArray = [];
+  const endDate = moment(
+    moment().utcOffset('+0700').format('YYYY-MM-DD'),
+  ).valueOf(); // Asia/Phnom_Penh
+
+  const tempDate = moment('2021-01-01');
+  while (tempDate.valueOf() <= endDate) {
+    // eslint-disable-next-line fp/no-mutating-methods
+    datesArray.push(tempDate.valueOf());
+
+    tempDate.add(1, 'days');
+  }
+
+  return datesArray;
+};
+
+const fetchEWSLocations = async (): Promise<FeatureCollection> => {
+  const url = `${BASE_URL}/location.geojson?type=River`;
+
+  const resp = await fetch(url);
+  const featureCollection: FeatureCollection = await resp.json();
+
+  return featureCollection;
+};
+
+const fetchEWSDataPoints = async (date: number): Promise<EWSSensorData[]> => {
+  const momentDate = moment(date).utc();
+
+  const startDate = momentDate.startOf('day').format();
+  const endDate = momentDate.clone().endOf('day').format();
+
+  const url = `${BASE_URL}/sensors/sensor_event?start=${startDate}&end=${endDate}`;
+
+  const resp = await fetch(url);
+  const values: EWSSensorData[] = await resp.json();
+
+  return values;
+};
+
+const createEWSstats = (values: number[]): statsEWS => {
+  if (values.length === 0) {
+    return {
+      mean: null,
+      max: null,
+      min: null,
+    };
+  }
+
+  return {
+    mean: values.reduce((acc, item) => acc + item, 0) / values.length,
+    max: Math.max(...values),
+    min: Math.min(...values),
+  };
+};
+
+export const fetchEWSData = async (date: number): Promise<PointData[]> => {
+  const [locations, values] = await Promise.all([
+    fetchEWSLocations(),
+    fetchEWSDataPoints(date),
+  ]);
+
+  const processedFeatures: PointData[] = locations.features.reduce(
+    (pointDataArray, feature) => {
+      const { properties, geometry } = feature;
+
+      if (!properties) {
+        return pointDataArray;
+      }
+      const locationValues: number[] = values
+        .filter(v => v.location_id === properties.id)
+        .map(v => v.value[1]);
+
+      const statsProperties: statsEWS = createEWSstats(locationValues);
+
+      const { coordinates } = geometry as Point;
+
+      const pointData: PointData = {
+        lon: coordinates[0],
+        lat: coordinates[1],
+        date,
+        ...properties,
+        ...statsProperties,
+      };
+
+      return [...pointDataArray, pointData];
+    },
+    [] as PointData[],
+  );
+
+  return processedFeatures;
+};

--- a/src/utils/server-utils.ts
+++ b/src/utils/server-utils.ts
@@ -13,9 +13,11 @@ import {
   WMSLayerProps,
   FeatureInfoType,
   LabelType,
+  PointDataProcessing,
 } from '../config/types';
 import { queryParamsToString } from '../context/layers/point_data';
 import { DEFAULT_DATE_FORMAT } from './name-utils';
+import { createEWSDatesArray } from './ews-utils';
 
 // Note: PRISM's date picker is designed to work with dates in the UTC timezone
 // Therefore, ambiguous dates (dates passed as string e.g 2020-08-01) shouldn't be calculated from the user's timezone and instead be converted directly to UTC. Possibly with moment.utc(string)
@@ -238,6 +240,7 @@ async function getPointDataCoverage(layer: PointDataLayerProps) {
     fallbackData: fallbackUrl,
     id,
     additionalQueryParams,
+    processing,
   } = layer;
   const loadPointLayerDataFromURL = async (fetchUrl: string) => {
     // TODO - merge formatUrl and queryParamsToString
@@ -255,6 +258,11 @@ async function getPointDataCoverage(layer: PointDataLayerProps) {
     }
     return (await response.json()) as PointDataDates;
   };
+
+  if (processing === PointDataProcessing.EWS) {
+    return createEWSDatesArray();
+  }
+
   // eslint-disable-next-line fp/no-mutation
   const data = await (pointDataFetchPromises[url] =
     pointDataFetchPromises[url] || loadPointLayerDataFromURL(url)).catch(


### PR DESCRIPTION
This PR enables PRISM to read from EWS sms API. The information is displayed as a point data layer.
- On a given date, PRISM reads all values for each sensor, using the following request:
```
http://sms.ews1294.info/api/v1/sensors/sensor_event?start=2022-04-23T00:00:00Z&end=2022-04-23T23:59:59Z
```

Then, the mean, max and min statistics are computed for each location, which are included within the geojson locations. 

![image](https://user-images.githubusercontent.com/3285923/165395118-57faa337-f3a9-409f-9d9c-f735becc75ed.png)
