### PR TITLE
Fix chart block resize flicker in dashboard overflow layout.

### DIFF
--- a/frontend/src/components/DashboardView/ChartBlock.tsx
+++ b/frontend/src/components/DashboardView/ChartBlock.tsx
@@ -155,9 +155,6 @@ function ChartBlock({
     initialChartHeight || ChartHeight.TALL,
   );
 
-  // Overflow state management - lock once triggered, reset on recalculation
-  const [isOverflowLocked, setIsOverflowLocked] = useState(false);
-
   const handleLayerChange = (id: LayerKey | undefined) => {
     formState.setChartLayerId(id);
     persistBlockConfig({ layerId: id ?? '' });

--- a/frontend/src/components/DashboardView/ChartBlock.tsx
+++ b/frontend/src/components/DashboardView/ChartBlock.tsx
@@ -46,7 +46,6 @@ interface ChartBlockProps extends Partial<DashboardChartConfig> {
   allowDownload?: boolean;
   chartHeight?: ChartHeight;
   isOverflowing?: boolean;
-  recalculationCount?: number;
   headerSlot?: ReactNode;
 }
 
@@ -59,7 +58,6 @@ function ChartBlock({
   allowDownload,
   chartHeight: initialChartHeight,
   isOverflowing,
-  recalculationCount,
   headerSlot,
 }: ChartBlockProps) {
   const classes = useStyles();
@@ -97,9 +95,6 @@ function ChartBlock({
   const [chartHeightOption, setChartHeightOption] = useState<ChartHeight>(
     initialChartHeight || ChartHeight.TALL,
   );
-
-  // Overflow state management - lock once triggered, reset on recalculation
-  const [isOverflowLocked, setIsOverflowLocked] = useState(false);
 
   const downloadFilename = buildCsvFileName([
     ...(chartTitle ? chartTitle.split(' ') : []),
@@ -166,24 +161,6 @@ function ChartBlock({
     }
   }, [isLoading, wasChartLoading, chartDataset]);
 
-  // Staged lock management: reset on recalculation, then lock if needed after measurement
-  useEffect(() => {
-    if (recalculationCount !== undefined && recalculationCount > 0) {
-      // Reset lock to allow new measurement
-      setIsOverflowLocked(false);
-
-      // After small delay, lock if overflow detected
-      const timeoutId = setTimeout(() => {
-        if (isOverflowing) {
-          setIsOverflowLocked(true);
-        }
-      }, 50);
-
-      return () => clearTimeout(timeoutId);
-    }
-    return undefined;
-  }, [recalculationCount, isOverflowing]);
-
   const formatDateRange = () => {
     const start = formState.startDate;
     const end = formState.endDate;
@@ -244,7 +221,13 @@ function ChartBlock({
             )}
 
             {!isLoading && !error && chartDataset && chartConfig && (
-              <Box className={classes.chartWrapper}>
+              <Box
+                className={
+                  isOverflowing
+                    ? classes.constrainedChartWrapper
+                    : classes.chartWrapper
+                }
+              >
                 <Chart
                   ref={chartRef}
                   title={t(chartSubtitle)}
@@ -258,9 +241,7 @@ function ChartBlock({
                   showDownloadIcons={false}
                   responsive
                   height={
-                    isOverflowing || isOverflowLocked
-                      ? undefined
-                      : CHART_HEIGHTS[chartHeightOption]
+                    isOverflowing ? undefined : CHART_HEIGHTS[chartHeightOption]
                   }
                 />
               </Box>
@@ -515,6 +496,19 @@ const useStyles = makeStyles(theme => ({
     display: 'flex',
     flexDirection: 'column',
     overflow: 'auto',
+    '& > *': {
+      maxWidth: '100%',
+    },
+  },
+  constrainedChartWrapper: {
+    flex: 1,
+    maxWidth: '100%',
+    position: 'relative',
+    width: '100%',
+    display: 'flex',
+    flexDirection: 'column',
+    overflow: 'hidden',
+    minHeight: 0,
     '& > *': {
       maxWidth: '100%',
     },

--- a/frontend/src/components/DashboardView/DashboardContent.tsx
+++ b/frontend/src/components/DashboardView/DashboardContent.tsx
@@ -344,7 +344,7 @@ function DashboardContent({
         flexDirection: 'column' as const,
         overflow: heightConfig.overflow,
         ...(heightConfig.overflow === 'scroll'
-          ? { scrollbarGutter: 'stable' as const }
+          ? { overflowX: 'hidden' as const, scrollbarGutter: 'stable' as const }
           : {}),
       };
     };

--- a/frontend/src/components/DashboardView/DashboardContent.tsx
+++ b/frontend/src/components/DashboardView/DashboardContent.tsx
@@ -188,7 +188,7 @@ function DashboardContent({
   };
 
   // Column Height Management - extracted to custom hook
-  const { componentHeights, columnRefs, componentRefs, recalculationCount } =
+  const { componentHeights, columnRefs, componentRefs } =
     useColumnHeightManagement({
       mode,
       exportConfig,
@@ -272,6 +272,9 @@ function DashboardContent({
         display: 'flex',
         flexDirection: 'column' as const,
         overflow: heightConfig.overflow,
+        ...(heightConfig.overflow === 'scroll'
+          ? { scrollbarGutter: 'stable' as const }
+          : {}),
       };
     };
 
@@ -419,8 +422,7 @@ function DashboardContent({
               adminUnitId={element.adminUnitId}
               chartHeight={element.chartHeight}
               allowDownload={!exportConfig}
-              isOverflowing={heightConfig?.overflow === 'auto'}
-              recalculationCount={recalculationCount}
+              isOverflowing={heightConfig?.overflow === 'scroll'}
               headerSlot={
                 mode === DashboardMode.EDIT
                   ? renderBlockTypeSelector(

--- a/frontend/src/components/DashboardView/useColumnHeightManagement.ts
+++ b/frontend/src/components/DashboardView/useColumnHeightManagement.ts
@@ -7,9 +7,12 @@ import type { ExportConfig } from './DashboardContent';
 // A constant for the gap between various columns and padding
 export const GAP = 16;
 
+// Buffer to prevent overflow/fit oscillation when scrollbars appear/disappear
+const OVERFLOW_HYSTERESIS = 20;
+
 interface HeightConfig {
   flex: string;
-  overflow: 'auto' | 'visible';
+  overflow: 'scroll' | 'visible';
 }
 
 interface UseColumnHeightManagementParams {
@@ -22,7 +25,6 @@ interface UseColumnHeightManagementReturn {
   componentHeights: Map<string, HeightConfig>;
   columnRefs: React.MutableRefObject<Map<number, HTMLDivElement>>;
   componentRefs: React.MutableRefObject<Map<string, HTMLDivElement>>;
-  recalculationCount: number;
 }
 
 /**
@@ -43,7 +45,6 @@ export function useColumnHeightManagement({
   const [componentHeights, setComponentHeights] = useState<
     Map<string, HeightConfig>
   >(new Map());
-  const [recalculationCount, setRecalculationCount] = useState(0);
   const columnRefs = useRef<Map<number, HTMLDivElement>>(new Map());
   const componentRefs = useRef<Map<string, HTMLDivElement>>(new Map());
   const checkTimeoutRef = useRef<NodeJS.Timeout | null>(null);
@@ -114,8 +115,16 @@ export function useColumnHeightManagement({
           }
         });
 
-        // If total natural height fits, let components use natural heights
-        if (totalNaturalHeight <= availableHeight) {
+        const wasOverflowing = tempComponentHeights.some(({ id }) =>
+          previousHeightsRef.current.has(id),
+        );
+
+        // Hysteresis prevents fit/overflow toggling when scrollbar presence shifts layout
+        const fitsInColumn = wasOverflowing
+          ? totalNaturalHeight <= availableHeight - OVERFLOW_HYSTERESIS
+          : totalNaturalHeight <= availableHeight;
+
+        if (fitsInColumn) {
           return;
         }
 
@@ -153,11 +162,12 @@ export function useColumnHeightManagement({
               overflow: 'visible',
             });
           } else {
-            // Large component: use redistributed height (with scroll)
+            // Large component: use redistributed height (with scroll).
+            // Use overflow: scroll (not auto) so scrollbar gutter stays stable.
             const flexBasis = `${redistributedHeight}px`;
             newHeights.set(id, {
               flex: `0 0 ${flexBasis}`,
-              overflow: 'auto',
+              overflow: 'scroll',
             });
           }
         });
@@ -192,9 +202,6 @@ export function useColumnHeightManagement({
       if (hasChanged) {
         previousHeightsRef.current = newHeights;
         setComponentHeights(newHeights);
-        // Increment recalculation count only when heights meaningfully changed
-        // This signals to components (like ChartBlock) to reset their state
-        setRecalculationCount(prev => prev + 1);
       }
     };
 
@@ -257,6 +264,5 @@ export function useColumnHeightManagement({
     componentHeights,
     columnRefs,
     componentRefs,
-    recalculationCount,
   };
 }


### PR DESCRIPTION
### Description

Prevent feedback loops from recalculationCount that cause rapid layout shifts (due to scrollbar's entrance and exit)

Example of bug:
https://github.com/user-attachments/assets/aca055a3-77f1-4e2f-943c-40b58b047c68

## How to test the feature:

- [ ] Make sure your scrollbars are set to "always show" in your OS settings
- [ ] Create a dashboard with a chart and other components in a column
- [ ] Reduce the height of the browser window until the chart component needs to resize
- [ ] Confirm chart resizes without scrollbar appearing and flickering

Test your changes with

- [ ] `REACT_APP_COUNTRY=rbd yarn start`
- [ ] `REACT_APP_COUNTRY=cambodia yarn start`
- [ ] `REACT_APP_COUNTRY=mozambique yarn start`
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

## Screenshot/video of feature:
<img width="1250" height="667" alt="Screenshot 2026-06-01 at 1 57 02 PM" src="https://github.com/user-attachments/assets/8ab7f3f6-5a03-4603-ad3c-ed50bea299ad" />
