### PR TITLE
Fix missing layers in batch map drop down

### DIFF
--- a/frontend/src/components/NavBar/PrintImage/image.tsx
+++ b/frontend/src/components/NavBar/PrintImage/image.tsx
@@ -7,7 +7,7 @@ import {
 } from '@material-ui/core';
 import { usePostHog } from '@posthog/react';
 import mask from '@turf/mask';
-import { appConfig, configMap, safeCountry } from 'config';
+import { appConfig, rawLayers, safeCountry } from 'config';
 import { AdminCodeString, LayerKey } from 'config/types';
 import { getBoundaryLayerSingleton, LayerDefinitions } from 'config/utils';
 import {
@@ -198,9 +198,11 @@ function DownloadImage({ open, handleClose }: DownloadImageProps) {
   );
 
   const [isDownloading, setIsDownloading] = useState(false);
-  const countryLayerIds = new Set(
-    Object.keys(configMap[safeCountry].rawLayers),
-  );
+  // Use the merged layer set (shared + country-specific) so shared layers a
+  // country only references via prism.json categories — e.g. `days_dry` — are
+  // not excluded. `configMap[safeCountry].rawLayers` holds only the country's
+  // own layers.json and would drop every referenced shared layer.
+  const countryLayerIds = new Set(Object.keys(rawLayers));
   const availableDates = useSelector(availableDatesSelector);
   const selectableLayers = Object.values(LayerDefinitions).filter(
     (l): l is DateCompatibleLayer =>


### PR DESCRIPTION
### Description

This fixes #1921 .

<!-- what this does -->

Changed the import from `configMap` to the merged `rawLayers` export 
Changed `countryLayerIds` to key off the merged set 

rawLayers is the shared + country-specific merge, so any shared WMS layer a country references via its prism.json categories — like days_dry for Mozambique — now passes the countryLayerIds.has(l.id) filter and appears in the "Create a sequence of maps" dropdown. 

## How to test the feature:

- [ ] any country
- [ ] select layer Days since last rain
- [ ] print map
- [ ] select batch map
- [ ] verify that days since last rain remains selected
- [ ] verify that all wms layers are available in the list of available layers

## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [ ] `REACT_APP_COUNTRY=rbd yarn start`
- [ ] `REACT_APP_COUNTRY=cambodia yarn start`
- [x] `REACT_APP_COUNTRY=mozambique yarn start`
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

## Screenshot/video of feature:
<img width="670" height="286" alt="image" src="https://github.com/user-attachments/assets/c1a2f475-3169-48b8-81d1-b0d232a3b6e4" />
