### PR TITLE
Add AA drought config; COUNTRY=tanzania

### DIFF
--- a/frontend/src/components/MapView/LeftPanel/AnticipatoryActionPanel/AnticipatoryActionDroughtPanel/utils/countryConfig.ts
+++ b/frontend/src/components/MapView/LeftPanel/AnticipatoryActionPanel/AnticipatoryActionDroughtPanel/utils/countryConfig.ts
@@ -183,6 +183,22 @@ const AADROUGHT_COUNTRY_CONFIGS: Record<string, AADroughtCountryConfig> = {
         'uses seasonal forecasts from ECMWF with longer lead time for preparedness (Ready phase) and shorter lead times for activation and mobilization (Set & Go! phases).',
     },
   }),
+  tanzania: createCountryConfig({
+    categories: [
+      { label: 'Severe', id: 'Severe' },
+      { label: 'Moderate', id: 'Moderate' },
+      { label: 'Mild', id: 'Mild' },
+      { label: 'Below Normal', id: 'Normal' },
+    ],
+    seasonStartMonth: 6,
+    forecastSource: 'ECMWF',
+    customContent: {
+      howToReadContent: [
+        { title: 'OND', text: 'October to December' },
+        { title: 'MAM', text: 'March to May' },
+      ],
+    },
+  }),
   zambia: createCountryConfig({
     singleWindowMode: true,
     categories: [{ label: 'Moderate', id: 'Moderate' }],

--- a/frontend/src/config/tanzania/index.ts
+++ b/frontend/src/config/tanzania/index.ts
@@ -3,7 +3,14 @@ import rawLayers from './layers.json';
 
 const rawTables = {};
 const rawReports = {};
-const translation = {};
+
+// Temp: hack for window labels
+const translation = {
+  en: {
+    'Window 1': 'OND',
+    'Window 2': 'MAM',
+  },
+};
 
 export default {
   appConfig,

--- a/frontend/src/config/tanzania/prism.json
+++ b/frontend/src/config/tanzania/prism.json
@@ -1,6 +1,8 @@
 {
   "country": "Tanzania",
   "countryAdmin0Id": 257,
+  "anticipatoryActionDroughtUrl": "https://data.earthobservation.vam.wfp.org/public-share/aa/staging/aa_probabilities_triggers_tza.csv",
+  "anticipatoryActionDroughtStagingUrl": "https://data.earthobservation.vam.wfp.org/public-share/aa/staging/aa_probabilities_triggers_tza.csv",
   "alertFormActive": false,
   "enableNavigationDropdown": true,
   "serversUrls": {


### PR DESCRIPTION
### Description

Add AA drought setup for Tanzania for an upcoming demo

## How to test the feature:

- [ ] `REACT_APP_COUNTRY=tanzania yarn start`
- [ ] go to the A. Action Drought module
- [ ] verify the module loads and districts are classified based on available forecast data in Nov 2024

## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [ ] `REACT_APP_COUNTRY=rbd yarn start`
- [ ] `REACT_APP_COUNTRY=cambodia yarn start`
- [ ] `REACT_APP_COUNTRY=mozambique yarn start`
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

## Screenshot/video of feature:
<img width="3024" height="1648" alt="Screenshot 2025-10-30 at 19 41 59" src="https://github.com/user-attachments/assets/d64cb970-5fdc-4f26-8734-942b1bfa9201" />
