### PR TITLE
Fix for "Allow PRISM build to be served from a subfolder"

### DIFF
--- a/src/context/analysisResultStateSlice.ts
+++ b/src/context/analysisResultStateSlice.ts
@@ -105,9 +105,7 @@ function getAdminBoundariesURL() {
   if (isLocalhost) {
     return defaultBoundariesPath;
   }
-  // the regex here removes the dot(s) at the beginning of a path, if there is at least one.
-  // e.g the path might be ' ./data/xxx '  instead of ' /data/xxx '
-  return window.location.origin + adminBoundariesPath.replace(/^\.+/, '');
+  return window.location.origin + window.location.pathname + adminBoundariesPath;
 }
 
 function generateTableFromApiData(

--- a/src/context/analysisResultStateSlice.ts
+++ b/src/context/analysisResultStateSlice.ts
@@ -105,7 +105,9 @@ function getAdminBoundariesURL() {
   if (isLocalhost) {
     return defaultBoundariesPath;
   }
-  return window.location.origin + window.location.pathname + adminBoundariesPath;
+  return (
+    window.location.origin + window.location.pathname + adminBoundariesPath
+  );
 }
 
 function generateTableFromApiData(


### PR DESCRIPTION
Sorry I forgot to check the "Run Analysis" in deployed URL for PR #474 (it has been merged now). The feature will not be working if it's served from a subfolder. This should fix it.

Deployed here: http://prism-sub-4.surge.sh/subfolder/build