### PR TITLE
Caching analysis results

### DIFF
--- a/frontend/src/components/DashboardView/TableBlock.tsx
+++ b/frontend/src/components/DashboardView/TableBlock.tsx
@@ -96,7 +96,6 @@ function TableBlock({
     initialStartDate,
     initialThreshold,
     initialStat,
-    useCache: true,
   });
 
   const { runAnalyser } = useAnalysisExecution(formState, {

--- a/frontend/src/context/analysisResultStateSlice.ts
+++ b/frontend/src/context/analysisResultStateSlice.ts
@@ -365,7 +365,7 @@ export type AnalysisDispatchParams = {
   date: ReturnType<Date['getTime']>; // just a hint to developers that we give a date number here, not just any number
   statistic: AggregationOperations; // we might have to deviate from this if analysis accepts more than what this enum provides
   exposureValue: ExposureValue;
-  useCache?: boolean; // If true, use cache if available, otherwise fetch fresh data
+  useCache?: boolean; // Optional bypass, defaults to true
 };
 
 export type PolygonAnalysisDispatchParams = {
@@ -377,7 +377,7 @@ export type PolygonAnalysisDispatchParams = {
   // just a hint to developers that we give a date number here, not just any number
   startDate: ReturnType<Date['getTime']>;
   endDate: ReturnType<Date['getTime']>;
-  useCache?: boolean; // If true, use cache if available, otherwise fetch fresh data
+  useCache?: boolean; // Optional bypass, defaults to true
 };
 
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours

--- a/frontend/src/utils/analysis-hooks.ts
+++ b/frontend/src/utils/analysis-hooks.ts
@@ -172,7 +172,7 @@ export const useAnalysisForm = (
     initialStartDate,
     initialThreshold,
     initialStat,
-    useCache = false,
+    useCache = true,
   } = options;
 
   const dispatch = useDispatch();


### PR DESCRIPTION
### Description

This adds an opt-in cache to our analysis results, specifically for use in the table block, which is oftentimes unmounted and re-rendered several times in quick succession, as the user moves from edit view to dashboard view to print and back and forth. Because the analysis panel does not have the use cache enabled, its flow is not changed. 

We keep this cache valid for 5 minutes, after which we'll refresh the results the next time `runAnalyzer` is called. 
We also only allow 4 results to be stored in our cache at any time to reduce risk of memory issues. 

## Screenshot/video of feature:
https://www.loom.com/share/48050f1ac83545b385a342404b03f1d3