### PR TITLE
updated ubuntu version for circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
 
   build_api:
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-2004:202201-02
     steps:
       - checkout
 


### PR DESCRIPTION
This PR updates the Circle CI config to migrate from Ubuntu 16.04 to 20.04
https://circleci.com/docs/2.0/images/linux-vm/16.04-to-20.04-migration/
