### PR TITLE
Fix dates issue with charts block

### DIFF
--- a/frontend/src/components/CreateDashboardView/utils.ts
+++ b/frontend/src/components/CreateDashboardView/utils.ts
@@ -36,7 +36,7 @@ export const defaultElementForType = (
     case DashboardElementType.CHART:
       return {
         type: DashboardElementType.CHART,
-        startDate: today(),
+        startDate: '',
         layerId: '',
         chartHeight: ChartHeight.TALL,
       };


### PR DESCRIPTION
### Description

This fixes the issue that @wadhwamatic found in #1856: https://github.com/WFP-VAM/prism-app/pull/1856#issuecomment-4426290491

The problem is that we were incorrectly initializing a start date for empty chart blocks in newly-created dashboards. But there’s already date-setting logic. Basically we doubled up on trying to set dates which was causing the end date to incorrectly get set to a year from today.

<!-- what this does -->

## How to test the feature:

- [ ] Run any deployment and create a new dashboard in the UI with at least one chart block
- [ ] Observe the default start and end dates

<img width="1927" height="1240" alt="image" src="https://github.com/user-attachments/assets/fe7d7406-05fe-4fc7-99f1-786fc8e3d74b" />


## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [ ] `REACT_APP_COUNTRY=rbd yarn start`
- [x] `REACT_APP_COUNTRY=cambodia yarn start`
- [ ] `REACT_APP_COUNTRY=mozambique yarn start`
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

## Screenshot/video of feature:
