### PR TITLE
add dashboard staging concept

### DIFF
--- a/api/alembic/versions/add_staging_status.py
+++ b/api/alembic/versions/add_staging_status.py
@@ -18,9 +18,7 @@ def upgrade() -> None:
     # ALTER TYPE ... ADD VALUE cannot run inside a transaction block on
     # PostgreSQL < 12, so use an autocommit block to be safe across versions.
     with op.get_context().autocommit_block():
-        op.execute(
-            "ALTER TYPE dashboard_status_enum ADD VALUE IF NOT EXISTS 'staging'"
-        )
+        op.execute("ALTER TYPE dashboard_status_enum ADD VALUE IF NOT EXISTS 'staging'")
 
 
 def downgrade() -> None:

--- a/api/alembic/versions/add_staging_status.py
+++ b/api/alembic/versions/add_staging_status.py
@@ -1,0 +1,30 @@
+"""Add 'staging' to dashboard_status_enum.
+
+Revision ID: add_staging_status
+Revises: map_export_schedules_001
+Create Date: 2026-06-03
+
+"""
+
+from alembic import op
+
+revision = "add_staging_status"
+down_revision = "map_export_schedules_001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # ALTER TYPE ... ADD VALUE cannot run inside a transaction block on
+    # PostgreSQL < 12, so use an autocommit block to be safe across versions.
+    with op.get_context().autocommit_block():
+        op.execute(
+            "ALTER TYPE dashboard_status_enum ADD VALUE IF NOT EXISTS 'staging'"
+        )
+
+
+def downgrade() -> None:
+    # PostgreSQL does not support removing a value from an enum type.
+    # Reverting would require recreating dashboard_status_enum without the
+    # value, which is unsafe while rows may reference it. No-op by design.
+    pass

--- a/api/prism_app/dashboard/published_dashboards.py
+++ b/api/prism_app/dashboard/published_dashboards.py
@@ -1,4 +1,8 @@
-"""Read merged dashboard config arrays for the public (published-only) API."""
+"""Read merged dashboard config arrays for the dashboard read API.
+
+Serves ``published`` rows by default; staging frontends opt in to also seeing
+``staging`` rows via ``include_staging``.
+"""
 
 from __future__ import annotations
 
@@ -12,15 +16,31 @@ from sqlalchemy.orm import Session, sessionmaker
 from sqlmodel import col
 
 
+def served_statuses(include_staging: bool) -> list[DashboardStatus]:
+    """Dashboard statuses exposed by the read API.
+
+    ``published`` is always served; ``staging`` is added only for staging
+    frontends. ``draft`` and ``archived`` are never served.
+    """
+    statuses = [DashboardStatus.published]
+    if include_staging:
+        statuses.append(DashboardStatus.staging)
+    return statuses
+
+
 def merge_published_dashboard_rows_for_country(
-    engine: Engine, country: str
+    engine: Engine, country: str, include_staging: bool = False
 ) -> list[Any]:
     """
     Return the combined top-level ``dashboard.json`` array for a country.
 
-    Merges each published row's ``config`` in ``title`` order. Each row's
+    Merges each served row's ``config`` in ``title`` order. Each row's
     ``config`` is a JSON list of dashboard row objects, or a single object for
     legacy rows.
+
+    By default only ``published`` rows are served. When ``include_staging`` is
+    true, ``staging`` rows are served alongside published ones (for staging
+    frontends previewing dashboards before they go public).
     """
     SessionLocal = sessionmaker(engine, class_=Session, expire_on_commit=False)
     with SessionLocal() as session:
@@ -28,7 +48,7 @@ def merge_published_dashboard_rows_for_country(
             session.scalars(
                 select(DashboardModel)
                 .where(col(DashboardModel.country) == country)
-                .where(col(DashboardModel.status) == DashboardStatus.published)
+                .where(col(DashboardModel.status).in_(served_statuses(include_staging)))
                 .order_by(col(DashboardModel.title))
             ).all()
         )

--- a/api/prism_app/database/dashboard_model.py
+++ b/api/prism_app/database/dashboard_model.py
@@ -14,10 +14,17 @@ from sqlmodel import Field, SQLModel
 
 
 class DashboardStatus(str, Enum):
-    """Publication state: drafts and archived rows are not served to the PRISM UI read API."""
+    """Publication state served to the PRISM UI read API.
+
+    ``published`` rows are served to everyone. ``staging`` rows are served only
+    to staging frontends (``GET /dashboards?include_staging=true``) so a
+    dashboard can be reviewed live before going public. ``draft`` and
+    ``archived`` are never served.
+    """
 
     draft = "draft"
     published = "published"
+    staging = "staging"
     archived = "archived"
 
 

--- a/api/prism_app/main.py
+++ b/api/prism_app/main.py
@@ -174,17 +174,25 @@ def get_published_dashboards(
         min_length=1,
         description="Country key (frontend configMap key)",
     ),
+    include_staging: bool = Query(
+        False,
+        description="Include status=staging rows (for staging frontends)",
+    ),
 ) -> list[Any]:
-    """Return merged dashboard rows for all published ``dashboard`` rows in this country.
+    """Return merged dashboard rows for the served ``dashboard`` rows in this country.
 
     The response is a single JSON array, the same top-level shape as the static
-    ``dashboards.json`` consumed by PRISM. Drafts are never included.
+    ``dashboards.json`` consumed by PRISM. ``published`` rows are always
+    included; ``staging`` rows are included only when ``include_staging`` is set.
+    Drafts and archived rows are never included.
     """
     if not alert_db.active or alert_db.engine is None:
         raise HTTPException(
             status_code=503, detail="Dashboard data is temporarily unavailable"
         )
-    return merge_published_dashboard_rows_for_country(alert_db.engine, country)
+    return merge_published_dashboard_rows_for_country(
+        alert_db.engine, country, include_staging=include_staging
+    )
 
 
 @timed

--- a/api/prism_app/tests/test_published_dashboards.py
+++ b/api/prism_app/tests/test_published_dashboards.py
@@ -1,6 +1,21 @@
 """Unit tests for dashboard read normalization helpers."""
 
+from prism_app.dashboard.published_dashboards import served_statuses
 from prism_app.dashboard.util import omit_none_keys
+from prism_app.database.dashboard_model import DashboardStatus
+
+
+def test_served_statuses_published_only_by_default() -> None:
+    assert served_statuses(include_staging=False) == [DashboardStatus.published]
+
+
+def test_served_statuses_includes_staging_when_requested() -> None:
+    statuses = served_statuses(include_staging=True)
+    assert DashboardStatus.published in statuses
+    assert DashboardStatus.staging in statuses
+    # Drafts and archived are never served.
+    assert DashboardStatus.draft not in statuses
+    assert DashboardStatus.archived not in statuses
 
 
 def test_omit_none_keys_removes_nested_null_object_fields() -> None:

--- a/api/prism_app/tests/test_published_dashboards_api.py
+++ b/api/prism_app/tests/test_published_dashboards_api.py
@@ -41,4 +41,20 @@ def test_get_dashboards_returns_merged_config():
             r = client.get("/dashboards", params={"country": "moz"})
     assert r.status_code == 200
     assert r.json() == sample
-    m.assert_called_once_with(mock_db.engine, "moz")
+    m.assert_called_once_with(mock_db.engine, "moz", include_staging=False)
+
+
+def test_get_dashboards_forwards_include_staging():
+    with patch("prism_app.main.alert_db") as mock_db:
+        mock_db.active = True
+        mock_db.engine = object()
+        with patch(
+            "prism_app.main.merge_published_dashboard_rows_for_country",
+            return_value=[],
+        ) as m:
+            r = client.get(
+                "/dashboards",
+                params={"country": "moz", "include_staging": "true"},
+            )
+    assert r.status_code == 200
+    m.assert_called_once_with(mock_db.engine, "moz", include_staging=True)

--- a/frontend/src/config/index.ts
+++ b/frontend/src/config/index.ts
@@ -84,7 +84,12 @@ const {
   REACT_APP_OAUTH_REDIRECT_URI: REDIRECT_URI,
   REACT_APP_TESTING: TESTING,
   REACT_APP_QA_MODE: QA_MODE,
+  REACT_APP_USE_STAGING: USE_STAGING,
 } = process.env;
+
+// When true, the dashboard read API is asked to also return status=staging
+// dashboards (see useDashboardConfig). Off in production builds.
+const useStagingDashboards = USE_STAGING === 'true';
 
 const safeCountry =
   COUNTRY && has(configMap, COUNTRY.toLocaleLowerCase())
@@ -211,4 +216,5 @@ export {
   rawTables,
   safeCountry,
   translation,
+  useStagingDashboards,
 };

--- a/frontend/src/hooks/useDashboardConfig.ts
+++ b/frontend/src/hooks/useDashboardConfig.ts
@@ -1,5 +1,5 @@
 import { useIsAuthenticated } from '@azure/msal-react';
-import { authRequired, safeCountry } from 'config';
+import { authRequired, safeCountry, useStagingDashboards } from 'config';
 import { setDashboards } from 'context/dashboardStateSlice';
 import { addNotification } from 'context/notificationStateSlice';
 import {
@@ -28,9 +28,11 @@ export function useDashboardConfig(): void {
   const dispatch = useDispatch();
   const isAuthenticated = useIsAuthenticated();
   const enabled = isAuthenticated || !authRequired;
-  const url = `${DASHBOARDS_API_URL}?${new URLSearchParams({
-    country: safeCountry,
-  }).toString()}`;
+  const params = new URLSearchParams({ country: safeCountry });
+  if (useStagingDashboards) {
+    params.set('include_staging', 'true');
+  }
+  const url = `${DASHBOARDS_API_URL}?${params.toString()}`;
 
   useEffect(() => {
     if (!enabled) {


### PR DESCRIPTION
### Description

This (temporarily) adds a staging status for dashboards so we can deploy frontends that get dashboards from the production backend for demo & training purposes

<!-- what this does -->

## How to test the feature:

- [ ] in the frontend, REACT_APP_USE_STAGING=true
- [ ] create a dashboard in the frontend. export the json
- [ ] upload the dashboard json through the admin console and set status to staging
- [ ] see the dashboard appear in the frontend

## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [ ] `REACT_APP_COUNTRY=rbd yarn start`
- [ ] `REACT_APP_COUNTRY=cambodia yarn start`
- [ ] `REACT_APP_COUNTRY=mozambique yarn start`
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

## Screenshot/video of feature:
