### PR TITLE
Fix typing

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -99,7 +99,7 @@ const configMap = {
 
 type Country = keyof typeof configMap;
 
-const DEFAULT: Country = 'cuba';
+const DEFAULT: Country = 'myanmar';
 
 const { REACT_APP_COUNTRY: COUNTRY } = process.env;
 const safeCountry =

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 import { has, get } from 'lodash';
 
 import { PublicClientApplication } from '@azure/msal-browser';
@@ -99,15 +100,23 @@ const configMap = {
 
 type Country = keyof typeof configMap;
 
-const DEFAULT: Country = 'myanmar';
+const DEFAULT: Country = 'cuba';
 
 const { REACT_APP_COUNTRY: COUNTRY } = process.env;
 const safeCountry =
   COUNTRY && has(configMap, COUNTRY) ? (COUNTRY as Country) : DEFAULT;
 
-const { appConfig, defaultBoundariesFile, rawLayers, rawTables } = configMap[
-  safeCountry
-];
+const {
+  appConfig,
+  defaultBoundariesFile,
+  rawLayers,
+  rawTables,
+}: {
+  appConfig: Record<string, any>;
+  defaultBoundariesFile: string;
+  rawLayers: Record<string, any>;
+  rawTables: Record<string, any>;
+} = configMap[safeCountry];
 
 const translation = get(configMap[safeCountry], 'translation', {});
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 import { has, get } from 'lodash';
 
 import { PublicClientApplication } from '@azure/msal-browser';

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -18,7 +18,13 @@ export type LayerType =
   | ImpactLayerProps
   | PointDataLayerProps;
 
-export type LayerKey = keyof typeof rawLayers;
+type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (
+  k: infer I,
+) => void
+  ? I
+  : never;
+
+export type LayerKey = keyof UnionToIntersection<typeof rawLayers>;
 
 type MenuGroupItem = {
   id: string;


### PR DESCRIPTION
Fix #231 

Converting the union type to an intersection for supporting multiple countries.
```
type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (
  k: infer I,
) => void
  ? I
  : never;
  
export type LayerKey = keyof UnionToIntersection<typeof rawLayers>;
```

Small Fix to typing of LayerKey #231