### PR TITLE
Add portuguese date locale

### DIFF
--- a/src/config/mozambique/translation.json
+++ b/src/config/mozambique/translation.json
@@ -1,5 +1,5 @@
 {
-    "date_locale": "eu",
+    "date_locale": "pt",
     "Hazards": "Riscos",
     "Precipitation products": "Produtos de precipitação",
     "10-day rainfall estimate (mm)": "Estimativa de precipitação a 10 dias (mm)",

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -5,9 +5,10 @@ import { extendMoment } from 'moment-range';
 import { initReactI18next, useTranslation } from 'react-i18next';
 import { registerLocale } from 'react-datepicker';
 import { useCallback } from 'react';
+import en from 'date-fns/locale/en-US';
 import fr from 'date-fns/locale/fr';
 import km from 'date-fns/locale/km';
-import en from 'date-fns/locale/en-US';
+import pt from 'date-fns/locale/pt';
 import { translation } from './config';
 import 'moment/locale/km';
 
@@ -17,6 +18,7 @@ const TRANSLATION_DEBUG = false;
 registerLocale('en', en);
 registerLocale('fr', fr);
 registerLocale('km', km);
+registerLocale('pt', pt);
 export const moment = extendMoment(Moment as any);
 moment.locale('en');
 


### PR DESCRIPTION
This PR adds the missing 'pt' locale and implements it in the Mozambique translation configuration