### PR TITLE
remove scale label parameter in chart config if x-axis is undefined

### DIFF
--- a/src/components/DataDrawer/Chart/index.tsx
+++ b/src/components/DataDrawer/Chart/index.tsx
@@ -36,10 +36,14 @@ function getChartConfig(stacked: boolean, title: string, xAxisLabel?: string) {
           ticks: {
             fontColor: '#CCC',
           },
-          scaleLabel: xAxisLabel && {
-            labelString: xAxisLabel,
-            display: true,
-          },
+          ...(xAxisLabel
+            ? {
+                scaleLabel: {
+                  labelString: xAxisLabel,
+                  display: true,
+                },
+              }
+            : {}),
         },
       ],
       yAxes: [


### PR DESCRIPTION
This PR fixes a bug where running an analysis followed by clicking on an layer with a chart associated with it causes an error. 