### PR TITLE
seed English by default

### DIFF
--- a/alerting/package.json
+++ b/alerting/package.json
@@ -17,6 +17,7 @@
     "glob": "^13.0.6",
     "js-yaml": "^4.1.1",
     "@isaacs/brace-expansion": ">=5.0.1",
+    "ws": "^8.20.1",
     "string-width": "4.2.3",
     "form-data": "^3.0.4",
     "lodash": "^4.18.0",
@@ -26,6 +27,7 @@
   "_resolutionsNotes": {
     "glob": "CVE-2025-64756 + jest compatibility - Parent: (direct devDependency), rimraf, jest - Already at latest (13.0.6) - Review periodically",
     "js-yaml": "CVE-2025-64718 - Security fix - Parent: eslint - Already at latest (4.1.1) - Keep resolution until eslint updates",
+    "ws": "GHSA-58qx-3vcg-4xpx / CVE-2026-45736 - Force ws >=8.20.1 for puppeteer-core transitive dependency.",
     "form-data": "CVE-2025-7783 - Security fix - GHSA-fjxv-7rqg-78g4 - Forces v3.0.4+ for transitive dependencies",
     "lodash": "Lodash security fixes - GHSA-r5fr-rjxr-66jc / GHSA-f23m-r3pf-42rh (CVE-2026-4800 / CVE-2026-2950) and prior - Forces v4.18.0+",
     "basic-ftp": "GHSA-5rq4-664w-9x2c path traversal + GHSA-6v7q-wjvx-w8wg + GHSA-rpmf-866q-6p89 (≥5.3.1) - Parent: puppeteer>get-uri - Pin until puppeteer bumps transitive",

--- a/alerting/yarn.lock
+++ b/alerting/yarn.lock
@@ -4255,10 +4255,10 @@ write-file-atomic@^5.0.1:
     imurmurhash "^0.1.4"
     signal-exit "^4.0.1"
 
-ws@^8.19.0:
-  version "8.19.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.19.0.tgz#ddc2bdfa5b9ad860204f5a72a4863a8895fd8c8b"
-  integrity sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==
+ws@^8.19.0, ws@^8.20.1:
+  version "8.20.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.20.1.tgz#91a9ae2b312ccf98e0a85ec499b48cef45ab0ddb"
+  integrity sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==
 
 xml-js@^1.6.11:
   version "1.6.11"

--- a/frontend/src/config/index.ts
+++ b/frontend/src/config/index.ts
@@ -155,11 +155,14 @@ export function getRawLayers(
 // 2. Override: value (country-specific translation overrides shared)
 export function getTranslation(country: Country): Record<string, any> {
   const countryTranslation = get(configMap[country], 'translation', {});
+  // Always seed English so the shared English file loads as the i18n
+  // fallback, even for countries that declare no translation override.
+  const baseTranslation = { en: {}, ...countryTranslation };
   return Object.fromEntries(
     Object.entries(
       QA_MODE || TESTING
-        ? merge({}, sharedTranslation, countryTranslation)
-        : countryTranslation,
+        ? merge({}, sharedTranslation, baseTranslation)
+        : baseTranslation,
     ).map(([key, value]) => [
       key,
       merge({}, sharedTranslation[key] || {}, value),

--- a/frontend/src/config/mozambique/index.ts
+++ b/frontend/src/config/mozambique/index.ts
@@ -5,7 +5,11 @@ import rawTables from './tables.json';
 // Country-specific translation overrides shared translation
 const translation = {
   pt: {},
-  en: { 'Admin 1': 'Province', 'Admin 2': 'District' },
+  en: {
+    'Admin 1': 'Province',
+    'Admin 2': 'District',
+    'Admin 3': 'Administrative Post',
+  },
 };
 const rawReports = {};
 


### PR DESCRIPTION
### Description

This fixes https://github.com/WFP-VAM/prism-app/issues/1873

<!-- what this does -->

- Fix batch map export status (and other shared English strings) showing raw translation keys in production builds for countries with an empty translation = {} override (e.g. Zimbabwe, Zambia).
- getTranslation now always seeds en so shared/translation/english.json loads as the i18n fallback, regardless of country override. Non-English languages remain opt-in; QA mode behavior is unchanged.
- Though not related, this PR also adds missing text for admin level 3 in Mozambique

To test:
- [ ] Run locally with REACT_APP_COUNTRY=zimbabwe yarn start, kick off a batch export, confirm row shows status: Running · X of Y maps instead of batch_export_status_and_maps.
- [ ]  Repeat with a country that overrides en (e.g. Somalia) — country-specific overrides still win over shared English.
- [ ] Repeat with a multi-language country (e.g. Mozambique) — non-English translations unaffected.

## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [ ] `REACT_APP_COUNTRY=rbd yarn start`
- [ ] `REACT_APP_COUNTRY=cambodia yarn start`
- [ ] `REACT_APP_COUNTRY=mozambique yarn start`
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

## Screenshot/video of feature:
<img width="3246" height="2020" alt="image" src="https://github.com/user-attachments/assets/7b875d3f-42c4-48b0-b595-3b3eddb88bba" />
