### PR TITLE
"scheduled by" field in scheduled export table

### DIFF
--- a/api/prism_app/admin_map_export.py
+++ b/api/prism_app/admin_map_export.py
@@ -30,12 +30,12 @@ from prism_app.map_export_layer_catalog import (
 )
 from prism_app.utils import utc_now
 from sqlalchemy import Select, cast, func, or_, select
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 from sqlalchemy.types import String
 from starlette.exceptions import HTTPException
 from starlette.requests import Request
 from starlette.responses import Response
-from starlette_admin import EnumField, StringField
+from starlette_admin import EnumField, HasOne, StringField
 from starlette_admin._types import RequestAction
 from starlette_admin.actions import link_row_action
 from starlette_admin.contrib.sqla import Admin
@@ -276,7 +276,7 @@ class MapExportScheduleView(PrismGatedModelView):
         ),
         StringField("export_url", read_only=True),
         PrettyJSONField("export_options", read_only=True),
-        "created_by_user_id",
+        HasOne("created_by_user", label="Scheduled by", identity="user"),
         "created_at",
         "updated_at",
     )
@@ -292,7 +292,7 @@ class MapExportScheduleView(PrismGatedModelView):
         "last_enqueued_date",
         "last_executed_at",
         "output_directory",
-        "created_by_user_id",
+        "created_by_user",
         "created_at",
         "updated_at",
     )
@@ -306,7 +306,7 @@ class MapExportScheduleView(PrismGatedModelView):
         "last_enqueued_date",
         "last_executed_at",
         "output_directory",
-        "created_by_user_id",
+        "created_by_user",
         "created_at",
         "updated_at",
         "country",
@@ -331,13 +331,27 @@ class MapExportScheduleView(PrismGatedModelView):
         return "clone_from" in request.query_params
 
     def get_list_query(self, request: Request) -> Select:
-        return _apply_schedule_owner_filter(super().get_list_query(request), request)
+        stmt = (
+            super()
+            .get_list_query(request)
+            .options(
+                joinedload(MapExportSchedule.created_by_user),
+            )
+        )
+        return _apply_schedule_owner_filter(stmt, request)
 
     def get_count_query(self, request: Request) -> Select:
         return _apply_schedule_owner_filter(super().get_count_query(request), request)
 
     def get_details_query(self, request: Request) -> Select:
-        return _apply_schedule_owner_filter(super().get_details_query(request), request)
+        stmt = (
+            super()
+            .get_details_query(request)
+            .options(
+                joinedload(MapExportSchedule.created_by_user),
+            )
+        )
+        return _apply_schedule_owner_filter(stmt, request)
 
     def get_search_query(self, request: Request, term: str) -> Any:
         """Case-insensitive search (explicit lower() for portability)."""
@@ -422,7 +436,7 @@ class MapExportScheduleView(PrismGatedModelView):
         serialized["last_checked_at"] = None
         serialized["last_enqueued_at"] = None
         serialized["last_enqueued_date"] = None
-        serialized["created_by_user_id"] = None
+        serialized["created_by_user"] = None
         return serialized
 
     @link_row_action(

--- a/api/prism_app/database/map_export_schedule_model.py
+++ b/api/prism_app/database/map_export_schedule_model.py
@@ -8,13 +8,15 @@ from enum import Enum
 from typing import Any, Optional, Self
 from uuid import UUID
 
+from prism_app.database.user_model import User
 from prism_app.export_schedule_validation import normalize_schedule_export_url
 from prism_app.utils import utc_now
 from pydantic import model_validator
 from sqlalchemy import JSON, Column, Date, DateTime, ForeignKey, Index, Integer, String
 from sqlalchemy.dialects.postgresql import UUID as PG_UUID
+from sqlalchemy.orm import relationship
 from sqlalchemy.types import Uuid
-from sqlmodel import Field, SQLModel
+from sqlmodel import Field, Relationship, SQLModel
 
 
 class MapExportScheduleStatus(str, Enum):
@@ -97,6 +99,14 @@ class MapExportSchedule(SQLModel, table=True):
             Uuid(as_uuid=True),
             ForeignKey("users.id", ondelete="SET NULL"),
             nullable=True,
+        ),
+    )
+    created_by_user: Optional[User] = Relationship(
+        sa_relationship=relationship(
+            User,
+            primaryjoin="MapExportSchedule.created_by_user_id == User.id",
+            foreign_keys="MapExportSchedule.created_by_user_id",
+            uselist=False,
         ),
     )
     created_at: datetime.datetime = Field(


### PR DESCRIPTION
### Description

Shows a "scheduled by" field in the map export schedules admin view that shows a user's name and email instead of the "created by user id"

<!-- what this does -->

## How to test the feature:

- Create a schedule from PRISM
- Inspect the schedule to see if the "created by" shows in both the lists and details views 


## Screenshot/video of feature:

<img width="1898" height="652" alt="image" src="https://github.com/user-attachments/assets/ab9754b8-f68b-4b10-bb27-73086520184b" />
