### PR TITLE
Temporarily disable batch maps from print UI; COUNTRY=rbd

### DIFF
--- a/frontend/src/components/NavBar/PrintImage/image.tsx
+++ b/frontend/src/components/NavBar/PrintImage/image.tsx
@@ -165,8 +165,9 @@ function DownloadImage({ open, handleClose }: DownloadImageProps) {
   const { selectedLayersWithDateSupport } = useLayers();
   const availableDates = useSelector(availableDatesSelector);
   const shouldEnableBatchMaps =
-    selectedLayersWithDateSupport.length > 0 &&
-    selectedLayersWithDateSupport.every(layer => layer.type === 'wms');
+    // selectedLayersWithDateSupport.length > 0 &&
+    // selectedLayersWithDateSupport.every(layer => layer.type === 'wms');
+    false; // Temporarily disable batch maps
 
   const mapCount = useMemo(() => {
     const { startDate, endDate } = dateRangeForBatchMaps;


### PR DESCRIPTION
### Description

This fixes https://github.com/WFP-VAM/prism-app/issues/1701 

<!-- what this does -->

## How to test the feature:

- [ ] Activate a WMS layer with dates
- [ ] Go to the print feature (click print icon)
- [ ] Confirm that the ability to generate a sequence of maps no longer appears

## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [x] `REACT_APP_COUNTRY=rbd yarn start`
- [x] `REACT_APP_COUNTRY=cambodia yarn start`
- [x] `REACT_APP_COUNTRY=mozambique yarn start`
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?

## Screenshot/video of feature:
