### PR TITLE
Handle display date selection edge case for forecasts

### DIFF
--- a/frontend/src/components/MapView/DateSelector/index.tsx
+++ b/frontend/src/components/MapView/DateSelector/index.tsx
@@ -238,9 +238,10 @@ const DateSelector = memo(() => {
         if (firstIndex === -1) {
           return layer.dateItems;
         }
-        // truncate the date item array at index matching timeline first date with a buffer of 1 day decrements
-
-        return layer.dateItems.slice(firstIndex - 1);
+        // Truncate the date item array at index matching timeline first date with a buffer of 1 day.
+        // Use Math.max to prevent negative indices - when firstIndex is 0, slice(-1) would
+        // incorrectly return only the last element instead of the full array.
+        return layer.dateItems.slice(Math.max(firstIndex - 1, 0));
       }),
     ];
   }, [orderedLayers, timelineStartDate]);


### PR DESCRIPTION
### Description

When a layer's first displayDate matched the timeline start date, the layer truncation logic incorrectly returned only the last element of the array instead of the full date range. This meant that _forecast layers_ with validity periods (e.g., dekad forecasts) would show only the end date (Jan 10) instead of all valid dates (Jan 1-10).

So we add a check to our date selector logic to ensure the slice index is never negative. This allows January 1st to be both a display date and a query date, leading to the expected styling in the timeline AND avoids the missing display date and a query date to cause the app to crash.

## How to test the feature:
- [ ] Load any 10 day forecast layer
- [ ] Check that page loads and is styled correctly

Test your changes with

- [x] `REACT_APP_COUNTRY=rbd yarn start`
- [x] `REACT_APP_COUNTRY=cambodia yarn start`
- [x] `REACT_APP_COUNTRY=mozambique yarn start`
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

## Screenshot/video of feature:
<img width="1386" height="1015" alt="Screenshot 2026-01-06 at 11 31 36 AM" src="https://github.com/user-attachments/assets/c87460c9-7581-4e22-a0e7-af3801c20ce4" />
