### PR TITLE
Increase timeout on flaky test step

### DIFF
--- a/api/prism_app/report.py
+++ b/api/prism_app/report.py
@@ -70,9 +70,9 @@ async def download_report(
         flood_extent_checkbox = page.get_by_role("checkbox", name="Flood extent")
         await expect(flood_extent_checkbox).to_be_visible(timeout=20_000)
 
-        # the switch status is flaky (sometimes checked, sometimes not)
-        # FIXME: this fails because the layer is not activated even though it appears in the url
-        await expect(flood_extent_checkbox).to_be_checked(timeout=20_000)
+        # very long timeout to prevent flakiness in this step that relies heavily
+        # on network bandwidth.
+        await expect(flood_extent_checkbox).to_be_checked(timeout=60_000)
         await expect(
             page.get_by_role("button", name="Exposure Analysis")
         ).not_to_be_disabled()


### PR DESCRIPTION
### Description

This should fix flakiness in the api test with `playwright`. Like in `cypress` tests, the map loading step is very slow in CI, probably because runners are heavily throttled in network (and CPU?). When testing locally with throttled network, the test fails in the same spot.
This should be sufficient to make it pass pretty much all the time.

## How to test the feature:

- [ ] Just run CI, the api test should not fail.

## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [ ] `REACT_APP_COUNTRY=rbd yarn start`
- [ ] `REACT_APP_COUNTRY=cambodia yarn start`
- [ ] `REACT_APP_COUNTRY=mozambique yarn start`
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

## Screenshot/video of feature:
