### PR TITLE
Move table block "Show on map" toggle into the edit top bar.

### DIFF
--- a/frontend/src/components/DashboardView/DashboardContent.tsx
+++ b/frontend/src/components/DashboardView/DashboardContent.tsx
@@ -16,7 +16,7 @@ import {
 import { Close, Edit } from '@material-ui/icons';
 import { getImageUrl } from 'assets/images';
 import { useSafeTranslation } from 'i18n';
-import { useEffect, useState } from 'react';
+import { type ReactNode, useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 
@@ -29,6 +29,10 @@ import {
   DashboardMode,
 } from '../../config/types';
 import { findDashboardByPath } from '../../config/utils';
+import {
+  isAnalysisLayerActiveSelector,
+  setIsMapLayerActive,
+} from '../../context/analysisResultStateSlice';
 import {
   dashboardColumnsSelector,
   dashboardConfigSelector,
@@ -131,6 +135,11 @@ function DashboardContent({
   const logoHeight = logoConfig ? logoHeightMultiplier * logoConfig.scale : 0;
   const dispatch = useDispatch();
   const syncEnabled = useSelector(dashboardSyncEnabledSelector);
+  const isAnalysisLayerActive = useSelector(isAnalysisLayerActiveSelector);
+
+  const handleToggleLayerVisibility = () => {
+    dispatch(setIsMapLayerActive(!isAnalysisLayerActive));
+  };
 
   type PendingAction =
     | { kind: 'remove'; columnIndex: number; elementIndex: number }
@@ -196,6 +205,7 @@ function DashboardContent({
     currentType: DashboardElementType,
     columnIndex: number,
     elementIndex: number,
+    extraContent?: ReactNode,
   ) => (
     <Box className={classes.blockTypeRow}>
       <Typography variant="h3" className={classes.blockLabel}>
@@ -224,15 +234,18 @@ function DashboardContent({
           </MenuItem>
         ))}
       </Select>
-      <IconButton
-        size="small"
-        onClick={() =>
-          stagePendingAction({ kind: 'remove', columnIndex, elementIndex })
-        }
-        className={classes.removeBlockButton}
-      >
-        <Close fontSize="small" />
-      </IconButton>
+      <Box className={classes.blockTypeRowActions}>
+        {extraContent}
+        <IconButton
+          size="small"
+          onClick={() =>
+            stagePendingAction({ kind: 'remove', columnIndex, elementIndex })
+          }
+          className={classes.removeBlockButton}
+        >
+          <Close fontSize="small" />
+        </IconButton>
+      </Box>
     </Box>
   );
 
@@ -366,6 +379,19 @@ function DashboardContent({
                       element.type,
                       columnIndex,
                       elementIndex,
+                      element.addResultToMap !== false ? (
+                        <FormControlLabel
+                          control={
+                            <Switch
+                              checked={isAnalysisLayerActive}
+                              onChange={handleToggleLayerVisibility}
+                              color="primary"
+                              size="small"
+                            />
+                          }
+                          label={t('Show on map')}
+                        />
+                      ) : undefined,
                     )
                   : undefined
               }
@@ -609,8 +635,13 @@ const useStyles = makeStyles(() => ({
       marginBottom: 0,
     },
   },
-  removeBlockButton: {
+  blockTypeRowActions: {
+    display: 'flex',
+    alignItems: 'center',
     marginLeft: 'auto',
+    gap: 8,
+  },
+  removeBlockButton: {
     color: '#757575',
     '&:hover': {
       color: '#212121',

--- a/frontend/src/components/DashboardView/TableBlock.tsx
+++ b/frontend/src/components/DashboardView/TableBlock.tsx
@@ -2,10 +2,8 @@ import {
   Box,
   Button,
   CircularProgress,
-  FormControlLabel,
   IconButton,
   makeStyles,
-  Switch,
   TextField,
   Tooltip,
   Typography,
@@ -30,7 +28,6 @@ import {
 } from 'config/types';
 import {
   analysisResultErrorSelector,
-  isAnalysisLayerActiveSelector,
   setIsMapLayerActive,
 } from 'context/analysisResultStateSlice';
 import { useSafeTranslation } from 'i18n';
@@ -81,7 +78,6 @@ function TableBlock({
   const { t } = useSafeTranslation();
   const dispatch = useDispatch();
   const mode = useSelector(dashboardModeSelector);
-  const isAnalysisLayerActive = useSelector(isAnalysisLayerActiveSelector);
   const analysisError = useSelector(analysisResultErrorSelector);
 
   // Create element ID for Redux state
@@ -142,10 +138,6 @@ function TableBlock({
         updates: { maxRows: newMaxRows },
       }),
     );
-  };
-
-  const handleToggleLayerVisibility = () => {
-    dispatch(setIsMapLayerActive(!isAnalysisLayerActive));
   };
 
   const handleDownloadCSV = () => {
@@ -468,21 +460,6 @@ function TableBlock({
         </Typography>
       )}
 
-      {formState.analysisResult && addResultToMap && (
-        <Box className={classes.toggleContainer}>
-          <FormControlLabel
-            control={
-              <Switch
-                checked={isAnalysisLayerActive}
-                onChange={handleToggleLayerVisibility}
-                color="primary"
-              />
-            }
-            label={t('Show on map')}
-          />
-        </Box>
-      )}
-
       <Box className={classes.formContainer}>
         <Box className={classes.formSection}>
           <HazardLayerSelector
@@ -674,10 +651,6 @@ const useStyles = makeStyles(theme => ({
     alignItems: 'center',
     justifyContent: 'center',
     padding: theme.spacing(4),
-  },
-  toggleContainer: {
-    padding: theme.spacing(1),
-    display: 'flex',
   },
 }));
 


### PR DESCRIPTION
### Description

@wadhwamatic raised that it was confusing how to not show table results on the map. Well the option to do so is hidden until the data loads and it's not the fastest endpoint. This moves that option to the top and has it always ready. 

## How to test the feature:

- [ ] Enter edit mode on a dashboard
- [ ] Toggle "Show on Map"
- [ ] Load data and toggle again
- [ ] Confirm it's controlling the map in non-edit mode

## Screenshot/video of feature:
<img width="600" height="606" alt="Screenshot 2026-05-29 at 10 31 23 AM" src="https://github.com/user-attachments/assets/b8a58d8d-1fe5-4427-8e66-e98a894e952d" />
