### PR TITLE
Batch map language fix

### DIFF
--- a/frontend/cypress/e2e/export.cy.ts
+++ b/frontend/cypress/e2e/export.cy.ts
@@ -104,4 +104,19 @@ describe('Export View', () => {
     // The raw {date} placeholder should NOT be visible
     cy.contains('{date}').should('not.exist');
   });
+
+  it('renders translated layer legend when language param is set', () => {
+    const exportUrl = new URL(`${frontendUrl}/export`);
+    exportUrl.searchParams.set('hazardLayerIds', 'precip_blended_dekad');
+    exportUrl.searchParams.set('date', '2024-05-15');
+    exportUrl.searchParams.set('bounds', '32,-27,41,-10');
+    exportUrl.searchParams.set('language', 'pt');
+
+    cy.visit(exportUrl.toString());
+
+    cy.get('.maplibregl-canvas', { timeout: 60000 }).should('exist');
+    cy.contains('Precipitação acumulada combinada INAM/CHIRP (10 dias)').should(
+      'be.visible',
+    );
+  });
 });

--- a/frontend/src/components/ExportView/index.tsx
+++ b/frontend/src/components/ExportView/index.tsx
@@ -15,8 +15,11 @@ import {
   WMSLayerDatesRequested,
 } from 'context/serverPreloadStateSlice';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
+import { useLocation } from 'react-router-dom';
 import { boundaryCache } from 'utils/boundary-cache';
+import { exportLanguage } from 'utils/exportLanguage';
 import useLayers from 'utils/layers-utils';
 import { getLayersCoverage } from 'utils/server-utils';
 import { useBoundaryData } from 'utils/useBoundaryData';
@@ -40,6 +43,9 @@ const displayedBoundaryLayers = getDisplayBoundaryLayers().reverse();
 
 const ExportView = memo(() => {
   const classes = useStyles();
+  const { search } = useLocation();
+  const { i18n } = useTranslation();
+  const exportLang = exportLanguage(search, { apply: true });
   const exportParams = useExportParams();
   const printRef = useRef<HTMLDivElement>(null);
   const titleRef = useRef<HTMLDivElement>(null);
@@ -199,6 +205,10 @@ const ExportView = memo(() => {
   // Footer always shows date text when visible, so just check footerVisibility
   const footerHeight =
     measuredFooterHeight || (exportParams.toggles.footerVisibility ? 60 : 0);
+
+  if (i18n.resolvedLanguage !== exportLang) {
+    return null;
+  }
 
   return (
     <Box className={classes.root}>

--- a/frontend/src/components/NavBar/PrintImage/batchMapExport/buildBatchExportUrls.test.ts
+++ b/frontend/src/components/NavBar/PrintImage/batchMapExport/buildBatchExportUrls.test.ts
@@ -1,0 +1,48 @@
+import { EXPORT_LANGUAGE_PARAM } from 'utils/exportLanguage';
+
+import { buildBatchExportUrls } from './buildBatchExportUrls';
+import type { BuildBatchExportUrlsInput } from './types';
+
+const baseInput: BuildBatchExportUrlsInput = {
+  formattedDates: ['2024-05-15'],
+  origin: 'http://localhost:3000',
+  exportPath: '/export',
+  baseSearchParams: new URLSearchParams('country=mozambique'),
+  printSelectedLayer: {
+    id: 'precip_blended_dekad',
+    title: 'Test layer',
+  } as any,
+  mapBounds: null,
+  mapZoom: 5,
+  mapDimensions: { aspectRatio: '4:3' },
+  titleText: 'Title',
+  footerText: '',
+  footerTextSize: 12,
+  logoPosition: 0,
+  logoScale: 1,
+  legendPosition: 0,
+  legendScale: 1,
+  bottomLogoScale: 1,
+  toggles: {
+    fullLayerDescription: true,
+    countryMask: false,
+    mapLabelsVisibility: true,
+    logoVisibility: true,
+    legendVisibility: true,
+    footerVisibility: true,
+    bottomLogoVisibility: true,
+  },
+  selectedBoundaries: [],
+  language: 'pt',
+};
+
+describe('buildBatchExportUrls', () => {
+  it('includes language query param on each export URL', () => {
+    const urls = buildBatchExportUrls(baseInput);
+    expect(urls).toHaveLength(1);
+    const url = new URL(urls[0]);
+    expect(url.searchParams.get(EXPORT_LANGUAGE_PARAM)).toBe('pt');
+    expect(url.searchParams.get('hazardLayerIds')).toBe('precip_blended_dekad');
+    expect(url.searchParams.get('date')).toBe('2024-05-15');
+  });
+});

--- a/frontend/src/components/NavBar/PrintImage/batchMapExport/buildBatchExportUrls.ts
+++ b/frontend/src/components/NavBar/PrintImage/batchMapExport/buildBatchExportUrls.ts
@@ -1,4 +1,5 @@
 import { isCustomRatio } from 'components/MapExport/aspectRatioConstants';
+import { EXPORT_LANGUAGE_PARAM } from 'utils/exportLanguage';
 
 import type { BuildBatchExportUrlsInput } from './types';
 
@@ -24,6 +25,7 @@ export function buildBatchExportUrls(
     bottomLogoScale,
     toggles,
     selectedBoundaries,
+    language,
   } = input;
 
   return formattedDates
@@ -75,6 +77,10 @@ export function buildBatchExportUrls(
 
       if (selectedBoundaries.length > 0) {
         params.set('selectedBoundaries', selectedBoundaries.join(','));
+      }
+
+      if (language) {
+        params.set(EXPORT_LANGUAGE_PARAM, language);
       }
 
       return `${origin}${exportPath}?${params.toString()}`;

--- a/frontend/src/components/NavBar/PrintImage/batchMapExport/types.ts
+++ b/frontend/src/components/NavBar/PrintImage/batchMapExport/types.ts
@@ -66,4 +66,6 @@ export type BuildBatchExportUrlsInput = {
   bottomLogoScale: number;
   toggles: Toggles;
   selectedBoundaries: AdminCodeString[];
+  /** Active i18n language code (e.g. pt) for server-side /export rendering. */
+  language: string;
 };

--- a/frontend/src/components/NavBar/PrintImage/image.tsx
+++ b/frontend/src/components/NavBar/PrintImage/image.tsx
@@ -52,6 +52,7 @@ import {
   getMapExportPageOrigin,
   MAP_EXPORT_MAX_URLS_PER_REQUEST,
 } from '../../../utils/constants';
+import { exportLanguage } from '../../../utils/exportLanguage';
 import { ALL_ASPECT_RATIO_OPTIONS } from '../../MapExport/aspectRatioConstants';
 import { downloadToFile } from '../../MapView/utils';
 import { buildBatchExportDatesDisplay } from './batchMapExport/batchExportArtifactFilename';
@@ -89,7 +90,7 @@ function DownloadImage({ open, handleClose }: DownloadImageProps) {
   const printRef = useRef<HTMLDivElement>(null);
   const { data } = useBoundaryData(boundaryLayer.id);
   const dispatch = useDispatch();
-  const { t } = useSafeTranslation();
+  const { t, i18n } = useSafeTranslation();
   const { enqueueBatchMapExportJob } = useBatchMapExportJobsActions();
 
   // list of toggles
@@ -571,6 +572,9 @@ function DownloadImage({ open, handleClose }: DownloadImageProps) {
         bottomLogoScale,
         toggles,
         selectedBoundaries,
+        language: exportLanguage(search, {
+          activeLanguage: i18n.resolvedLanguage,
+        }),
       });
 
       const layerDisplayName =

--- a/frontend/src/utils/exportLanguage.ts
+++ b/frontend/src/utils/exportLanguage.ts
@@ -1,0 +1,44 @@
+import { appConfig } from 'config';
+import i18n, { languages } from 'i18n';
+import { get } from 'lodash';
+
+/** URL query param for export / batch map language (see ExportView). */
+export const EXPORT_LANGUAGE_PARAM = 'language';
+
+type ExportLanguageOptions = {
+  /** Navbar / i18n language when building batch URLs and the page URL has no param. */
+  activeLanguage?: string | null;
+  /** Switch i18n to the resolved language (ExportView). */
+  apply?: boolean;
+};
+
+/**
+ * Resolve export language: `?language=` on the page URL, else active UI language
+ * (batch only), else app default. Optionally applies to i18n.
+ */
+export function exportLanguage(
+  search: string,
+  options?: ExportLanguageOptions,
+): string {
+  const defaultLocale = get(appConfig, 'defaultLanguage', 'en');
+  const fallback = languages.includes(defaultLocale) ? defaultLocale : 'en';
+
+  const fromUrl = new URLSearchParams(search).get(EXPORT_LANGUAGE_PARAM);
+  let lang: string;
+  if (fromUrl && languages.includes(fromUrl)) {
+    lang = fromUrl;
+  } else if (
+    options?.activeLanguage &&
+    languages.includes(options.activeLanguage)
+  ) {
+    lang = options.activeLanguage;
+  } else {
+    lang = fallback;
+  }
+
+  if (options?.apply && i18n.resolvedLanguage !== lang) {
+    void i18n.changeLanguage(lang);
+  }
+
+  return lang;
+}


### PR DESCRIPTION
### Description

This fixes #1872.

# Summary
Batch map exports were always rendered in English because Playwright opens /export in a fresh browser context without the user’s language selection. The print preview used the in-app i18n language, but export URLs never carried that language through.

This change adds a language query param to each batch export URL and teaches /export to apply it before rendering, so layer titles and legends match the language selected in the navbar.

# Changes
Add `exportLanguage()` to resolve language: ?language= on the page URL → active UI language (batch enqueue only) → app default; optionally applies to i18n on /export
Embed language on every batch export URL in buildBatchExportUrls
ExportView applies the param and waits for i18n to match before rendering (avoids English flash before Playwright captures)


# Test
Manual — batch export (primary)

- Open a multi-language country (e.g. Mozambique).
- Switch the navbar language to Portuguese (or another non-English option).
- Select a dated layer (e.g. 10-day rainfall).
- Open Print → Batch maps, pick a valid cadence and date range.
- Confirm the preview shows translated layer name and legend.
- Export (PDF or PNG) and wait for the job to finish.
- Download the result and confirm layer name and legend are translated (not English).
- Manual — /export URL

Visit `/export?hazardLayerIds=precip_blended_dekad&date=2024-05-15&bounds=32,-27,41,-10&language=pt`
Confirm the legend shows the Portuguese layer title.

# Regression

Single-map print/download from the dialog still works.
Batch export with language left at default (English) still produces valid output.