### PR TITLE
Hide batch maps in UI

### DIFF
--- a/frontend/src/components/NavBar/PrintImage/image.tsx
+++ b/frontend/src/components/NavBar/PrintImage/image.tsx
@@ -285,7 +285,7 @@ function DownloadImage({ open, handleClose }: DownloadImageProps) {
     }
   }, [availableCadences, cadence]);
 
-  const shouldEnableBatchMaps = true;
+  const shouldEnableBatchMaps = false;
 
   const shouldShowMultiLayerWarning = selectedLayersWithDateSupport.length > 1;
 


### PR DESCRIPTION
### Description

This temporarily hides batch maps from the print UI

<!-- what this does -->

## How to test the feature:

- [ ] select a rainfall layer and click the print button
- [ ] verify that that the option to create a sequence of maps is not visible in the print screen UI

## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [ ] `REACT_APP_COUNTRY=rbd yarn start`
- [ ] `REACT_APP_COUNTRY=cambodia yarn start`
- [ ] `REACT_APP_COUNTRY=mozambique yarn start`
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

## Screenshot/video of feature:
