### PR TITLE
Removing map zoom from batch map configs

### DIFF
--- a/frontend/src/components/ExportView/index.tsx
+++ b/frontend/src/components/ExportView/index.tsx
@@ -232,18 +232,6 @@ const ExportView = memo(() => {
     );
   }, [exportParams.date, selectedLayersWithDateSupport]);
 
-  const exportInitialViewState = useMemo(() => {
-    const { bounds, zoom } = exportParams;
-    if (!bounds || zoom == null || !new URLSearchParams(search).has('zoom')) {
-      return undefined;
-    }
-    return {
-      longitude: (bounds.west + bounds.east) / 2,
-      latitude: (bounds.south + bounds.north) / 2,
-      zoom,
-    };
-  }, [exportParams.bounds, exportParams.zoom, search]);
-
   // Use measured footer height, or estimate if not yet measured
   // Footer always shows date text when visible, so just check footerVisibility
   const footerHeight =
@@ -270,7 +258,6 @@ const ExportView = memo(() => {
         legendPosition={exportParams.legendPosition}
         legendScale={exportParams.legendScale}
         bounds={exportParams.bounds ?? undefined}
-        initialViewState={exportInitialViewState}
         mapStyle={processedMapStyle}
         invertedAdminBoundaryLimitPolygon={invertedAdminBoundaryLimitPolygon}
         printRef={printRef}

--- a/frontend/src/components/MapExport/MapExportLayout.test.tsx
+++ b/frontend/src/components/MapExport/MapExportLayout.test.tsx
@@ -80,11 +80,6 @@ const defaultProps = {
   logoScale: 1,
   legendPosition: 0,
   legendScale: 1,
-  initialViewState: {
-    longitude: 0,
-    latitude: 0,
-    zoom: 5,
-  },
   mapStyle: 'mock-style',
 };
 

--- a/frontend/src/components/MapExport/MapExportLayout.tsx
+++ b/frontend/src/components/MapExport/MapExportLayout.tsx
@@ -304,42 +304,16 @@ function MapExportLayout({
     // If bounds are provided, fit the map to those bounds.
     // This ensures precise geographic extent matching (e.g., for exports).
     if (bounds && map) {
-      if (initialViewState) {
-        map.jumpTo({
-          center: [initialViewState.longitude, initialViewState.latitude],
-          zoom: initialViewState.zoom,
-        });
-      } else {
-        map.fitBounds(
-          [
-            [bounds.west, bounds.south],
-            [bounds.east, bounds.north],
-          ],
-          {
-            padding: 0,
-            animate: false,
-          },
-        );
-      }
-    }
-
-    // Capture preview bounds/zoom (must run before print-preview early return below).
-    if (onBoundsChange && map) {
-      let lastBoundsStr: string | null = null;
-      let lastZoom: number | null = null;
-
-      map.on('idle', () => {
-        const mapBounds = map.getBounds();
-        const zoom = map.getZoom();
-        if (mapBounds) {
-          const boundsStr = `${mapBounds.getWest()},${mapBounds.getSouth()},${mapBounds.getEast()},${mapBounds.getNorth()}`;
-          if (boundsStr !== lastBoundsStr || zoom !== lastZoom) {
-            lastBoundsStr = boundsStr;
-            lastZoom = zoom;
-            onBoundsChange(mapBounds, zoom);
-          }
-        }
-      });
+      map.fitBounds(
+        [
+          [bounds.west, bounds.south],
+          [bounds.east, bounds.north],
+        ],
+        {
+          padding: 0,
+          animate: false,
+        },
+      );
     }
 
     // Capture preview bounds/zoom (must run before print-preview early return below).

--- a/frontend/src/components/MapExport/MapExportLayout.tsx
+++ b/frontend/src/components/MapExport/MapExportLayout.tsx
@@ -107,7 +107,6 @@ function MapExportLayout({
   titleHeight = 0,
   legendPosition,
   legendScale,
-  initialViewState,
   bounds,
   mapStyle: mapStyleProp,
   invertedAdminBoundaryLimitPolygon,
@@ -262,11 +261,8 @@ function MapExportLayout({
     ? `calc(100% - ${logoHeight * 8}px)`
     : '100%';
 
-  // Calculate fallback initial view state from bounds if not provided
+  // Calculate fallback initial view state from bounds
   const effectiveInitialViewState = useMemo(() => {
-    if (initialViewState) {
-      return initialViewState;
-    }
     if (bounds) {
       return {
         longitude: (bounds.west + bounds.east) / 2,
@@ -275,7 +271,7 @@ function MapExportLayout({
       };
     }
     return { longitude: 0, latitude: 0, zoom: 2 };
-  }, [initialViewState, bounds]);
+  }, [bounds]);
 
   const handleMapLoad = (e: any) => {
     e.target.addControl(new maplibregl.ScaleControl({}), 'bottom-right');
@@ -305,8 +301,8 @@ function MapExportLayout({
     // Load SDF icons for point data layers
     ensureSDFIconsLoaded(mapRef.current?.getMap());
 
-    // Match preview viewport: use captured center+zoom when provided (/export?zoom=…).
-    // fitBounds alone ignores zoom and can match a prior export when only zoom changed.
+    // If bounds are provided, fit the map to those bounds.
+    // This ensures precise geographic extent matching (e.g., for exports).
     if (bounds && map) {
       if (initialViewState) {
         map.jumpTo({
@@ -325,6 +321,25 @@ function MapExportLayout({
           },
         );
       }
+    }
+
+    // Capture preview bounds/zoom (must run before print-preview early return below).
+    if (onBoundsChange && map) {
+      let lastBoundsStr: string | null = null;
+      let lastZoom: number | null = null;
+
+      map.on('idle', () => {
+        const mapBounds = map.getBounds();
+        const zoom = map.getZoom();
+        if (mapBounds) {
+          const boundsStr = `${mapBounds.getWest()},${mapBounds.getSouth()},${mapBounds.getEast()},${mapBounds.getNorth()}`;
+          if (boundsStr !== lastBoundsStr || zoom !== lastZoom) {
+            lastBoundsStr = boundsStr;
+            lastZoom = zoom;
+            onBoundsChange(mapBounds, zoom);
+          }
+        }
+      });
     }
 
     // Capture preview bounds/zoom (must run before print-preview early return below).

--- a/frontend/src/components/MapExport/MapExportLayout.tsx
+++ b/frontend/src/components/MapExport/MapExportLayout.tsx
@@ -343,11 +343,13 @@ function MapExportLayout({
     }
 
     // Capture preview bounds/zoom (must run before print-preview early return below).
+    // Use moveend (fires after fitBounds and user pan/zoom) rather than idle
+    // (which waits for all tiles to load and may not fire before export is captured).
     if (onBoundsChange && map) {
       let lastBoundsStr: string | null = null;
       let lastZoom: number | null = null;
 
-      map.on('idle', () => {
+      const reportBounds = () => {
         const mapBounds = map.getBounds();
         const zoom = map.getZoom();
         if (mapBounds) {
@@ -358,7 +360,11 @@ function MapExportLayout({
             onBoundsChange(mapBounds, zoom);
           }
         }
-      });
+      };
+
+      // Capture immediately (fitBounds with animate:false is synchronous)
+      reportBounds();
+      map.on('moveend', reportBounds);
     }
 
     // Track tile loading using idle event and areTilesLoaded() for robust detection

--- a/frontend/src/components/MapExport/types.ts
+++ b/frontend/src/components/MapExport/types.ts
@@ -50,7 +50,6 @@ export interface ExportParams {
 
   // Map bounds (new)
   bounds: ExportMapBounds | null;
-  zoom: number | null;
 
   // Print config options
   mapWidth: number; // 50-100
@@ -100,13 +99,6 @@ export interface MapExportLayoutProps {
   // Legend
   legendPosition: number;
   legendScale: number;
-
-  // Map view state
-  initialViewState?: {
-    longitude: number;
-    latitude: number;
-    zoom: number;
-  };
 
   // Bounds to fit map to
   bounds?: ExportMapBounds;

--- a/frontend/src/components/NavBar/PrintImage/batchMapExport/mapExportTemplate.test.ts
+++ b/frontend/src/components/NavBar/PrintImage/batchMapExport/mapExportTemplate.test.ts
@@ -41,7 +41,6 @@ const sharedTemplate = {
   baseSearchParams: new URLSearchParams('baselineLayerId=old-layer'),
   printSelectedLayer,
   mapBounds,
-  mapZoom: 5.5,
   mapDimensions: { aspectRatio: '4:3' as const },
   titleText: 'Mozambique - {date_coverage}',
   footerText: 'Footer text',
@@ -69,7 +68,6 @@ describe('buildBatchExportUrls', () => {
     expect(params.get('hazardLayerIds')).toBe('rainfall_blended_dekad');
     expect(params.get('baselineLayerId')).toBeNull();
     expect(params.get('bounds')).toBe('30,-26,41,-10');
-    expect(params.get('zoom')).toBe('5.5');
     expect(params.get('toggles')).toBe(
       JSON.stringify({
         fullLayerDescription: true,
@@ -116,17 +114,15 @@ describe('buildBatchExportUrls', () => {
     expect(params.get('customHeight')).toBe('9');
   });
 
-  test('omits bounds and zoom when not available', () => {
+  test('omits bounds when not available', () => {
     const [url] = buildBatchExportUrls({
       ...sharedTemplate,
       formattedDates: ['2024-05-01'],
       mapBounds: null,
-      mapZoom: null,
     });
     const params = new URL(url).searchParams;
 
     expect(params.get('bounds')).toBeNull();
-    expect(params.get('zoom')).toBeNull();
   });
 });
 
@@ -179,7 +175,6 @@ describe('buildScheduleExportOptions', () => {
 
     expect(options.origin).toBe('https://prism.example.org');
     expect(options.queryParams.bounds).toBe('30,-26,41,-10');
-    expect(options.queryParams.zoom).toBe('5.5');
     expect(options.queryParams.aspectRatio).toBe('4:3');
     expect(options.queryParams.toggles?.fullLayerDescription).toBe(true);
     expect(options.queryParams).not.toHaveProperty('date');
@@ -207,7 +202,6 @@ describe('schedule/batch template parity', () => {
 
     expect(scheduleParams.get('bounds')).toBe(batchParams.get('bounds'));
     expect(scheduleParams.get('language')).toBe(batchParams.get('language'));
-    expect(scheduleParams.get('zoom')).toBe(batchParams.get('zoom'));
     expect(scheduleParams.get('aspectRatio')).toBe(
       batchParams.get('aspectRatio'),
     );
@@ -236,7 +230,6 @@ describe('applyMapExportPrintTemplate', () => {
     const params = new URLSearchParams();
     applyMapExportPrintTemplate(params, {
       mapBounds,
-      mapZoom: 4,
       mapDimensions: { aspectRatio: 'A4-P' as AspectRatio },
       titleText: 'T',
       footerText: 'F',

--- a/frontend/src/components/NavBar/PrintImage/batchMapExport/mapExportTemplate.ts
+++ b/frontend/src/components/NavBar/PrintImage/batchMapExport/mapExportTemplate.ts
@@ -14,7 +14,6 @@ import type { BuildBatchExportUrlsInput } from './types';
 /** Print layout fields shared by batch export URLs and schedule export_options. */
 export type MapExportPrintTemplate = {
   mapBounds: LngLatBounds | null;
-  mapZoom: number | null;
   mapDimensions: MapDimensions;
   titleText: string;
   footerText: string;
@@ -87,9 +86,6 @@ export function applyMapExportPrintTemplate(
   if (template.mapBounds) {
     params.set('bounds', boundsString(template.mapBounds));
   }
-  if (template.mapZoom != null) {
-    params.set('zoom', String(template.mapZoom));
-  }
 
   params.set('mapWidth', '100');
   params.set('mapHeight', '100');
@@ -122,7 +118,6 @@ function printTemplateFromBatchInput(
 ): MapExportPrintTemplate {
   return {
     mapBounds: input.mapBounds,
-    mapZoom: input.mapZoom,
     mapDimensions: input.mapDimensions,
     titleText: input.titleText,
     footerText: input.footerText,
@@ -178,10 +173,6 @@ function scheduleQueryParamsFromTemplate(
     bottomLogoScale: template.bottomLogoScale,
     toggles: exportTogglesForUrl(template.toggles),
   };
-
-  if (template.mapZoom != null) {
-    queryParams.zoom = String(template.mapZoom);
-  }
 
   if (isCustomRatio(template.mapDimensions.aspectRatio)) {
     queryParams.aspectRatio = 'Custom';

--- a/frontend/src/components/NavBar/PrintImage/batchMapExport/types.ts
+++ b/frontend/src/components/NavBar/PrintImage/batchMapExport/types.ts
@@ -54,7 +54,6 @@ export type BuildBatchExportUrlsInput = {
   baseSearchParams: URLSearchParams;
   printSelectedLayer: DateCompatibleLayer;
   mapBounds: LngLatBounds | null;
-  mapZoom: number | null;
   mapDimensions: MapDimensions;
   titleText: string;
   footerText: string;

--- a/frontend/src/components/NavBar/PrintImage/batchMapExport/useMapExportTemplate.ts
+++ b/frontend/src/components/NavBar/PrintImage/batchMapExport/useMapExportTemplate.ts
@@ -13,7 +13,6 @@ import {
 
 export type UseMapExportTemplateInput = {
   mapBounds: LngLatBounds | null;
-  mapZoom: number | null;
   mapDimensions: MapDimensions;
   previewMapWidth: number | null;
   previewMapHeight: number | null;
@@ -33,7 +32,6 @@ export type UseMapExportTemplateInput = {
 function printTemplateFields(input: UseMapExportTemplateInput) {
   return {
     mapBounds: input.mapBounds,
-    mapZoom: input.mapZoom,
     mapDimensions: input.mapDimensions,
     titleText: input.titleText,
     footerText: input.footerText,

--- a/frontend/src/components/NavBar/PrintImage/image.tsx
+++ b/frontend/src/components/NavBar/PrintImage/image.tsx
@@ -423,7 +423,6 @@ function DownloadImage({ open, handleClose }: DownloadImageProps) {
 
   const mapExportTemplate = useMapExportTemplate({
     mapBounds: previewBounds,
-    mapZoom: previewZoom,
     mapDimensions,
     previewMapWidth,
     previewMapHeight,

--- a/frontend/src/components/NavBar/PrintImage/printPreview.tsx
+++ b/frontend/src/components/NavBar/PrintImage/printPreview.tsx
@@ -215,20 +215,6 @@ function PrintPreview() {
     setPreviewMapReady(true);
   }, []);
 
-  const previewInitialViewState = useMemo(() => {
-    const bounds = printConfig?.previewBounds;
-    const zoom = printConfig?.previewZoom;
-    if (!bounds || zoom == null) {
-      return undefined;
-    }
-    const center = bounds.getCenter();
-    return {
-      longitude: center.lng,
-      latitude: center.lat,
-      zoom,
-    };
-  }, [printConfig?.previewBounds, printConfig?.previewZoom]);
-
   if (!printConfig || !selectedMap) {
     return null;
   }
@@ -327,7 +313,6 @@ function PrintPreview() {
         legendPosition={legendPosition}
         legendScale={legendScale}
         bounds={geographicBoundsForExport}
-        initialViewState={previewInitialViewState}
         mapStyle={processedMapStyle}
         maxBounds={maxBounds}
         invertedAdminBoundaryLimitPolygon={invertedAdminBoundaryLimitPolygon}

--- a/frontend/src/utils/mapExportSchedulesApi.ts
+++ b/frontend/src/utils/mapExportSchedulesApi.ts
@@ -8,7 +8,6 @@ export type MapExportScheduleCadenceApi =
 
 export type ScheduleExportQueryParams = {
   bounds: string;
-  zoom?: string;
   mapWidth?: number;
   mapHeight?: number;
   aspectRatio?: string;

--- a/frontend/src/utils/useExportParams.ts
+++ b/frontend/src/utils/useExportParams.ts
@@ -37,7 +37,6 @@ const exportParamsSchema = {
   date: defineParam('date', param.stringOrNull()),
 
   // Map bounds
-  zoom: defineParam('zoom', param.number(5)),
   bounds: defineParam(
     'bounds',
     param.custom<ExportMapBounds | null>(v => {


### PR DESCRIPTION
### Description

@ericboucher found an issue where updating the zoom didn't update the exported map. That's because our onMapBounds event wasn't getting fired. 

He put the fix in #1914 ([here exactly](https://github.com/WFP-VAM/prism-app/pull/1914/changes/715157c00fc3fa931ca6367ec633390e65292820#diff-3b0af57ce711913996158e0e461c483757e9aba833cef09918afd161b872d123)) but also introduced updates to zoom tracking and initial viewport that I don't believe are necessary. Now that we have _accurate_ map bounds (due to the fix in 715157c) we can remove our zoom config handling.

(when we have a fixed aspect ratio, as we do, our bounds should perfectly match the desired zoom)

## How to test the feature:
- [ ] Run multiple batch map exports at different zoom levels. 
- [ ] Confirm that the generated batch maps have updated views that match your print preview. 

## Checklist - did you ...

Test your changes with

- [ ] `REACT_APP_COUNTRY=rbd yarn start`
- [ ] `REACT_APP_COUNTRY=cambodia yarn start`
- [x] `REACT_APP_COUNTRY=mozambique yarn start`
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?

## Screenshot/video of feature:
Two maps with different zooms:
[bd66d2af-6cd0-4c73-9188-0063c6ded39c.pdf](https://github.com/user-attachments/files/28601472/bd66d2af-6cd0-4c73-9188-0063c6ded39c.pdf)
[e7ea2c3b-c86b-436f-998c-4bd6b1e194aa.pdf](https://github.com/user-attachments/files/28601473/e7ea2c3b-c86b-436f-998c-4bd6b1e194aa.pdf)
<img width="1044" height="970" alt="Screenshot 2026-06-04 at 10 11 22 AM" src="https://github.com/user-attachments/assets/0a8d8714-010c-40c7-92a5-3b7d8d33943c" />
