### PR TITLE
issue-413: updated .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,15 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
 # Dependencies
-/node_modules
+node_modules
 /.pnp
 .pnp.js
 
 # Testing
-/coverage
+coverage
 
 # Production
-/build
+build
 
 # Misc
 .DS_Store


### PR DESCRIPTION
I updated .gitignore in order to exclude the following in any folder: node_modules, build, and coverage.  This is done in anticipation of creating a website folder per #413 .  For example, running `yarn install` in `prism-frontend/website` will create a node_modules folder at `prism-frontend/website/node_modules` and the current .gitignore would permit tracking of this new node_modules folder because it isn't at root.

Happy to answer any questions or discuss any concerns.