### PR TITLE
Multiple layers url

### DIFF
--- a/src/components/MapView/Layers/PointDataLayer/index.tsx
+++ b/src/components/MapView/Layers/PointDataLayer/index.tsx
@@ -8,7 +8,10 @@ import {
   LayerData,
   loadLayerData,
 } from '../../../../context/layers/layer-data';
-import { layerDataSelector } from '../../../../context/mapStateSlice/selectors';
+import {
+  layerDataSelector,
+  mapSelector,
+} from '../../../../context/mapStateSlice/selectors';
 import { useDefaultDate } from '../../../../utils/useDefaultDate';
 import { getFeatureInfoPropsData } from '../../utils';
 import { getBoundaryLayerSingleton } from '../../../../config/utils';
@@ -30,16 +33,21 @@ function PointDataLayer({ layer }: { layer: PointDataLayerProps }) {
     | undefined;
   const dispatch = useDispatch();
 
+  const map = useSelector(mapSelector);
+
   const { data } = layerData || {};
   const { features } = data || {};
   const { t } = useSafeTranslation();
+
+  const { id: layerId } = layer;
+
   useEffect(() => {
     if (!features) {
       dispatch(loadLayerData({ layer, date: selectedDate }));
     }
   }, [features, dispatch, layer, selectedDate]);
 
-  if (!features) {
+  if (!features || map?.getSource(layerId)) {
     return null;
   }
 
@@ -80,7 +88,7 @@ function PointDataLayer({ layer }: { layer: PointDataLayerProps }) {
     return (
       <GeoJSONLayer
         before={`layer-${boundaryId}-line`}
-        id={`layer-${layer.id}`}
+        id={layerId}
         data={features}
         fillPaint={fillPaintData(layer, layer.dataField)}
         fillOnClick={onClickFunc}
@@ -90,7 +98,7 @@ function PointDataLayer({ layer }: { layer: PointDataLayerProps }) {
   return (
     <GeoJSONLayer
       before={`layer-${boundaryId}-line`}
-      id={`layer-${layer.id}`}
+      id={layerId}
       data={features}
       circleLayout={circleLayout}
       circlePaint={circlePaint(layer, layer.dataField)}

--- a/src/components/MapView/index.tsx
+++ b/src/components/MapView/index.tsx
@@ -283,7 +283,7 @@ function MapView({ classes }: MapViewProps) {
 
     const dateInt = moment(urlDate).valueOf();
 
-    if (urlDate === null || dateInt === selectedDate) {
+    if (!urlDate || dateInt === selectedDate) {
       return;
     }
 

--- a/src/components/MapView/index.tsx
+++ b/src/components/MapView/index.tsx
@@ -42,7 +42,7 @@ import {
 } from '../../config/types';
 
 import { Extent } from './Layers/raster-utils';
-import { useUrlHistory } from '../../utils/url-utils';
+import { useUrlHistory, UrlLayerKey, getUrlKey } from '../../utils/url-utils';
 
 import {
   LayerDefinitions,
@@ -208,11 +208,8 @@ function MapView({ classes }: MapViewProps) {
       status is also updated. There are guards in case the values are not valid, such as invalid
       date or layerids.
       */
-    const HAZARD_LAYER_PARAM = 'hazardLayerId';
-    const BASELINE_LAYER_PARAM = 'baselineLayerId';
-
-    const hazardLayerIds = urlParams.get(HAZARD_LAYER_PARAM);
-    const baselineLayerId = urlParams.get(BASELINE_LAYER_PARAM);
+    const hazardLayerIds = urlParams.get(UrlLayerKey.HAZARD);
+    const baselineLayerId = urlParams.get(UrlLayerKey.ADMINLEVEL);
 
     /*
       In case we don't have hazard or baseline layers we will use the default
@@ -224,10 +221,7 @@ function MapView({ classes }: MapViewProps) {
       if (defaultLayer) {
         if (Object.keys(LayerDefinitions).includes(defaultLayer)) {
           const layer = LayerDefinitions[defaultLayer as LayerKey];
-          const urlLayerKey =
-            layer.type === 'admin_level_data'
-              ? BASELINE_LAYER_PARAM
-              : HAZARD_LAYER_PARAM;
+          const urlLayerKey: UrlLayerKey = getUrlKey(layer);
           updateHistory(urlLayerKey, defaultLayer);
         } else if (!defaultLayerAttempted) {
           dispatch(
@@ -255,7 +249,7 @@ function MapView({ classes }: MapViewProps) {
 
     const urlLayerIds = [
       ...hazardLayersArray,
-      ...(baselineLayerId === null ? [] : baselineLayerId),
+      ...(baselineLayerId === null ? [] : [baselineLayerId]),
     ];
 
     // Check for invalid layer ids.

--- a/src/components/NavBar/MenuSwitch/SwitchItem/index.tsx
+++ b/src/components/NavBar/MenuSwitch/SwitchItem/index.tsx
@@ -37,8 +37,8 @@ function SwitchItem({ classes, layer }: SwitchItemProps) {
   const {
     updateHistory,
     removeKeyFromUrl,
-    appendHazardLayerToUrl,
-    removeHazardLayerFromUrl,
+    appendLayerToUrl,
+    removeLayerFromUrl,
   } = useUrlHistory();
 
   const { id: layerId, title: layerTitle, group } = layer;
@@ -80,7 +80,11 @@ function SwitchItem({ classes, layer }: SwitchItemProps) {
     const urlLayerKey = getUrlKey(selectedLayer);
 
     if (checked) {
-      const updatedUrl = appendHazardLayerToUrl(selectedLayers, selectedLayer);
+      const updatedUrl = appendLayerToUrl(
+        urlLayerKey,
+        selectedLayers,
+        selectedLayer,
+      );
 
       updateHistory(urlLayerKey, updatedUrl);
 
@@ -92,7 +96,7 @@ function SwitchItem({ classes, layer }: SwitchItemProps) {
         safeDispatchAddLayer(map, defaultBoundary, dispatch);
       }
     } else {
-      const updatedUrl = removeHazardLayerFromUrl(selectedLayer.id);
+      const updatedUrl = removeLayerFromUrl(urlLayerKey, selectedLayer.id);
 
       if (updatedUrl === '') {
         removeKeyFromUrl(urlLayerKey);

--- a/src/utils/url-utils.ts
+++ b/src/utils/url-utils.ts
@@ -38,11 +38,12 @@ export const useUrlHistory = () => {
     replace({ search: '' });
   };
 
-  const appendHazardLayerToUrl = (
+  const appendLayerToUrl = (
+    layerKey: UrlLayerKey,
     selectedLayers: LayerType[],
     layer: LayerType,
   ): string => {
-    const urlLayers = urlParams.get(UrlLayerKey.HAZARD);
+    const urlLayers = urlParams.get(layerKey);
 
     const selectedLayersUrl = urlLayers !== null ? urlLayers.split(',') : [];
 
@@ -58,8 +59,11 @@ export const useUrlHistory = () => {
     return updatedUrl.join(',');
   };
 
-  const removeHazardLayerFromUrl = (layerId: string): string => {
-    const urlLayers = urlParams.get(UrlLayerKey.HAZARD);
+  const removeLayerFromUrl = (
+    layerKey: UrlLayerKey,
+    layerId: string,
+  ): string => {
+    const urlLayers = urlParams.get(layerKey);
 
     const selectedLayersUrl = urlLayers !== null ? urlLayers.split(',') : [];
 
@@ -98,7 +102,7 @@ export const useUrlHistory = () => {
   const removeKeyFromUrl = (key: string) => {
     urlParams.delete(key);
 
-    if (key === 'hazardLayerId') {
+    if (key === UrlLayerKey.HAZARD) {
       urlParams.delete('date');
     }
 
@@ -113,8 +117,8 @@ export const useUrlHistory = () => {
     updateAnalysisParams,
     resetAnalysisParams,
     getAnalysisParams,
-    appendHazardLayerToUrl,
-    removeHazardLayerFromUrl,
+    appendLayerToUrl,
+    removeLayerFromUrl,
   };
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5634,9 +5634,9 @@ events@^3.0.0:
   integrity sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg==
 
 eventsource@^1.0.7:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/eventsource/-/eventsource-1.0.7.tgz#8fbc72c93fcd34088090bc0a4e64f4b5cee6d8d0"
-  integrity sha512-4Ln17+vVT0k8aWq+t/bF5arcS3EpT9gYtW66EPacdj/mAFevznsnyoHLPy2BA8gbIQeIHoPsvwmfBftfcG//BQ==
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/eventsource/-/eventsource-1.1.1.tgz#4544a35a57d7120fba4fa4c86cb4023b2c09df2f"
+  integrity sha512-qV5ZC0h7jYIAOhArFJgSfdyz6rALJyb270714o7ZtNnw2WSJ+eexhKtE0O8LYPRsHZHf2osHKZBxGPvm3kPkCA==
   dependencies:
     original "^1.0.0"
 


### PR DESCRIPTION
This PR modifies PRISM to include multiple HazardLayers of different types (point, WMS) within the url.

**How to test:** Using Cambodia deployment
- Select a PointDataLayer, i.e. EWS 1294 river level data.
- Select a WMSLayer, 3-month rainfall aggregate (mm).

The url parameter **hazardlayerids** will have both layer ids. In case user selects another layer with the same type of a previously selected, PRISM will do an id replace.

![image](https://user-images.githubusercontent.com/3285923/176416187-86026e94-caaf-4392-ab40-c529c0d4ae4f.png)


closes #403 