### PR TITLE
Avoid flaky frontend docker build in CI

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -137,7 +137,7 @@ jobs:
           chmod +x $DOCKER_CONFIG/cli-plugins/docker-compose
           docker compose version
       - name: Build containers
-        run: cd api && make build
+        run: cd api && make ci-build
       - name: Run tests
         run: cd api && make api-test
 

--- a/api/Makefile
+++ b/api/Makefile
@@ -4,6 +4,11 @@ build:
 	docker compose -f docker-compose.yml -f docker-compose.test.yml build --no-cache
 	docker compose -f docker-compose.yml -f docker-compose.test.yml pull
 
+# CI: use layer cache; (no --no-cache)
+ci-build:
+	docker compose -f docker-compose.yml -f docker-compose.test.yml build
+	docker compose -f docker-compose.yml -f docker-compose.test.yml pull
+
 api:
 	docker compose -f docker-compose.yml -f docker-compose.develop.yml up
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -3,12 +3,6 @@
 # against the frontend using playwright
 FROM node:20
 
-# Update and upgrade system packages
-RUN --mount=type=cache,target=/var/cache/apt \
-    apt-get update && \
-    apt-get upgrade -y && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
-
 # copy dependencies definitions for better caching
 WORKDIR /common/
 


### PR DESCRIPTION
### Description

Avoid flaky frontend docker build in CI by removing upgrade tests and --no-cache in CI.


<!-- what this does -->

## How to test the feature:

- [ ]
- [ ]

## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [ ] `REACT_APP_COUNTRY=rbd yarn start`
- [ ] `REACT_APP_COUNTRY=cambodia yarn start`
- [ ] `REACT_APP_COUNTRY=mozambique yarn start`
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

## Screenshot/video of feature:
