### PR TITLE
Fix error in legend text for intense and extreme rainfall days; COUNTRY=mozambique

### DIFF
--- a/frontend/src/config/shared/layers.json
+++ b/frontend/src/config/shared/layers.json
@@ -1048,7 +1048,7 @@
       "mode": "dekad"
     },
     "opacity": 0.7,
-    "legend_text": "Total number of heavy rain days (rainfall > 90th percentile) within last 30 days of dekad",
+    "legend_text": "Total number of intense rain days (rainfall > 90th percentile) within last 30 days of dekad",
     "legend": "xnhie_12_0_14",
     "additional_query_params": {
       "styles": "xnhie_12_0_14"
@@ -1070,7 +1070,7 @@
       "mode": "dekad"
     },
     "opacity": 0.7,
-    "legend_text": "Total number of heavy rain days (rainfall > 95th percentile) within last 30 days of dekad",
+    "legend_text": "Total number of extreme rain days (rainfall > 95th percentile) within last 30 days of dekad",
     "legend": "xnhie_12_0_14",
     "additional_query_params": {
       "styles": "xnhie_12_0_14"


### PR DESCRIPTION
### Description

This fixes an error in the legend text for two layers. It's applied to the shared layers.json config

To do: ensure that translations are correct as well

<!-- what this does -->

## How to test the feature:

- [ ]
- [ ]

## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [ ] `REACT_APP_COUNTRY=rbd yarn start`
- [ ] `REACT_APP_COUNTRY=cambodia yarn start`
- [ ] `REACT_APP_COUNTRY=mozambique yarn start`
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

## Screenshot/video of feature:
