### PR TITLE
Git ignore eslint cache files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ build
 dist
 builds
 
+# Caches
+**/.eslintcache
+
 # Misc
 .DS_Store
 


### PR DESCRIPTION
### Description

Follow-up to #1902, we should ignore the generated cache files. These files can stay on our own machines and update themselves as we work. It's not essential (or really useful) to have the cache file checked into our repository and included in PR reviews. 