### PR TITLE
Hide edit button for published dashboards

### DIFF
--- a/frontend/src/components/DashboardView/index.tsx
+++ b/frontend/src/components/DashboardView/index.tsx
@@ -166,7 +166,7 @@ function DashboardView() {
             ? classes.editLayout
             : classes.previewLayout
         }
-        onEditClick={handleClosePreview}
+        onEditClick={dashboardConfig.isDraft ? handleClosePreview : undefined}
       />
       {mode === DashboardMode.EDIT && (
         <Box className={classes.toolbar}>


### PR DESCRIPTION
### Description

Fast-follow for the dashboard frontend edit PR.

<!-- what this does -->

## How to test the feature:

- View dashboards in PRISM
- Ensure that locally created dashboards are editable
- Ensure that published dashboards (from the API) are not editable. The edit button should be hidden.

## Checklist - did you ...
Test your changes with

- [ ] `REACT_APP_COUNTRY=rbd yarn start`
- [ ] `REACT_APP_COUNTRY=cambodia yarn start`
- [x] `REACT_APP_COUNTRY=mozambique yarn start`
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

## Screenshots

**Published dashboard (no edit button)**
<img width="949" height="480" alt="Screenshot 2026-06-03 at 1 11 18 PM" src="https://github.com/user-attachments/assets/3be930bb-bc3a-461b-91b4-894807887228" />

**Local dashboard (edit button intact)**
<img width="1011" height="435" alt="image" src="https://github.com/user-attachments/assets/4f580f83-c55a-48cf-93a2-b7bea3c82adb" />

