### PR TITLE
Handle analysis errors + fix zones url

### DIFF
--- a/frontend/src/context/analysisResultStateSlice.ts
+++ b/frontend/src/context/analysisResultStateSlice.ts
@@ -1137,6 +1137,10 @@ export const isDataTableDrawerActiveSelector = (state: RootState): boolean =>
 export const invertedColorsSelector = (state: RootState): boolean =>
   state.analysisResultState.invertedColors!!;
 
+export const analysisResultErrorSelector = (
+  state: RootState,
+): string | undefined => state.analysisResultState.error;
+
 // Setters
 export const {
   setIsMapLayerActive,


### PR DESCRIPTION
### Description

This PR addresses an error in which an incorrect zone URL was being used on dashboards for the stats request. It also adds better error and loading management within the table block. Now we only retry an analysis request three times from the table block, then we show an error state. This PR also adds an initial render view before the loading state starts that was previously showing a confusing prompt to configure (that was unnecessary). 