### PR TITLE
Enhance "go to" feature

### DIFF
--- a/src/components/MapView/Layers/BoundaryDropdown.tsx
+++ b/src/components/MapView/Layers/BoundaryDropdown.tsx
@@ -199,6 +199,7 @@ function SimpleBoundaryDropdown({
   setSelectedBoundaries,
   labelMessage,
   selectAll,
+  onlyNewCategory,
   ...rest
 }: BoundaryDropdownProps) {
   const { t, i18n: i18nLocale } = useSafeTranslation();
@@ -279,12 +280,16 @@ function SimpleBoundaryDropdown({
                       categoryValues.includes(val),
                     ).length === categoryValues.length;
 
+                  const newBoundariesValue = onlyNewCategory
+                    ? categoryValues
+                    : [...selectedBoundaries, ...categoryValues];
+
                   setSelectedBoundaries(
                     areAllChildrenSelected
                       ? selectedBoundaries.filter(
                           val => !categoryValues.includes(val),
                         )
-                      : [...selectedBoundaries, ...categoryValues],
+                      : newBoundariesValue,
                     true,
                   );
                 }}
@@ -312,6 +317,7 @@ interface BoundaryDropdownProps {
   selectedBoundaries: string[];
   setSelectedBoundaries: (boundaries: string[], appendMany?: boolean) => void;
   labelMessage?: string;
+  onlyNewCategory?: boolean;
   selectAll: boolean;
 }
 
@@ -396,6 +402,7 @@ export const GotoBoundaryDropdown = () => {
       <ButtonStyleBoundaryDropdown
         selectedBoundaries={boundaries}
         selectAll={false}
+        onlyNewCategory
         labelMessage={t('Go To')}
         className={styles.formControl}
         setSelectedBoundaries={(newSelectedBoundaries, appendMany) => {

--- a/src/components/MapView/Layers/BoundaryDropdown.tsx
+++ b/src/components/MapView/Layers/BoundaryDropdown.tsx
@@ -75,6 +75,9 @@ const useStyles = makeStyles((theme: Theme) => ({
     alignSelf: 'end',
     marginBottom: '0.4em',
   },
+  list: {
+    '& .Mui-selected': { backgroundColor: '#ADD8E6' },
+  },
 }));
 const TIMEOUT_ANIMATION_DELAY = 10;
 const SearchField = forwardRef(
@@ -202,6 +205,7 @@ function SimpleBoundaryDropdown({
   onlyNewCategory,
   ...rest
 }: BoundaryDropdownProps) {
+  const styles = useStyles();
   const { t, i18n: i18nLocale } = useSafeTranslation();
   const [search, setSearch] = useState('');
 
@@ -229,6 +233,9 @@ function SimpleBoundaryDropdown({
       <InputLabel>{labelMessage}</InputLabel>
       <Select
         multiple
+        MenuProps={{
+          classes: { list: styles.list },
+        }}
         onClose={() => {
           // empty search so that component shows correct options
           // otherwise, we would only show selected options which satisfy the search

--- a/src/components/MapView/Layers/BoundaryDropdown.tsx
+++ b/src/components/MapView/Layers/BoundaryDropdown.tsx
@@ -75,8 +75,10 @@ const useStyles = makeStyles((theme: Theme) => ({
     alignSelf: 'end',
     marginBottom: '0.4em',
   },
-  list: {
-    '& .Mui-selected': { backgroundColor: '#ADD8E6' },
+  root: {
+    '&$selected': {
+      backgroundColor: '#ADD8E6',
+    },
   },
 }));
 const TIMEOUT_ANIMATION_DELAY = 10;
@@ -233,9 +235,6 @@ function SimpleBoundaryDropdown({
       <InputLabel>{labelMessage}</InputLabel>
       <Select
         multiple
-        MenuProps={{
-          classes: { list: styles.list },
-        }}
         onClose={() => {
           // empty search so that component shows correct options
           // otherwise, we would only show selected options which satisfy the search
@@ -307,7 +306,11 @@ function SimpleBoundaryDropdown({
               </ClickableListSubheader>
             ) : null,
             ...category.children.map(({ label, value }) => (
-              <MenuItem key={value} value={value}>
+              <MenuItem
+                classes={{ root: styles.root }}
+                key={value}
+                value={value}
+              >
                 {label}
               </MenuItem>
             )),

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -108,9 +108,17 @@ const { REACT_APP_COUNTRY: COUNTRY } = process.env;
 const safeCountry =
   COUNTRY && has(configMap, COUNTRY) ? (COUNTRY as Country) : DEFAULT;
 
-const { appConfig, defaultBoundariesFile, rawLayers, rawTables } = configMap[
-  safeCountry
-];
+const {
+  appConfig,
+  defaultBoundariesFile,
+  rawLayers,
+  rawTables,
+}: {
+  appConfig: Record<string, any>;
+  defaultBoundariesFile: string;
+  rawLayers: Record<string, any>;
+  rawTables: Record<string, any>;
+} = configMap[safeCountry];
 
 const translation = get(configMap[safeCountry], 'translation', {});
 

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -18,7 +18,13 @@ export type LayerType =
   | ImpactLayerProps
   | PointDataLayerProps;
 
-export type LayerKey = keyof typeof rawLayers;
+type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (
+  k: infer I,
+) => void
+  ? I
+  : never;
+
+export type LayerKey = keyof UnionToIntersection<typeof rawLayers>;
 
 type MenuGroupItem = {
   id: string;


### PR DESCRIPTION
When we reselect admin level 1 in `Go To` feature we need only values from new admin level 1, but at the moment we added new admin level 1 to array and it's works wrong

Fix it by adding new props and now when we reselect admin level 1, we rewrite array using only selected data

now it works like that
https://user-images.githubusercontent.com/90055175/178262031-70bceffe-5113-4de8-8d09-7f2873436767.mov

