### PR TITLE
Fix dashboard "invalid JSON" toast caused by SPA 200-HTML rewrite

### DIFF
--- a/frontend/src/dashboardConfig/fetchDashboardConfig.test.ts
+++ b/frontend/src/dashboardConfig/fetchDashboardConfig.test.ts
@@ -15,11 +15,14 @@ describe('fetchDashboardConfig', () => {
     global.fetch = originalFetch;
   });
 
+  const jsonHeaders = new Headers({ 'content-type': 'application/json' });
+
   it('returns validated dashboards on success', async () => {
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
       status: 200,
       statusText: 'OK',
+      headers: jsonHeaders,
       json: async () => validBody,
     } as unknown as Response);
 
@@ -28,6 +31,26 @@ describe('fetchDashboardConfig', () => {
     );
     expect(data).toHaveLength(1);
     expect(data[0].title).toBe('T');
+  });
+
+  it('treats 200 + HTML (SPA fallback) as a 404 so the UI stays silent', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: new Headers({ 'content-type': 'text/html; charset=utf-8' }),
+      json: async () => {
+        throw new SyntaxError('Unexpected token <');
+      },
+    } as unknown as Response);
+
+    await expect(
+      fetchDashboardConfig('https://example.com/x/dashboard.json'),
+    ).rejects.toMatchObject({
+      name: 'DashboardConfigFetchError',
+      causeType: 'http',
+      status: 404,
+    });
   });
 
   it('throws DashboardConfigFetchError on network failure', async () => {
@@ -65,6 +88,7 @@ describe('fetchDashboardConfig', () => {
       ok: true,
       status: 200,
       statusText: 'OK',
+      headers: jsonHeaders,
       json: async () => {
         throw new SyntaxError('Unexpected token');
       },
@@ -82,6 +106,7 @@ describe('fetchDashboardConfig', () => {
       ok: true,
       status: 200,
       statusText: 'OK',
+      headers: jsonHeaders,
       json: async () => ({ not: 'array' }),
     } as unknown as Response);
 

--- a/frontend/src/dashboardConfig/fetchDashboardConfig.ts
+++ b/frontend/src/dashboardConfig/fetchDashboardConfig.ts
@@ -50,6 +50,19 @@ export async function fetchDashboardConfig(url: string): Promise<Dashboard[]> {
     );
   }
 
+  // Static hosts (e.g. Firebase Hosting, see frontend/firebase.json) rewrite unknown paths
+  // to `/index.html` and return it with status 200, so a missing dashboard.json arrives as
+  // HTML — not a 404 — and JSON.parse below would throw. Treat a non-JSON content-type as
+  // "not found" so the UI stays silent, matching the 404 path.
+  const contentType = response.headers.get('content-type') ?? '';
+  if (!contentType.toLowerCase().includes('json')) {
+    throw new DashboardConfigFetchError(
+      'Dashboard configuration not found',
+      'http',
+      404,
+    );
+  }
+
   let parsed: unknown;
   try {
     parsed = await response.json();


### PR DESCRIPTION
### Description

Alternative fix for the "invalid JSON" toast seen when a country has no `dashboard.json` (the problem #1810 addresses by committing 30 empty `[]` files).

**Root cause.** `frontend/firebase.json` uses a catch-all SPA rewrite — `{ "source": "**", "destination": "/index.html" }` — so a missing `/data/{country}/dashboard.json` is served as `index.html` with **status 200**. The existing not-found guard in `dashboardConfigQueryError.ts` only catches HTTP 404, so HTML reaches `JSON.parse`, throws, and the user sees the "Dashboard configuration is not valid JSON" notification. The same pattern would hit any S3 website endpoint or static host that rewrites on 404.

**Fix.** After the `response.ok` check in `fetchDashboardConfig.ts`, inspect `content-type`. If it's not JSON, throw the same "http 404" signal that `useDashboardConfig` already swallows silently. Real JSON corruption still surfaces (those responses advertise `application/json`).

### Trade-offs vs. committing empty per-country files

- No 30-file repo churn; no need to maintain an empty file per new country.
- Dashboard enablement stays runtime-driven, which leaves room for @conor-jh's upcoming UI-driven dashboard creation without a rebuild per enablement (see the #1810 discussion on a `prism.json` flag).
- Covers S3-URL deployments too, not just the local `public/data` path.

### How to test

- [ ] `REACT_APP_COUNTRY=cambodia yarn start` — country without a dashboard: no error toast, no Dashboard nav item.
- [ ] `REACT_APP_COUNTRY=mozambique yarn start` with a local `public/data/mozambique/dashboard.json` — dashboards load as before.
- [ ] Simulate Firebase fallback by pointing `REACT_APP_DASHBOARD_CONFIG_BUCKET_URL` at an origin that serves HTML for missing files — toast should not appear.
- [x] `yarn test fetchDashboardConfig` — new test covers the 200-plus-HTML path.

### Checklist

- [x] Add / update tests
- [x] Add / update code comments explaining the SPA-rewrite failure mode

https://claude.ai/code/session_01WMhiv3eU972baZyw2gMgCZ