### PR TITLE
CI - run QA deploy in parallel

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -131,7 +131,6 @@ jobs:
           CYPRESS_DEFAULT_COMMAND_TIMEOUT: 10000
 
   frontend_build_and_deploy:
-    needs: frontend_tests
     if: github.event_name != 'push'
     name: frontend_build_and_deploy
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description

This is a small tweak to run the QA deploy in parallel instead of waiting for all the tests to run first.
It might fail from time to time but would give us a speedier delivery of QA endpoints.

<!-- what this does -->

## How to test the feature:

- [ ]
- [ ]

## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [ ] `REACT_APP_COUNTRY=rbd yarn start`
- [ ] `REACT_APP_COUNTRY=cambodia yarn start`
- [ ] `REACT_APP_COUNTRY=mozambique yarn start`
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

## Screenshot/video of feature:
