### PR TITLE
Fix date comparison in moz e2e test

### DIFF
--- a/frontend/cypress/e2e/mozambique.cy.ts
+++ b/frontend/cypress/e2e/mozambique.cy.ts
@@ -36,8 +36,8 @@ describe('Loading dates', () => {
           .should('match', /^[A-Z][a-z]{2} \d{1,2}, \d{4}$/)
           .as('aaDate')
           .then(function () {
-            const firstDate = new Date(this.initialDate).getDate();
-            const secondDate = new Date(this.aaDate).getDate();
+            const firstDate = new Date(this.initialDate).getTime();
+            const secondDate = new Date(this.aaDate).getTime();
             expect(secondDate).to.be.greaterThan(firstDate);
           });
       },


### PR DESCRIPTION
### Description

This test had been comparing the day of the month, where we actually wanted to compare the actual date was bigger than another date. The result of this was that the test would fail on the first of the month. This fix changes it so the actual dates are compared rather than the day of the month. 

