### PR TITLE
Admin layer fix

### DIFF
--- a/api/prism_app/data/schedule_layer_manifest.json
+++ b/api/prism_app/data/schedule_layer_manifest.json
@@ -1,768 +1,31 @@
 {
   "countries": {
-    "afghanistan": [],
-    "bhutan": [],
-    "cambodia": [
+    "afghanistan": [
       {
-        "id": "days_dry",
-        "title": "Days since last rain",
-        "server_layer_name": "dlc_dekad"
+        "id": "2m_water_anomaly",
+        "title": "2-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_2month"
       },
       {
-        "id": "days_extreme_rain",
-        "title": "Number of days with extreme rainfall in the last 30 days",
-        "server_layer_name": "xne_dekad"
+        "id": "3m_water_anomaly",
+        "title": "3-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_3month"
       },
       {
-        "id": "days_heavy_rain",
-        "title": "Number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xnh_dekad"
+        "id": "4m_water_anomaly",
+        "title": "4-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_4month"
       },
       {
-        "id": "days_intense_rain",
-        "title": "Number of days with intense rainfall in the last 30 days",
-        "server_layer_name": "xni_dekad"
+        "id": "5m_water_anomaly",
+        "title": "5-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_5month"
       },
       {
-        "id": "flood_duration",
-        "title": "Flood duration",
-        "server_layer_name": "hf_duration_khm"
+        "id": "6m_water_anomaly",
+        "title": "6-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_6month"
       },
-      {
-        "id": "flood_extent",
-        "title": "Flood extent",
-        "server_layer_name": "hf_water_khm"
-      },
-      {
-        "id": "flood_pixel_age",
-        "title": "Flood pixel age",
-        "server_layer_name": "hf_age_khm"
-      },
-      {
-        "id": "lst_amplitude",
-        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
-        "server_layer_name": "myd11a2_taa_dekad"
-      },
-      {
-        "id": "lst_anomaly",
-        "title": "Daytime Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_daytime",
-        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "ndvi_dekad",
-        "title": "10-day NDVI (MODIS)",
-        "server_layer_name": "mxd13a2_vim_dekad"
-      },
-      {
-        "id": "ndvi_dekad_anomaly",
-        "title": "10-day NDVI anomaly (MODIS)",
-        "server_layer_name": "mxd13a2_viq_dekad"
-      },
-      {
-        "id": "rain_anomaly_1month",
-        "title": "Monthly rainfall anomaly",
-        "server_layer_name": "r1q_dekad"
-      },
-      {
-        "id": "rain_anomaly_1year",
-        "title": "1-year rainfall anomaly",
-        "server_layer_name": "ryq_dekad"
-      },
-      {
-        "id": "rain_anomaly_3month",
-        "title": "3-month rainfall anomaly",
-        "server_layer_name": "r3q_dekad"
-      },
-      {
-        "id": "rain_anomaly_6month",
-        "title": "6-month rainfall anomaly",
-        "server_layer_name": "r6q_dekad"
-      },
-      {
-        "id": "rain_anomaly_9month",
-        "title": "9-month rainfall anomaly",
-        "server_layer_name": "r9q_dekad"
-      },
-      {
-        "id": "rain_anomaly_dekad",
-        "title": "10-day rainfall anomaly",
-        "server_layer_name": "rfq_dekad"
-      },
-      {
-        "id": "rainfall_agg_1month",
-        "title": "1-month rainfall aggregate",
-        "server_layer_name": "r1h_dekad"
-      },
-      {
-        "id": "rainfall_agg_1year",
-        "title": "1-year rainfall aggregate (mm)",
-        "server_layer_name": "ryh_dekad"
-      },
-      {
-        "id": "rainfall_agg_3month",
-        "title": "3-month rainfall aggregate (mm)",
-        "server_layer_name": "r3h_dekad"
-      },
-      {
-        "id": "rainfall_agg_6month",
-        "title": "6-month rainfall aggregate (mm)",
-        "server_layer_name": "r6h_dekad"
-      },
-      {
-        "id": "rainfall_agg_9month",
-        "title": "9-month rainfall aggregate (mm)",
-        "server_layer_name": "r9h_dekad"
-      },
-      {
-        "id": "rainfall_dekad",
-        "title": "10-day rainfall estimate (mm)",
-        "server_layer_name": "rfh_dekad"
-      },
-      {
-        "id": "spi_1m",
-        "title": "SPI - 1-month",
-        "server_layer_name": "r1s_dekad"
-      },
-      {
-        "id": "spi_1y",
-        "title": "SPI - 1-year",
-        "server_layer_name": "rys_dekad"
-      },
-      {
-        "id": "spi_3m",
-        "title": "SPI - 3-month",
-        "server_layer_name": "r3s_dekad"
-      },
-      {
-        "id": "spi_6m",
-        "title": "SPI - 6-month",
-        "server_layer_name": "r6s_dekad"
-      },
-      {
-        "id": "spi_9m",
-        "title": "SPI - 9-month",
-        "server_layer_name": "r9s_dekad"
-      },
-      {
-        "id": "streak_dry_days",
-        "title": "Longest number of consecutive dry days",
-        "server_layer_name": "dlx_dekad"
-      },
-      {
-        "id": "streak_extreme_rain",
-        "title": "Longest consecutive extreme rainfall days",
-        "server_layer_name": "xle_dekad"
-      },
-      {
-        "id": "streak_heavy_rain",
-        "title": "Longest consecutive number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xlh_dekad"
-      },
-      {
-        "id": "streak_intense_rain",
-        "title": "Longest consecutive intense rainfall days",
-        "server_layer_name": "xli_dekad"
-      },
-      {
-        "id": "wp_pop_icunadj",
-        "title": "population",
-        "server_layer_name": "wp_pop_icunadj"
-      }
-    ],
-    "cameroon": [
-      {
-        "id": "days_dry",
-        "title": "Days since last rain",
-        "server_layer_name": "dlc_dekad"
-      },
-      {
-        "id": "days_extreme_rain",
-        "title": "Number of days with extreme rainfall in the last 30 days",
-        "server_layer_name": "xne_dekad"
-      },
-      {
-        "id": "days_heavy_rain",
-        "title": "Number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xnh_dekad"
-      },
-      {
-        "id": "days_intense_rain",
-        "title": "Number of days with intense rainfall in the last 30 days",
-        "server_layer_name": "xni_dekad"
-      },
-      {
-        "id": "lst_amplitude",
-        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
-        "server_layer_name": "myd11a2_taa_dekad"
-      },
-      {
-        "id": "lst_anomaly",
-        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_daytime",
-        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "ndvi_dekad",
-        "title": "10-day NDVI (MODIS)",
-        "server_layer_name": "mxd13a2_vim_dekad"
-      },
-      {
-        "id": "ndvi_dekad_anomaly",
-        "title": "10-day NDVI anomaly (MODIS)",
-        "server_layer_name": "mxd13a2_viq_dekad"
-      },
-      {
-        "id": "precip_blended_1m",
-        "title": "Blended rainfall aggregate (1-month)",
-        "server_layer_name": "rfb_blended_zwe_dekad"
-      },
-      {
-        "id": "precip_blended_1y",
-        "title": "Blended rainfall aggregate (1-year)",
-        "server_layer_name": "rfb_blended_zwe_dekad"
-      },
-      {
-        "id": "precip_blended_3m",
-        "title": "Blended rainfall aggregate (3-month)",
-        "server_layer_name": "rfb_blended_zwe_dekad"
-      },
-      {
-        "id": "precip_blended_6m",
-        "title": "Blended rainfall aggregate (6-month)",
-        "server_layer_name": "rfb_blended_zwe_dekad"
-      },
-      {
-        "id": "precip_blended_9m",
-        "title": "Blended rainfall aggregate (9-month)",
-        "server_layer_name": "rfb_blended_zwe_dekad"
-      },
-      {
-        "id": "precip_blended_anomaly_1m",
-        "title": "Blended rainfall anomaly (1-month)",
-        "server_layer_name": "rfq_blended_zwe_dekad"
-      },
-      {
-        "id": "precip_blended_anomaly_1y",
-        "title": "Blended rainfall anomaly (1-year)",
-        "server_layer_name": "rfq_blended_zwe_dekad"
-      },
-      {
-        "id": "precip_blended_anomaly_3m",
-        "title": "Blended rainfall anomaly (3-month)",
-        "server_layer_name": "rfq_blended_zwe_dekad"
-      },
-      {
-        "id": "precip_blended_anomaly_6m",
-        "title": "Blended rainfall anomaly (6-month)",
-        "server_layer_name": "rfq_blended_zwe_dekad"
-      },
-      {
-        "id": "precip_blended_anomaly_9m",
-        "title": "Blended rainfall anomaly (9-month)",
-        "server_layer_name": "rfq_blended_zwe_dekad"
-      },
-      {
-        "id": "precip_blended_dekad",
-        "title": "Blended rainfall aggregate (10-day)",
-        "server_layer_name": "rfb_blended_zwe_dekad"
-      },
-      {
-        "id": "precip_blended_dekad_anomaly",
-        "title": "Blended rainfall anomaly (10-day)",
-        "server_layer_name": "rfq_blended_zwe_dekad"
-      },
-      {
-        "id": "rain_anomaly_1month",
-        "title": "Monthly rainfall anomaly",
-        "server_layer_name": "r1q_dekad"
-      },
-      {
-        "id": "rain_anomaly_1year",
-        "title": "1-year rainfall anomaly",
-        "server_layer_name": "ryq_dekad"
-      },
-      {
-        "id": "rain_anomaly_3month",
-        "title": "3-month rainfall anomaly",
-        "server_layer_name": "r3q_dekad"
-      },
-      {
-        "id": "rain_anomaly_6month",
-        "title": "6-month rainfall anomaly",
-        "server_layer_name": "r6q_dekad"
-      },
-      {
-        "id": "rain_anomaly_9month",
-        "title": "9-month rainfall anomaly",
-        "server_layer_name": "r9q_dekad"
-      },
-      {
-        "id": "rain_anomaly_dekad",
-        "title": "10-day rainfall anomaly",
-        "server_layer_name": "rfq_dekad"
-      },
-      {
-        "id": "rainfall_agg_1month",
-        "title": "1-month rainfall aggregate (mm)",
-        "server_layer_name": "r1h_dekad"
-      },
-      {
-        "id": "rainfall_agg_1year",
-        "title": "1-year rainfall aggregate (mm)",
-        "server_layer_name": "ryh_dekad"
-      },
-      {
-        "id": "rainfall_agg_3month",
-        "title": "3-month rainfall aggregate (mm)",
-        "server_layer_name": "r3h_dekad"
-      },
-      {
-        "id": "rainfall_agg_6month",
-        "title": "6-month rainfall aggregate (mm)",
-        "server_layer_name": "r6h_dekad"
-      },
-      {
-        "id": "rainfall_agg_9month",
-        "title": "9-month rainfall aggregate (mm)",
-        "server_layer_name": "r9h_dekad"
-      },
-      {
-        "id": "rainfall_dekad",
-        "title": "10-day rainfall estimate (mm)",
-        "server_layer_name": "rfh_dekad"
-      },
-      {
-        "id": "spi_1m",
-        "title": "SPI - 1-month",
-        "server_layer_name": "r1s_dekad"
-      },
-      {
-        "id": "spi_1y",
-        "title": "SPI - 1-year",
-        "server_layer_name": "rys_dekad"
-      },
-      {
-        "id": "spi_3m",
-        "title": "SPI - 3-month",
-        "server_layer_name": "r3s_dekad"
-      },
-      {
-        "id": "spi_6m",
-        "title": "SPI - 6-month",
-        "server_layer_name": "r6s_dekad"
-      },
-      {
-        "id": "spi_9m",
-        "title": "SPI - 9-month",
-        "server_layer_name": "r9s_dekad"
-      },
-      {
-        "id": "streak_dry_days",
-        "title": "Longest number of consecutive dry days",
-        "server_layer_name": "dlx_dekad"
-      },
-      {
-        "id": "streak_extreme_rain",
-        "title": "Longest consecutive extreme rainfall days",
-        "server_layer_name": "xle_dekad"
-      },
-      {
-        "id": "streak_heavy_rain",
-        "title": "Longest consecutive number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xlh_dekad"
-      },
-      {
-        "id": "streak_intense_rain",
-        "title": "Longest consecutive intense rainfall days",
-        "server_layer_name": "xli_dekad"
-      }
-    ],
-    "colombia": [],
-    "cuba": [
-      {
-        "id": "days_dry",
-        "title": "Days since last rain",
-        "server_layer_name": "dlc_dekad"
-      },
-      {
-        "id": "days_extreme_rain",
-        "title": "Number of days with extreme rainfall in the last 30 days",
-        "server_layer_name": "xne_dekad"
-      },
-      {
-        "id": "days_heavy_rain",
-        "title": "Number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xnh_dekad"
-      },
-      {
-        "id": "days_intense_rain",
-        "title": "Number of days with intense rainfall in the last 30 days",
-        "server_layer_name": "xni_dekad"
-      },
-      {
-        "id": "lst_amplitude",
-        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
-        "server_layer_name": "myd11a2_taa_dekad"
-      },
-      {
-        "id": "lst_anomaly",
-        "title": "Daytime Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_daytime",
-        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "lst_nighttime",
-        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "ndvi_dekad",
-        "title": "10-day NDVI (MODIS)",
-        "server_layer_name": "mxd13a2_vim_dekad"
-      },
-      {
-        "id": "ndvi_dekad_anomaly",
-        "title": "10-day NDVI anomaly (MODIS)",
-        "server_layer_name": "mxd13a2_viq_dekad"
-      },
-      {
-        "id": "precip_blended_1m",
-        "title": "Blended rainfall aggregate (1-month)",
-        "server_layer_name": "rfb_blended_cub_dekad"
-      },
-      {
-        "id": "precip_blended_1y",
-        "title": "Blended rainfall aggregate (1-year)",
-        "server_layer_name": "rfb_blended_cub_dekad"
-      },
-      {
-        "id": "precip_blended_3m",
-        "title": "Blended rainfall aggregate (3-month)",
-        "server_layer_name": "rfb_blended_cub_dekad"
-      },
-      {
-        "id": "precip_blended_6m",
-        "title": "Blended rainfall aggregate (6-month)",
-        "server_layer_name": "rfb_blended_cub_dekad"
-      },
-      {
-        "id": "precip_blended_9m",
-        "title": "Blended rainfall aggregate (9-month)",
-        "server_layer_name": "rfb_blended_cub_dekad"
-      },
-      {
-        "id": "precip_blended_anomaly_1m",
-        "title": "Blended rainfall anomaly (1-month)",
-        "server_layer_name": "rfq_blended_cub_dekad"
-      },
-      {
-        "id": "precip_blended_anomaly_1y",
-        "title": "Blended rainfall anomaly (1-year)",
-        "server_layer_name": "rfq_blended_cub_dekad"
-      },
-      {
-        "id": "precip_blended_anomaly_3m",
-        "title": "Blended rainfall anomaly (3-month)",
-        "server_layer_name": "rfq_blended_cub_dekad"
-      },
-      {
-        "id": "precip_blended_anomaly_6m",
-        "title": "Blended rainfall anomaly (6-month)",
-        "server_layer_name": "rfq_blended_cub_dekad"
-      },
-      {
-        "id": "precip_blended_anomaly_9m",
-        "title": "Blended rainfall anomaly (9-month)",
-        "server_layer_name": "rfq_blended_cub_dekad"
-      },
-      {
-        "id": "precip_blended_dekad",
-        "title": "Blended rainfall aggregate (10-day)",
-        "server_layer_name": "rfb_blended_cub_dekad"
-      },
-      {
-        "id": "precip_blended_dekad_anomaly",
-        "title": "Blended rainfall anomaly (10-day)",
-        "server_layer_name": "rfq_blended_cub_dekad"
-      },
-      {
-        "id": "rain_anomaly_1month",
-        "title": "Monthly rainfall anomaly",
-        "server_layer_name": "r1q_dekad"
-      },
-      {
-        "id": "rain_anomaly_1year",
-        "title": "1-year rainfall anomaly",
-        "server_layer_name": "ryq_dekad"
-      },
-      {
-        "id": "rain_anomaly_3month",
-        "title": "3-month rainfall anomaly",
-        "server_layer_name": "r3q_dekad"
-      },
-      {
-        "id": "rain_anomaly_6month",
-        "title": "6-month rainfall anomaly",
-        "server_layer_name": "r6q_dekad"
-      },
-      {
-        "id": "rain_anomaly_9month",
-        "title": "9-month rainfall anomaly",
-        "server_layer_name": "r9q_dekad"
-      },
-      {
-        "id": "rain_anomaly_dekad",
-        "title": "10-day rainfall anomaly",
-        "server_layer_name": "rfq_dekad"
-      },
-      {
-        "id": "rainfall_agg_1month",
-        "title": "1-month rainfall aggregate (mm)",
-        "server_layer_name": "r1h_dekad"
-      },
-      {
-        "id": "rainfall_agg_1year",
-        "title": "1-year rainfall aggregate (mm)",
-        "server_layer_name": "ryh_dekad"
-      },
-      {
-        "id": "rainfall_agg_3month",
-        "title": "3-month rainfall aggregate (mm)",
-        "server_layer_name": "r3h_dekad"
-      },
-      {
-        "id": "rainfall_agg_6month",
-        "title": "6-month rainfall aggregate (mm)",
-        "server_layer_name": "r6h_dekad"
-      },
-      {
-        "id": "rainfall_agg_9month",
-        "title": "9-month rainfall aggregate (mm)",
-        "server_layer_name": "r9h_dekad"
-      },
-      {
-        "id": "rainfall_dekad",
-        "title": "10-day rainfall estimate (mm)",
-        "server_layer_name": "rfh_dekad"
-      },
-      {
-        "id": "spi_1m",
-        "title": "SPI - 1-month",
-        "server_layer_name": "r1s_dekad"
-      },
-      {
-        "id": "spi_1y",
-        "title": "SPI - 1-year",
-        "server_layer_name": "rys_dekad"
-      },
-      {
-        "id": "spi_3m",
-        "title": "SPI - 3-month",
-        "server_layer_name": "r3s_dekad"
-      },
-      {
-        "id": "spi_6m",
-        "title": "SPI - 6-month",
-        "server_layer_name": "r6s_dekad"
-      },
-      {
-        "id": "spi_9m",
-        "title": "SPI - 9-month",
-        "server_layer_name": "r9s_dekad"
-      },
-      {
-        "id": "streak_dry_days",
-        "title": "Longest number of consecutive dry days",
-        "server_layer_name": "dlx_dekad"
-      },
-      {
-        "id": "streak_extreme_rain",
-        "title": "Longest consecutive extreme rainfall days",
-        "server_layer_name": "xle_dekad"
-      },
-      {
-        "id": "streak_heavy_rain",
-        "title": "Longest consecutive number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xlh_dekad"
-      },
-      {
-        "id": "streak_intense_rain",
-        "title": "Longest consecutive intense rainfall days",
-        "server_layer_name": "xli_dekad"
-      }
-    ],
-    "ecuador": [
-      {
-        "id": "days_dry",
-        "title": "Days since last rain",
-        "server_layer_name": "dlc_dekad"
-      },
-      {
-        "id": "days_extreme_rain",
-        "title": "Number of days with extreme rainfall in the last 30 days",
-        "server_layer_name": "xne_dekad"
-      },
-      {
-        "id": "days_heavy_rain",
-        "title": "Number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xnh_dekad"
-      },
-      {
-        "id": "days_intense_rain",
-        "title": "Number of days with intense rainfall in the last 30 days",
-        "server_layer_name": "xni_dekad"
-      },
-      {
-        "id": "lst_amplitude",
-        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
-        "server_layer_name": "myd11a2_taa_dekad"
-      },
-      {
-        "id": "lst_anomaly",
-        "title": "Daytime Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_daytime",
-        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "lst_nighttime",
-        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "ndvi_dekad",
-        "title": "10-day NDVI (MODIS)",
-        "server_layer_name": "mxd13a2_vim_dekad"
-      },
-      {
-        "id": "ndvi_dekad_anomaly",
-        "title": "10-day NDVI anomaly (MODIS)",
-        "server_layer_name": "mxd13a2_viq_dekad"
-      },
-      {
-        "id": "rain_anomaly_1month",
-        "title": "Monthly rainfall anomaly",
-        "server_layer_name": "r1q_dekad"
-      },
-      {
-        "id": "rain_anomaly_1year",
-        "title": "1-year rainfall anomaly",
-        "server_layer_name": "ryq_dekad"
-      },
-      {
-        "id": "rain_anomaly_3month",
-        "title": "3-month rainfall anomaly",
-        "server_layer_name": "r3q_dekad"
-      },
-      {
-        "id": "rain_anomaly_6month",
-        "title": "6-month rainfall anomaly",
-        "server_layer_name": "r6q_dekad"
-      },
-      {
-        "id": "rain_anomaly_9month",
-        "title": "9-month rainfall anomaly",
-        "server_layer_name": "r9q_dekad"
-      },
-      {
-        "id": "rain_anomaly_dekad",
-        "title": "10-day rainfall anomaly",
-        "server_layer_name": "rfq_dekad"
-      },
-      {
-        "id": "rainfall_agg_1month",
-        "title": "1-month rainfall aggregate (mm)",
-        "server_layer_name": "r1h_dekad"
-      },
-      {
-        "id": "rainfall_agg_1year",
-        "title": "1-year rainfall aggregate (mm)",
-        "server_layer_name": "ryh_dekad"
-      },
-      {
-        "id": "rainfall_agg_3month",
-        "title": "3-month rainfall aggregate (mm)",
-        "server_layer_name": "r3h_dekad"
-      },
-      {
-        "id": "rainfall_agg_6month",
-        "title": "6-month rainfall aggregate (mm)",
-        "server_layer_name": "r6h_dekad"
-      },
-      {
-        "id": "rainfall_agg_9month",
-        "title": "9-month rainfall aggregate (mm)",
-        "server_layer_name": "r9h_dekad"
-      },
-      {
-        "id": "rainfall_dekad",
-        "title": "10-day rainfall estimate (mm)",
-        "server_layer_name": "rfh_dekad"
-      },
-      {
-        "id": "spi_1m",
-        "title": "SPI - 1-month",
-        "server_layer_name": "r1s_dekad"
-      },
-      {
-        "id": "spi_1y",
-        "title": "SPI - 1-year",
-        "server_layer_name": "rys_dekad"
-      },
-      {
-        "id": "spi_3m",
-        "title": "SPI - 3-month",
-        "server_layer_name": "r3s_dekad"
-      },
-      {
-        "id": "spi_6m",
-        "title": "SPI - 6-month",
-        "server_layer_name": "r6s_dekad"
-      },
-      {
-        "id": "spi_9m",
-        "title": "SPI - 9-month",
-        "server_layer_name": "r9s_dekad"
-      },
-      {
-        "id": "streak_dry_days",
-        "title": "Longest number of consecutive dry days",
-        "server_layer_name": "dlx_dekad"
-      },
-      {
-        "id": "streak_extreme_rain",
-        "title": "Longest consecutive extreme rainfall days",
-        "server_layer_name": "xle_dekad"
-      },
-      {
-        "id": "streak_heavy_rain",
-        "title": "Longest consecutive number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xlh_dekad"
-      },
-      {
-        "id": "streak_intense_rain",
-        "title": "Longest consecutive intense rainfall days",
-        "server_layer_name": "xli_dekad"
-      }
-    ],
-    "global": [],
-    "haiti": [
       {
         "id": "daily_rainfall_forecast",
         "title": "Rolling daily rainfall forecast",
@@ -789,6 +52,11 @@
         "server_layer_name": "xni_dekad"
       },
       {
+        "id": "dekad_rainfall_anomaly_forecast",
+        "title": "10-day rainfall forecast anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
         "id": "dekad_rainfall_forecast",
         "title": "10-day rainfall forecast",
         "server_layer_name": "rfh_dekad_forecast"
@@ -804,9 +72,24 @@
         "server_layer_name": "myd11a2_txd_dekad"
       },
       {
+        "id": "lst_day_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
         "id": "lst_daytime",
         "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
         "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_nighttime",
+        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "monthly_water_anomaly",
+        "title": "Monthly Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_dekad"
       },
       {
         "id": "ndvi_dekad",
@@ -854,6 +137,802 @@
         "server_layer_name": "r6q_dekad"
       },
       {
+        "id": "rain_anomaly_7month",
+        "title": "7-month rainfall anomaly",
+        "server_layer_name": "r7q_dekad"
+      },
+      {
+        "id": "rain_anomaly_8month",
+        "title": "8-month rainfall anomaly",
+        "server_layer_name": "r8q_dekad"
+      },
+      {
+        "id": "rain_anomaly_9month",
+        "title": "9-month rainfall anomaly",
+        "server_layer_name": "r9q_dekad"
+      },
+      {
+        "id": "rain_anomaly_dekad",
+        "title": "10-day rainfall anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rainfall_agg_1month",
+        "title": "1-month rainfall aggregate",
+        "server_layer_name": "r1h_dekad"
+      },
+      {
+        "id": "rainfall_agg_1year",
+        "title": "1-year rainfall aggregate (mm)",
+        "server_layer_name": "ryh_dekad"
+      },
+      {
+        "id": "rainfall_agg_2month",
+        "title": "2-month rainfall aggregate (mm)",
+        "server_layer_name": "r2h_dekad"
+      },
+      {
+        "id": "rainfall_agg_3month",
+        "title": "3-month rainfall aggregate (mm)",
+        "server_layer_name": "r3h_dekad"
+      },
+      {
+        "id": "rainfall_agg_4month",
+        "title": "4-month rainfall aggregate (mm)",
+        "server_layer_name": "r4h_dekad"
+      },
+      {
+        "id": "rainfall_agg_5month",
+        "title": "5-month rainfall aggregate (mm)",
+        "server_layer_name": "r5h_dekad"
+      },
+      {
+        "id": "rainfall_agg_6month",
+        "title": "6-month rainfall aggregate (mm)",
+        "server_layer_name": "r6h_dekad"
+      },
+      {
+        "id": "rainfall_agg_7month",
+        "title": "7-month rainfall aggregate (mm)",
+        "server_layer_name": "r7h_dekad"
+      },
+      {
+        "id": "rainfall_agg_8month",
+        "title": "8-month rainfall aggregate (mm)",
+        "server_layer_name": "r8h_dekad"
+      },
+      {
+        "id": "rainfall_agg_9month",
+        "title": "9-month rainfall aggregate (mm)",
+        "server_layer_name": "r9h_dekad"
+      },
+      {
+        "id": "rainfall_dekad",
+        "title": "10-day rainfall estimate (mm)",
+        "server_layer_name": "rfh_dekad"
+      },
+      {
+        "id": "spi_1m",
+        "title": "SPI - 1-month",
+        "server_layer_name": "r1s_dekad"
+      },
+      {
+        "id": "spi_1y",
+        "title": "SPI - 1-year",
+        "server_layer_name": "rys_dekad"
+      },
+      {
+        "id": "spi_2m",
+        "title": "SPI - 2-month",
+        "server_layer_name": "r2s_dekad"
+      },
+      {
+        "id": "spi_3m",
+        "title": "SPI - 3-month",
+        "server_layer_name": "r3s_dekad"
+      },
+      {
+        "id": "spi_6m",
+        "title": "SPI - 6-month",
+        "server_layer_name": "r6s_dekad"
+      },
+      {
+        "id": "spi_9m",
+        "title": "SPI - 9-month",
+        "server_layer_name": "r9s_dekad"
+      },
+      {
+        "id": "streak_dry_days",
+        "title": "Longest dry spell",
+        "server_layer_name": "dlx_dekad"
+      },
+      {
+        "id": "streak_extreme_rain",
+        "title": "Longest consecutive extreme rainfall days",
+        "server_layer_name": "xle_dekad"
+      },
+      {
+        "id": "streak_heavy_rain",
+        "title": "Longest consecutive heavy rainfall days",
+        "server_layer_name": "xlh_dekad"
+      },
+      {
+        "id": "streak_intense_rain",
+        "title": "Longest consecutive intense rainfall days",
+        "server_layer_name": "xli_dekad"
+      }
+    ],
+    "bhutan": [
+      {
+        "id": "2m_water_anomaly",
+        "title": "2-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_2month"
+      },
+      {
+        "id": "3m_water_anomaly",
+        "title": "3-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_3month"
+      },
+      {
+        "id": "4m_water_anomaly",
+        "title": "4-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_4month"
+      },
+      {
+        "id": "5m_water_anomaly",
+        "title": "5-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_5month"
+      },
+      {
+        "id": "6m_water_anomaly",
+        "title": "6-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_6month"
+      },
+      {
+        "id": "daily_rainfall_forecast",
+        "title": "Rolling daily rainfall forecast",
+        "server_layer_name": "rfh_daily_forecast"
+      },
+      {
+        "id": "days_dry",
+        "title": "Days since last rain",
+        "server_layer_name": "dlc_dekad"
+      },
+      {
+        "id": "days_extreme_rain",
+        "title": "Number of days with extreme rainfall in the last 30 days",
+        "server_layer_name": "xne_dekad"
+      },
+      {
+        "id": "days_heavy_rain",
+        "title": "Number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xnh_dekad"
+      },
+      {
+        "id": "days_intense_rain",
+        "title": "Number of days with intense rainfall in the last 30 days",
+        "server_layer_name": "xni_dekad"
+      },
+      {
+        "id": "dekad_rainfall_anomaly_forecast",
+        "title": "10-day rainfall forecast anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "dekad_rainfall_forecast",
+        "title": "10-day rainfall forecast",
+        "server_layer_name": "rfh_dekad_forecast"
+      },
+      {
+        "id": "lst_amplitude",
+        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
+        "server_layer_name": "myd11a2_taa_dekad"
+      },
+      {
+        "id": "lst_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_day_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_daytime",
+        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_nighttime",
+        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "monthly_water_anomaly",
+        "title": "Monthly Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_dekad"
+      },
+      {
+        "id": "ndvi_dekad",
+        "title": "10-day NDVI (MODIS)",
+        "server_layer_name": "mxd13a2_vim_dekad"
+      },
+      {
+        "id": "ndvi_dekad_anomaly",
+        "title": "10-day NDVI anomaly (MODIS)",
+        "server_layer_name": "mxd13a2_viq_dekad"
+      },
+      {
+        "id": "rain_anomaly_1month",
+        "title": "Monthly rainfall anomaly",
+        "server_layer_name": "r1q_dekad"
+      },
+      {
+        "id": "rain_anomaly_1year",
+        "title": "1-year rainfall anomaly",
+        "server_layer_name": "ryq_dekad"
+      },
+      {
+        "id": "rain_anomaly_2month",
+        "title": "2-month rainfall anomaly",
+        "server_layer_name": "r2q_dekad"
+      },
+      {
+        "id": "rain_anomaly_3month",
+        "title": "3-month rainfall anomaly",
+        "server_layer_name": "r3q_dekad"
+      },
+      {
+        "id": "rain_anomaly_4month",
+        "title": "4-month rainfall anomaly",
+        "server_layer_name": "r4q_dekad"
+      },
+      {
+        "id": "rain_anomaly_5month",
+        "title": "5-month rainfall anomaly",
+        "server_layer_name": "r5q_dekad"
+      },
+      {
+        "id": "rain_anomaly_6month",
+        "title": "6-month rainfall anomaly",
+        "server_layer_name": "r6q_dekad"
+      },
+      {
+        "id": "rain_anomaly_7month",
+        "title": "7-month rainfall anomaly",
+        "server_layer_name": "r7q_dekad"
+      },
+      {
+        "id": "rain_anomaly_8month",
+        "title": "8-month rainfall anomaly",
+        "server_layer_name": "r8q_dekad"
+      },
+      {
+        "id": "rain_anomaly_9month",
+        "title": "9-month rainfall anomaly",
+        "server_layer_name": "r9q_dekad"
+      },
+      {
+        "id": "rain_anomaly_dekad",
+        "title": "10-day rainfall anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rainfall_agg_1month",
+        "title": "1-month rainfall aggregate",
+        "server_layer_name": "r1h_dekad"
+      },
+      {
+        "id": "rainfall_agg_1year",
+        "title": "1-year rainfall aggregate (mm)",
+        "server_layer_name": "ryh_dekad"
+      },
+      {
+        "id": "rainfall_agg_2month",
+        "title": "2-month rainfall aggregate (mm)",
+        "server_layer_name": "r2h_dekad"
+      },
+      {
+        "id": "rainfall_agg_3month",
+        "title": "3-month rainfall aggregate (mm)",
+        "server_layer_name": "r3h_dekad"
+      },
+      {
+        "id": "rainfall_agg_4month",
+        "title": "4-month rainfall aggregate (mm)",
+        "server_layer_name": "r4h_dekad"
+      },
+      {
+        "id": "rainfall_agg_5month",
+        "title": "5-month rainfall aggregate (mm)",
+        "server_layer_name": "r5h_dekad"
+      },
+      {
+        "id": "rainfall_agg_6month",
+        "title": "6-month rainfall aggregate (mm)",
+        "server_layer_name": "r6h_dekad"
+      },
+      {
+        "id": "rainfall_agg_7month",
+        "title": "7-month rainfall aggregate (mm)",
+        "server_layer_name": "r7h_dekad"
+      },
+      {
+        "id": "rainfall_agg_8month",
+        "title": "8-month rainfall aggregate (mm)",
+        "server_layer_name": "r8h_dekad"
+      },
+      {
+        "id": "rainfall_agg_9month",
+        "title": "9-month rainfall aggregate (mm)",
+        "server_layer_name": "r9h_dekad"
+      },
+      {
+        "id": "rainfall_dekad",
+        "title": "10-day rainfall estimate (mm)",
+        "server_layer_name": "rfh_dekad"
+      },
+      {
+        "id": "spi_1m",
+        "title": "SPI - 1-month",
+        "server_layer_name": "r1s_dekad"
+      },
+      {
+        "id": "spi_1y",
+        "title": "SPI - 1-year",
+        "server_layer_name": "rys_dekad"
+      },
+      {
+        "id": "spi_2m",
+        "title": "SPI - 2-month",
+        "server_layer_name": "r2s_dekad"
+      },
+      {
+        "id": "spi_3m",
+        "title": "SPI - 3-month",
+        "server_layer_name": "r3s_dekad"
+      },
+      {
+        "id": "spi_6m",
+        "title": "SPI - 6-month",
+        "server_layer_name": "r6s_dekad"
+      },
+      {
+        "id": "spi_9m",
+        "title": "SPI - 9-month",
+        "server_layer_name": "r9s_dekad"
+      },
+      {
+        "id": "streak_dry_days",
+        "title": "Longest dry spell",
+        "server_layer_name": "dlx_dekad"
+      },
+      {
+        "id": "streak_extreme_rain",
+        "title": "Longest consecutive extreme rainfall days",
+        "server_layer_name": "xle_dekad"
+      },
+      {
+        "id": "streak_heavy_rain",
+        "title": "Longest consecutive heavy rainfall days",
+        "server_layer_name": "xlh_dekad"
+      },
+      {
+        "id": "streak_intense_rain",
+        "title": "Longest consecutive intense rainfall days",
+        "server_layer_name": "xli_dekad"
+      }
+    ],
+    "cambodia": [
+      {
+        "id": "2m_water_anomaly",
+        "title": "2-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_2month"
+      },
+      {
+        "id": "3m_water_anomaly",
+        "title": "3-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_3month"
+      },
+      {
+        "id": "4m_water_anomaly",
+        "title": "4-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_4month"
+      },
+      {
+        "id": "5m_water_anomaly",
+        "title": "5-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_5month"
+      },
+      {
+        "id": "6m_water_anomaly",
+        "title": "6-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_6month"
+      },
+      {
+        "id": "daily_rainfall_forecast",
+        "title": "Rolling daily rainfall forecast",
+        "server_layer_name": "rfh_daily_forecast"
+      },
+      {
+        "id": "days_dry",
+        "title": "Days since last rain",
+        "server_layer_name": "dlc_dekad"
+      },
+      {
+        "id": "days_extreme_rain",
+        "title": "Number of days with extreme rainfall in the last 30 days",
+        "server_layer_name": "xne_dekad"
+      },
+      {
+        "id": "days_heavy_rain",
+        "title": "Number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xnh_dekad"
+      },
+      {
+        "id": "days_intense_rain",
+        "title": "Number of days with intense rainfall in the last 30 days",
+        "server_layer_name": "xni_dekad"
+      },
+      {
+        "id": "dekad_rainfall_anomaly_forecast",
+        "title": "10-day rainfall forecast anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "dekad_rainfall_forecast",
+        "title": "10-day rainfall forecast",
+        "server_layer_name": "rfh_dekad_forecast"
+      },
+      {
+        "id": "lst_amplitude",
+        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
+        "server_layer_name": "myd11a2_taa_dekad"
+      },
+      {
+        "id": "lst_anomaly",
+        "title": "Daytime Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_day_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_daytime",
+        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_nighttime",
+        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "monthly_water_anomaly",
+        "title": "Monthly Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_dekad"
+      },
+      {
+        "id": "ndvi_dekad",
+        "title": "10-day NDVI (MODIS)",
+        "server_layer_name": "mxd13a2_vim_dekad"
+      },
+      {
+        "id": "ndvi_dekad_anomaly",
+        "title": "10-day NDVI anomaly (MODIS)",
+        "server_layer_name": "mxd13a2_viq_dekad"
+      },
+      {
+        "id": "rain_anomaly_1month",
+        "title": "Monthly rainfall anomaly",
+        "server_layer_name": "r1q_dekad"
+      },
+      {
+        "id": "rain_anomaly_1year",
+        "title": "1-year rainfall anomaly",
+        "server_layer_name": "ryq_dekad"
+      },
+      {
+        "id": "rain_anomaly_2month",
+        "title": "2-month rainfall anomaly",
+        "server_layer_name": "r2q_dekad"
+      },
+      {
+        "id": "rain_anomaly_3month",
+        "title": "3-month rainfall anomaly",
+        "server_layer_name": "r3q_dekad"
+      },
+      {
+        "id": "rain_anomaly_4month",
+        "title": "4-month rainfall anomaly",
+        "server_layer_name": "r4q_dekad"
+      },
+      {
+        "id": "rain_anomaly_5month",
+        "title": "5-month rainfall anomaly",
+        "server_layer_name": "r5q_dekad"
+      },
+      {
+        "id": "rain_anomaly_6month",
+        "title": "6-month rainfall anomaly",
+        "server_layer_name": "r6q_dekad"
+      },
+      {
+        "id": "rain_anomaly_7month",
+        "title": "7-month rainfall anomaly",
+        "server_layer_name": "r7q_dekad"
+      },
+      {
+        "id": "rain_anomaly_8month",
+        "title": "8-month rainfall anomaly",
+        "server_layer_name": "r8q_dekad"
+      },
+      {
+        "id": "rain_anomaly_9month",
+        "title": "9-month rainfall anomaly",
+        "server_layer_name": "r9q_dekad"
+      },
+      {
+        "id": "rain_anomaly_dekad",
+        "title": "10-day rainfall anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rainfall_agg_1month",
+        "title": "1-month rainfall aggregate",
+        "server_layer_name": "r1h_dekad"
+      },
+      {
+        "id": "rainfall_agg_1year",
+        "title": "1-year rainfall aggregate (mm)",
+        "server_layer_name": "ryh_dekad"
+      },
+      {
+        "id": "rainfall_agg_2month",
+        "title": "2-month rainfall aggregate (mm)",
+        "server_layer_name": "r2h_dekad"
+      },
+      {
+        "id": "rainfall_agg_3month",
+        "title": "3-month rainfall aggregate (mm)",
+        "server_layer_name": "r3h_dekad"
+      },
+      {
+        "id": "rainfall_agg_4month",
+        "title": "4-month rainfall aggregate (mm)",
+        "server_layer_name": "r4h_dekad"
+      },
+      {
+        "id": "rainfall_agg_5month",
+        "title": "5-month rainfall aggregate (mm)",
+        "server_layer_name": "r5h_dekad"
+      },
+      {
+        "id": "rainfall_agg_6month",
+        "title": "6-month rainfall aggregate (mm)",
+        "server_layer_name": "r6h_dekad"
+      },
+      {
+        "id": "rainfall_agg_7month",
+        "title": "7-month rainfall aggregate (mm)",
+        "server_layer_name": "r7h_dekad"
+      },
+      {
+        "id": "rainfall_agg_8month",
+        "title": "8-month rainfall aggregate (mm)",
+        "server_layer_name": "r8h_dekad"
+      },
+      {
+        "id": "rainfall_agg_9month",
+        "title": "9-month rainfall aggregate (mm)",
+        "server_layer_name": "r9h_dekad"
+      },
+      {
+        "id": "rainfall_dekad",
+        "title": "10-day rainfall estimate (mm)",
+        "server_layer_name": "rfh_dekad"
+      },
+      {
+        "id": "spi_1m",
+        "title": "SPI - 1-month",
+        "server_layer_name": "r1s_dekad"
+      },
+      {
+        "id": "spi_1y",
+        "title": "SPI - 1-year",
+        "server_layer_name": "rys_dekad"
+      },
+      {
+        "id": "spi_2m",
+        "title": "SPI - 2-month",
+        "server_layer_name": "r2s_dekad"
+      },
+      {
+        "id": "spi_3m",
+        "title": "SPI - 3-month",
+        "server_layer_name": "r3s_dekad"
+      },
+      {
+        "id": "spi_6m",
+        "title": "SPI - 6-month",
+        "server_layer_name": "r6s_dekad"
+      },
+      {
+        "id": "spi_9m",
+        "title": "SPI - 9-month",
+        "server_layer_name": "r9s_dekad"
+      },
+      {
+        "id": "streak_dry_days",
+        "title": "Longest number of consecutive dry days",
+        "server_layer_name": "dlx_dekad"
+      },
+      {
+        "id": "streak_extreme_rain",
+        "title": "Longest consecutive extreme rainfall days",
+        "server_layer_name": "xle_dekad"
+      },
+      {
+        "id": "streak_heavy_rain",
+        "title": "Longest consecutive number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xlh_dekad"
+      },
+      {
+        "id": "streak_intense_rain",
+        "title": "Longest consecutive intense rainfall days",
+        "server_layer_name": "xli_dekad"
+      }
+    ],
+    "cameroon": [
+      {
+        "id": "2m_water_anomaly",
+        "title": "2-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_2month"
+      },
+      {
+        "id": "3m_water_anomaly",
+        "title": "3-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_3month"
+      },
+      {
+        "id": "4m_water_anomaly",
+        "title": "4-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_4month"
+      },
+      {
+        "id": "5m_water_anomaly",
+        "title": "5-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_5month"
+      },
+      {
+        "id": "6m_water_anomaly",
+        "title": "6-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_6month"
+      },
+      {
+        "id": "daily_rainfall_forecast",
+        "title": "Rolling daily rainfall forecast",
+        "server_layer_name": "rfh_daily_forecast"
+      },
+      {
+        "id": "days_dry",
+        "title": "Days since last rain",
+        "server_layer_name": "dlc_dekad"
+      },
+      {
+        "id": "days_extreme_rain",
+        "title": "Number of days with extreme rainfall in the last 30 days",
+        "server_layer_name": "xne_dekad"
+      },
+      {
+        "id": "days_heavy_rain",
+        "title": "Number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xnh_dekad"
+      },
+      {
+        "id": "days_intense_rain",
+        "title": "Number of days with intense rainfall in the last 30 days",
+        "server_layer_name": "xni_dekad"
+      },
+      {
+        "id": "dekad_rainfall_anomaly_forecast",
+        "title": "10-day rainfall forecast anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "dekad_rainfall_forecast",
+        "title": "10-day rainfall forecast",
+        "server_layer_name": "rfh_dekad_forecast"
+      },
+      {
+        "id": "lst_amplitude",
+        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
+        "server_layer_name": "myd11a2_taa_dekad"
+      },
+      {
+        "id": "lst_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_day_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_daytime",
+        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_nighttime",
+        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "monthly_water_anomaly",
+        "title": "Monthly Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_dekad"
+      },
+      {
+        "id": "ndvi_dekad",
+        "title": "10-day NDVI (MODIS)",
+        "server_layer_name": "mxd13a2_vim_dekad"
+      },
+      {
+        "id": "ndvi_dekad_anomaly",
+        "title": "10-day NDVI anomaly (MODIS)",
+        "server_layer_name": "mxd13a2_viq_dekad"
+      },
+      {
+        "id": "rain_anomaly_1month",
+        "title": "Monthly rainfall anomaly",
+        "server_layer_name": "r1q_dekad"
+      },
+      {
+        "id": "rain_anomaly_1year",
+        "title": "1-year rainfall anomaly",
+        "server_layer_name": "ryq_dekad"
+      },
+      {
+        "id": "rain_anomaly_2month",
+        "title": "2-month rainfall anomaly",
+        "server_layer_name": "r2q_dekad"
+      },
+      {
+        "id": "rain_anomaly_3month",
+        "title": "3-month rainfall anomaly",
+        "server_layer_name": "r3q_dekad"
+      },
+      {
+        "id": "rain_anomaly_4month",
+        "title": "4-month rainfall anomaly",
+        "server_layer_name": "r4q_dekad"
+      },
+      {
+        "id": "rain_anomaly_5month",
+        "title": "5-month rainfall anomaly",
+        "server_layer_name": "r5q_dekad"
+      },
+      {
+        "id": "rain_anomaly_6month",
+        "title": "6-month rainfall anomaly",
+        "server_layer_name": "r6q_dekad"
+      },
+      {
+        "id": "rain_anomaly_7month",
+        "title": "7-month rainfall anomaly",
+        "server_layer_name": "r7q_dekad"
+      },
+      {
+        "id": "rain_anomaly_8month",
+        "title": "8-month rainfall anomaly",
+        "server_layer_name": "r8q_dekad"
+      },
+      {
         "id": "rain_anomaly_9month",
         "title": "9-month rainfall anomaly",
         "server_layer_name": "r9q_dekad"
@@ -899,6 +978,16 @@
         "server_layer_name": "r6h_dekad"
       },
       {
+        "id": "rainfall_agg_7month",
+        "title": "7-month rainfall aggregate (mm)",
+        "server_layer_name": "r7h_dekad"
+      },
+      {
+        "id": "rainfall_agg_8month",
+        "title": "8-month rainfall aggregate (mm)",
+        "server_layer_name": "r8h_dekad"
+      },
+      {
         "id": "rainfall_agg_9month",
         "title": "9-month rainfall aggregate (mm)",
         "server_layer_name": "r9h_dekad"
@@ -917,6 +1006,1321 @@
         "id": "spi_1y",
         "title": "SPI - 1-year",
         "server_layer_name": "rys_dekad"
+      },
+      {
+        "id": "spi_2m",
+        "title": "SPI - 2-month",
+        "server_layer_name": "r2s_dekad"
+      },
+      {
+        "id": "spi_3m",
+        "title": "SPI - 3-month",
+        "server_layer_name": "r3s_dekad"
+      },
+      {
+        "id": "spi_6m",
+        "title": "SPI - 6-month",
+        "server_layer_name": "r6s_dekad"
+      },
+      {
+        "id": "spi_9m",
+        "title": "SPI - 9-month",
+        "server_layer_name": "r9s_dekad"
+      },
+      {
+        "id": "streak_dry_days",
+        "title": "Longest number of consecutive dry days",
+        "server_layer_name": "dlx_dekad"
+      },
+      {
+        "id": "streak_extreme_rain",
+        "title": "Longest consecutive extreme rainfall days",
+        "server_layer_name": "xle_dekad"
+      },
+      {
+        "id": "streak_heavy_rain",
+        "title": "Longest consecutive number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xlh_dekad"
+      },
+      {
+        "id": "streak_intense_rain",
+        "title": "Longest consecutive intense rainfall days",
+        "server_layer_name": "xli_dekad"
+      }
+    ],
+    "colombia": [
+      {
+        "id": "2m_water_anomaly",
+        "title": "2-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_2month"
+      },
+      {
+        "id": "3m_water_anomaly",
+        "title": "3-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_3month"
+      },
+      {
+        "id": "4m_water_anomaly",
+        "title": "4-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_4month"
+      },
+      {
+        "id": "5m_water_anomaly",
+        "title": "5-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_5month"
+      },
+      {
+        "id": "6m_water_anomaly",
+        "title": "6-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_6month"
+      },
+      {
+        "id": "daily_rainfall_forecast",
+        "title": "Rolling daily rainfall forecast",
+        "server_layer_name": "rfh_daily_forecast"
+      },
+      {
+        "id": "days_dry",
+        "title": "Days since last rain",
+        "server_layer_name": "dlc_dekad"
+      },
+      {
+        "id": "days_extreme_rain",
+        "title": "Number of days with extreme rainfall in the last 30 days",
+        "server_layer_name": "xne_dekad"
+      },
+      {
+        "id": "days_heavy_rain",
+        "title": "Number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xnh_dekad"
+      },
+      {
+        "id": "days_intense_rain",
+        "title": "Number of days with intense rainfall in the last 30 days",
+        "server_layer_name": "xni_dekad"
+      },
+      {
+        "id": "dekad_rainfall_anomaly_forecast",
+        "title": "10-day rainfall forecast anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "dekad_rainfall_forecast",
+        "title": "10-day rainfall forecast",
+        "server_layer_name": "rfh_dekad_forecast"
+      },
+      {
+        "id": "lst_amplitude",
+        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
+        "server_layer_name": "myd11a2_taa_dekad"
+      },
+      {
+        "id": "lst_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_day_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_daytime",
+        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_nighttime",
+        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "monthly_water_anomaly",
+        "title": "Monthly Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_dekad"
+      },
+      {
+        "id": "ndvi_dekad",
+        "title": "10-day NDVI (MODIS)",
+        "server_layer_name": "mxd13a2_vim_dekad"
+      },
+      {
+        "id": "ndvi_dekad_anomaly",
+        "title": "10-day NDVI anomaly (MODIS)",
+        "server_layer_name": "mxd13a2_viq_dekad"
+      },
+      {
+        "id": "rain_anomaly_1month",
+        "title": "Monthly rainfall anomaly",
+        "server_layer_name": "r1q_dekad"
+      },
+      {
+        "id": "rain_anomaly_1year",
+        "title": "1-year rainfall anomaly",
+        "server_layer_name": "ryq_dekad"
+      },
+      {
+        "id": "rain_anomaly_2month",
+        "title": "2-month rainfall anomaly",
+        "server_layer_name": "r2q_dekad"
+      },
+      {
+        "id": "rain_anomaly_3month",
+        "title": "3-month rainfall anomaly",
+        "server_layer_name": "r3q_dekad"
+      },
+      {
+        "id": "rain_anomaly_4month",
+        "title": "4-month rainfall anomaly",
+        "server_layer_name": "r4q_dekad"
+      },
+      {
+        "id": "rain_anomaly_5month",
+        "title": "5-month rainfall anomaly",
+        "server_layer_name": "r5q_dekad"
+      },
+      {
+        "id": "rain_anomaly_6month",
+        "title": "6-month rainfall anomaly",
+        "server_layer_name": "r6q_dekad"
+      },
+      {
+        "id": "rain_anomaly_7month",
+        "title": "7-month rainfall anomaly",
+        "server_layer_name": "r7q_dekad"
+      },
+      {
+        "id": "rain_anomaly_8month",
+        "title": "8-month rainfall anomaly",
+        "server_layer_name": "r8q_dekad"
+      },
+      {
+        "id": "rain_anomaly_9month",
+        "title": "9-month rainfall anomaly",
+        "server_layer_name": "r9q_dekad"
+      },
+      {
+        "id": "rain_anomaly_dekad",
+        "title": "10-day rainfall anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rainfall_agg_1month",
+        "title": "1-month rainfall aggregate",
+        "server_layer_name": "r1h_dekad"
+      },
+      {
+        "id": "rainfall_agg_1year",
+        "title": "1-year rainfall aggregate (mm)",
+        "server_layer_name": "ryh_dekad"
+      },
+      {
+        "id": "rainfall_agg_2month",
+        "title": "2-month rainfall aggregate (mm)",
+        "server_layer_name": "r2h_dekad"
+      },
+      {
+        "id": "rainfall_agg_3month",
+        "title": "3-month rainfall aggregate (mm)",
+        "server_layer_name": "r3h_dekad"
+      },
+      {
+        "id": "rainfall_agg_4month",
+        "title": "4-month rainfall aggregate (mm)",
+        "server_layer_name": "r4h_dekad"
+      },
+      {
+        "id": "rainfall_agg_5month",
+        "title": "5-month rainfall aggregate (mm)",
+        "server_layer_name": "r5h_dekad"
+      },
+      {
+        "id": "rainfall_agg_6month",
+        "title": "6-month rainfall aggregate (mm)",
+        "server_layer_name": "r6h_dekad"
+      },
+      {
+        "id": "rainfall_agg_7month",
+        "title": "7-month rainfall aggregate (mm)",
+        "server_layer_name": "r7h_dekad"
+      },
+      {
+        "id": "rainfall_agg_8month",
+        "title": "8-month rainfall aggregate (mm)",
+        "server_layer_name": "r8h_dekad"
+      },
+      {
+        "id": "rainfall_agg_9month",
+        "title": "9-month rainfall aggregate (mm)",
+        "server_layer_name": "r9h_dekad"
+      },
+      {
+        "id": "rainfall_dekad",
+        "title": "10-day rainfall estimate (mm)",
+        "server_layer_name": "rfh_dekad"
+      },
+      {
+        "id": "spi_1m",
+        "title": "SPI - 1-month",
+        "server_layer_name": "r1s_dekad"
+      },
+      {
+        "id": "spi_1y",
+        "title": "SPI - 1-year",
+        "server_layer_name": "rys_dekad"
+      },
+      {
+        "id": "spi_2m",
+        "title": "SPI - 2-month",
+        "server_layer_name": "r2s_dekad"
+      },
+      {
+        "id": "spi_3m",
+        "title": "SPI - 3-month",
+        "server_layer_name": "r3s_dekad"
+      },
+      {
+        "id": "spi_6m",
+        "title": "SPI - 6-month",
+        "server_layer_name": "r6s_dekad"
+      },
+      {
+        "id": "spi_9m",
+        "title": "SPI - 9-month",
+        "server_layer_name": "r9s_dekad"
+      },
+      {
+        "id": "streak_dry_days",
+        "title": "Longest dry spell",
+        "server_layer_name": "dlx_dekad"
+      },
+      {
+        "id": "streak_extreme_rain",
+        "title": "Longest consecutive extreme rainfall days",
+        "server_layer_name": "xle_dekad"
+      },
+      {
+        "id": "streak_heavy_rain",
+        "title": "Longest consecutive heavy rainfall days",
+        "server_layer_name": "xlh_dekad"
+      },
+      {
+        "id": "streak_intense_rain",
+        "title": "Longest consecutive intense rainfall days",
+        "server_layer_name": "xli_dekad"
+      }
+    ],
+    "cuba": [
+      {
+        "id": "2m_water_anomaly",
+        "title": "2-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_2month"
+      },
+      {
+        "id": "3m_water_anomaly",
+        "title": "3-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_3month"
+      },
+      {
+        "id": "4m_water_anomaly",
+        "title": "4-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_4month"
+      },
+      {
+        "id": "5m_water_anomaly",
+        "title": "5-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_5month"
+      },
+      {
+        "id": "6m_water_anomaly",
+        "title": "6-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_6month"
+      },
+      {
+        "id": "daily_rainfall_forecast",
+        "title": "Rolling daily rainfall forecast",
+        "server_layer_name": "rfh_daily_forecast"
+      },
+      {
+        "id": "days_dry",
+        "title": "Days since last rain",
+        "server_layer_name": "dlc_dekad"
+      },
+      {
+        "id": "days_extreme_rain",
+        "title": "Number of days with extreme rainfall in the last 30 days",
+        "server_layer_name": "xne_dekad"
+      },
+      {
+        "id": "days_heavy_rain",
+        "title": "Number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xnh_dekad"
+      },
+      {
+        "id": "days_intense_rain",
+        "title": "Number of days with intense rainfall in the last 30 days",
+        "server_layer_name": "xni_dekad"
+      },
+      {
+        "id": "dekad_rainfall_anomaly_forecast",
+        "title": "10-day rainfall forecast anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "dekad_rainfall_forecast",
+        "title": "10-day rainfall forecast",
+        "server_layer_name": "rfh_dekad_forecast"
+      },
+      {
+        "id": "lst_amplitude",
+        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
+        "server_layer_name": "myd11a2_taa_dekad"
+      },
+      {
+        "id": "lst_anomaly",
+        "title": "Daytime Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_day_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_daytime",
+        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_nighttime",
+        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "monthly_water_anomaly",
+        "title": "Monthly Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_dekad"
+      },
+      {
+        "id": "ndvi_dekad",
+        "title": "10-day NDVI (MODIS)",
+        "server_layer_name": "mxd13a2_vim_dekad"
+      },
+      {
+        "id": "ndvi_dekad_anomaly",
+        "title": "10-day NDVI anomaly (MODIS)",
+        "server_layer_name": "mxd13a2_viq_dekad"
+      },
+      {
+        "id": "rain_anomaly_1month",
+        "title": "Monthly rainfall anomaly",
+        "server_layer_name": "r1q_dekad"
+      },
+      {
+        "id": "rain_anomaly_1year",
+        "title": "1-year rainfall anomaly",
+        "server_layer_name": "ryq_dekad"
+      },
+      {
+        "id": "rain_anomaly_2month",
+        "title": "2-month rainfall anomaly",
+        "server_layer_name": "r2q_dekad"
+      },
+      {
+        "id": "rain_anomaly_3month",
+        "title": "3-month rainfall anomaly",
+        "server_layer_name": "r3q_dekad"
+      },
+      {
+        "id": "rain_anomaly_4month",
+        "title": "4-month rainfall anomaly",
+        "server_layer_name": "r4q_dekad"
+      },
+      {
+        "id": "rain_anomaly_5month",
+        "title": "5-month rainfall anomaly",
+        "server_layer_name": "r5q_dekad"
+      },
+      {
+        "id": "rain_anomaly_6month",
+        "title": "6-month rainfall anomaly",
+        "server_layer_name": "r6q_dekad"
+      },
+      {
+        "id": "rain_anomaly_7month",
+        "title": "7-month rainfall anomaly",
+        "server_layer_name": "r7q_dekad"
+      },
+      {
+        "id": "rain_anomaly_8month",
+        "title": "8-month rainfall anomaly",
+        "server_layer_name": "r8q_dekad"
+      },
+      {
+        "id": "rain_anomaly_9month",
+        "title": "9-month rainfall anomaly",
+        "server_layer_name": "r9q_dekad"
+      },
+      {
+        "id": "rain_anomaly_dekad",
+        "title": "10-day rainfall anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rainfall_agg_1month",
+        "title": "1-month rainfall aggregate (mm)",
+        "server_layer_name": "r1h_dekad"
+      },
+      {
+        "id": "rainfall_agg_1year",
+        "title": "1-year rainfall aggregate (mm)",
+        "server_layer_name": "ryh_dekad"
+      },
+      {
+        "id": "rainfall_agg_2month",
+        "title": "2-month rainfall aggregate (mm)",
+        "server_layer_name": "r2h_dekad"
+      },
+      {
+        "id": "rainfall_agg_3month",
+        "title": "3-month rainfall aggregate (mm)",
+        "server_layer_name": "r3h_dekad"
+      },
+      {
+        "id": "rainfall_agg_4month",
+        "title": "4-month rainfall aggregate (mm)",
+        "server_layer_name": "r4h_dekad"
+      },
+      {
+        "id": "rainfall_agg_5month",
+        "title": "5-month rainfall aggregate (mm)",
+        "server_layer_name": "r5h_dekad"
+      },
+      {
+        "id": "rainfall_agg_6month",
+        "title": "6-month rainfall aggregate (mm)",
+        "server_layer_name": "r6h_dekad"
+      },
+      {
+        "id": "rainfall_agg_7month",
+        "title": "7-month rainfall aggregate (mm)",
+        "server_layer_name": "r7h_dekad"
+      },
+      {
+        "id": "rainfall_agg_8month",
+        "title": "8-month rainfall aggregate (mm)",
+        "server_layer_name": "r8h_dekad"
+      },
+      {
+        "id": "rainfall_agg_9month",
+        "title": "9-month rainfall aggregate (mm)",
+        "server_layer_name": "r9h_dekad"
+      },
+      {
+        "id": "rainfall_dekad",
+        "title": "10-day rainfall estimate (mm)",
+        "server_layer_name": "rfh_dekad"
+      },
+      {
+        "id": "spi_1m",
+        "title": "SPI - 1-month",
+        "server_layer_name": "r1s_dekad"
+      },
+      {
+        "id": "spi_1y",
+        "title": "SPI - 1-year",
+        "server_layer_name": "rys_dekad"
+      },
+      {
+        "id": "spi_2m",
+        "title": "SPI - 2-month",
+        "server_layer_name": "r2s_dekad"
+      },
+      {
+        "id": "spi_3m",
+        "title": "SPI - 3-month",
+        "server_layer_name": "r3s_dekad"
+      },
+      {
+        "id": "spi_6m",
+        "title": "SPI - 6-month",
+        "server_layer_name": "r6s_dekad"
+      },
+      {
+        "id": "spi_9m",
+        "title": "SPI - 9-month",
+        "server_layer_name": "r9s_dekad"
+      },
+      {
+        "id": "streak_dry_days",
+        "title": "Longest number of consecutive dry days",
+        "server_layer_name": "dlx_dekad"
+      },
+      {
+        "id": "streak_extreme_rain",
+        "title": "Longest consecutive extreme rainfall days",
+        "server_layer_name": "xle_dekad"
+      },
+      {
+        "id": "streak_heavy_rain",
+        "title": "Longest consecutive number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xlh_dekad"
+      },
+      {
+        "id": "streak_intense_rain",
+        "title": "Longest consecutive intense rainfall days",
+        "server_layer_name": "xli_dekad"
+      }
+    ],
+    "ecuador": [
+      {
+        "id": "2m_water_anomaly",
+        "title": "2-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_2month"
+      },
+      {
+        "id": "3m_water_anomaly",
+        "title": "3-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_3month"
+      },
+      {
+        "id": "4m_water_anomaly",
+        "title": "4-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_4month"
+      },
+      {
+        "id": "5m_water_anomaly",
+        "title": "5-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_5month"
+      },
+      {
+        "id": "6m_water_anomaly",
+        "title": "6-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_6month"
+      },
+      {
+        "id": "daily_rainfall_forecast",
+        "title": "Rolling daily rainfall forecast",
+        "server_layer_name": "rfh_daily_forecast"
+      },
+      {
+        "id": "days_dry",
+        "title": "Days since last rain",
+        "server_layer_name": "dlc_dekad"
+      },
+      {
+        "id": "days_extreme_rain",
+        "title": "Number of days with extreme rainfall in the last 30 days",
+        "server_layer_name": "xne_dekad"
+      },
+      {
+        "id": "days_heavy_rain",
+        "title": "Number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xnh_dekad"
+      },
+      {
+        "id": "days_intense_rain",
+        "title": "Number of days with intense rainfall in the last 30 days",
+        "server_layer_name": "xni_dekad"
+      },
+      {
+        "id": "dekad_rainfall_anomaly_forecast",
+        "title": "10-day rainfall forecast anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "dekad_rainfall_forecast",
+        "title": "10-day rainfall forecast",
+        "server_layer_name": "rfh_dekad_forecast"
+      },
+      {
+        "id": "lst_amplitude",
+        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
+        "server_layer_name": "myd11a2_taa_dekad"
+      },
+      {
+        "id": "lst_anomaly",
+        "title": "Daytime Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_day_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_daytime",
+        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_nighttime",
+        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "monthly_water_anomaly",
+        "title": "Monthly Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_dekad"
+      },
+      {
+        "id": "ndvi_dekad",
+        "title": "10-day NDVI (MODIS)",
+        "server_layer_name": "mxd13a2_vim_dekad"
+      },
+      {
+        "id": "ndvi_dekad_anomaly",
+        "title": "10-day NDVI anomaly (MODIS)",
+        "server_layer_name": "mxd13a2_viq_dekad"
+      },
+      {
+        "id": "rain_anomaly_1month",
+        "title": "Monthly rainfall anomaly",
+        "server_layer_name": "r1q_dekad"
+      },
+      {
+        "id": "rain_anomaly_1year",
+        "title": "1-year rainfall anomaly",
+        "server_layer_name": "ryq_dekad"
+      },
+      {
+        "id": "rain_anomaly_2month",
+        "title": "2-month rainfall anomaly",
+        "server_layer_name": "r2q_dekad"
+      },
+      {
+        "id": "rain_anomaly_3month",
+        "title": "3-month rainfall anomaly",
+        "server_layer_name": "r3q_dekad"
+      },
+      {
+        "id": "rain_anomaly_4month",
+        "title": "4-month rainfall anomaly",
+        "server_layer_name": "r4q_dekad"
+      },
+      {
+        "id": "rain_anomaly_5month",
+        "title": "5-month rainfall anomaly",
+        "server_layer_name": "r5q_dekad"
+      },
+      {
+        "id": "rain_anomaly_6month",
+        "title": "6-month rainfall anomaly",
+        "server_layer_name": "r6q_dekad"
+      },
+      {
+        "id": "rain_anomaly_7month",
+        "title": "7-month rainfall anomaly",
+        "server_layer_name": "r7q_dekad"
+      },
+      {
+        "id": "rain_anomaly_8month",
+        "title": "8-month rainfall anomaly",
+        "server_layer_name": "r8q_dekad"
+      },
+      {
+        "id": "rain_anomaly_9month",
+        "title": "9-month rainfall anomaly",
+        "server_layer_name": "r9q_dekad"
+      },
+      {
+        "id": "rain_anomaly_dekad",
+        "title": "10-day rainfall anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rainfall_agg_1month",
+        "title": "1-month rainfall aggregate (mm)",
+        "server_layer_name": "r1h_dekad"
+      },
+      {
+        "id": "rainfall_agg_1year",
+        "title": "1-year rainfall aggregate (mm)",
+        "server_layer_name": "ryh_dekad"
+      },
+      {
+        "id": "rainfall_agg_2month",
+        "title": "2-month rainfall aggregate (mm)",
+        "server_layer_name": "r2h_dekad"
+      },
+      {
+        "id": "rainfall_agg_3month",
+        "title": "3-month rainfall aggregate (mm)",
+        "server_layer_name": "r3h_dekad"
+      },
+      {
+        "id": "rainfall_agg_4month",
+        "title": "4-month rainfall aggregate (mm)",
+        "server_layer_name": "r4h_dekad"
+      },
+      {
+        "id": "rainfall_agg_5month",
+        "title": "5-month rainfall aggregate (mm)",
+        "server_layer_name": "r5h_dekad"
+      },
+      {
+        "id": "rainfall_agg_6month",
+        "title": "6-month rainfall aggregate (mm)",
+        "server_layer_name": "r6h_dekad"
+      },
+      {
+        "id": "rainfall_agg_7month",
+        "title": "7-month rainfall aggregate (mm)",
+        "server_layer_name": "r7h_dekad"
+      },
+      {
+        "id": "rainfall_agg_8month",
+        "title": "8-month rainfall aggregate (mm)",
+        "server_layer_name": "r8h_dekad"
+      },
+      {
+        "id": "rainfall_agg_9month",
+        "title": "9-month rainfall aggregate (mm)",
+        "server_layer_name": "r9h_dekad"
+      },
+      {
+        "id": "rainfall_dekad",
+        "title": "10-day rainfall estimate (mm)",
+        "server_layer_name": "rfh_dekad"
+      },
+      {
+        "id": "spi_1m",
+        "title": "SPI - 1-month",
+        "server_layer_name": "r1s_dekad"
+      },
+      {
+        "id": "spi_1y",
+        "title": "SPI - 1-year",
+        "server_layer_name": "rys_dekad"
+      },
+      {
+        "id": "spi_2m",
+        "title": "SPI - 2-month",
+        "server_layer_name": "r2s_dekad"
+      },
+      {
+        "id": "spi_3m",
+        "title": "SPI - 3-month",
+        "server_layer_name": "r3s_dekad"
+      },
+      {
+        "id": "spi_6m",
+        "title": "SPI - 6-month",
+        "server_layer_name": "r6s_dekad"
+      },
+      {
+        "id": "spi_9m",
+        "title": "SPI - 9-month",
+        "server_layer_name": "r9s_dekad"
+      },
+      {
+        "id": "streak_dry_days",
+        "title": "Longest number of consecutive dry days",
+        "server_layer_name": "dlx_dekad"
+      },
+      {
+        "id": "streak_extreme_rain",
+        "title": "Longest consecutive extreme rainfall days",
+        "server_layer_name": "xle_dekad"
+      },
+      {
+        "id": "streak_heavy_rain",
+        "title": "Longest consecutive number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xlh_dekad"
+      },
+      {
+        "id": "streak_intense_rain",
+        "title": "Longest consecutive intense rainfall days",
+        "server_layer_name": "xli_dekad"
+      }
+    ],
+    "global": [
+      {
+        "id": "2m_water_anomaly",
+        "title": "2-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_2month"
+      },
+      {
+        "id": "3m_water_anomaly",
+        "title": "3-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_3month"
+      },
+      {
+        "id": "4m_water_anomaly",
+        "title": "4-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_4month"
+      },
+      {
+        "id": "5m_water_anomaly",
+        "title": "5-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_5month"
+      },
+      {
+        "id": "6m_water_anomaly",
+        "title": "6-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_6month"
+      },
+      {
+        "id": "daily_rainfall_forecast",
+        "title": "Rolling daily rainfall forecast",
+        "server_layer_name": "rfh_daily_forecast"
+      },
+      {
+        "id": "days_dry",
+        "title": "Days since last rain",
+        "server_layer_name": "dlc_dekad"
+      },
+      {
+        "id": "days_extreme_rain",
+        "title": "Number of days with extreme rainfall in the last 30 days",
+        "server_layer_name": "xne_dekad"
+      },
+      {
+        "id": "days_heavy_rain",
+        "title": "Number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xnh_dekad"
+      },
+      {
+        "id": "days_intense_rain",
+        "title": "Number of days with intense rainfall in the last 30 days",
+        "server_layer_name": "xni_dekad"
+      },
+      {
+        "id": "dekad_rainfall_anomaly_forecast",
+        "title": "10-day rainfall forecast anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "dekad_rainfall_forecast",
+        "title": "10-day rainfall forecast",
+        "server_layer_name": "rfh_dekad_forecast"
+      },
+      {
+        "id": "lst_amplitude",
+        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
+        "server_layer_name": "myd11a2_taa_dekad"
+      },
+      {
+        "id": "lst_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_day_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_daytime",
+        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_nighttime",
+        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "monthly_water_anomaly",
+        "title": "Monthly Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_dekad"
+      },
+      {
+        "id": "ndvi_dekad",
+        "title": "10-day NDVI (MODIS)",
+        "server_layer_name": "mxd13a2_vim_dekad"
+      },
+      {
+        "id": "ndvi_dekad_anomaly",
+        "title": "10-day NDVI anomaly (MODIS)",
+        "server_layer_name": "mxd13a2_viq_dekad"
+      },
+      {
+        "id": "rain_anomaly_1month",
+        "title": "Monthly rainfall anomaly",
+        "server_layer_name": "r1q_dekad"
+      },
+      {
+        "id": "rain_anomaly_1year",
+        "title": "1-year rainfall anomaly",
+        "server_layer_name": "ryq_dekad"
+      },
+      {
+        "id": "rain_anomaly_2month",
+        "title": "2-month rainfall anomaly",
+        "server_layer_name": "r2q_dekad"
+      },
+      {
+        "id": "rain_anomaly_3month",
+        "title": "3-month rainfall anomaly",
+        "server_layer_name": "r3q_dekad"
+      },
+      {
+        "id": "rain_anomaly_4month",
+        "title": "4-month rainfall anomaly",
+        "server_layer_name": "r4q_dekad"
+      },
+      {
+        "id": "rain_anomaly_5month",
+        "title": "5-month rainfall anomaly",
+        "server_layer_name": "r5q_dekad"
+      },
+      {
+        "id": "rain_anomaly_6month",
+        "title": "6-month rainfall anomaly",
+        "server_layer_name": "r6q_dekad"
+      },
+      {
+        "id": "rain_anomaly_7month",
+        "title": "7-month rainfall anomaly",
+        "server_layer_name": "r7q_dekad"
+      },
+      {
+        "id": "rain_anomaly_8month",
+        "title": "8-month rainfall anomaly",
+        "server_layer_name": "r8q_dekad"
+      },
+      {
+        "id": "rain_anomaly_9month",
+        "title": "9-month rainfall anomaly",
+        "server_layer_name": "r9q_dekad"
+      },
+      {
+        "id": "rain_anomaly_dekad",
+        "title": "10-day rainfall anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rainfall_agg_1month",
+        "title": "1-month rainfall aggregate",
+        "server_layer_name": "r1h_dekad"
+      },
+      {
+        "id": "rainfall_agg_1year",
+        "title": "1-year rainfall aggregate (mm)",
+        "server_layer_name": "ryh_dekad"
+      },
+      {
+        "id": "rainfall_agg_2month",
+        "title": "2-month rainfall aggregate (mm)",
+        "server_layer_name": "r2h_dekad"
+      },
+      {
+        "id": "rainfall_agg_3month",
+        "title": "3-month rainfall aggregate (mm)",
+        "server_layer_name": "r3h_dekad"
+      },
+      {
+        "id": "rainfall_agg_4month",
+        "title": "4-month rainfall aggregate (mm)",
+        "server_layer_name": "r4h_dekad"
+      },
+      {
+        "id": "rainfall_agg_5month",
+        "title": "5-month rainfall aggregate (mm)",
+        "server_layer_name": "r5h_dekad"
+      },
+      {
+        "id": "rainfall_agg_6month",
+        "title": "6-month rainfall aggregate (mm)",
+        "server_layer_name": "r6h_dekad"
+      },
+      {
+        "id": "rainfall_agg_7month",
+        "title": "7-month rainfall aggregate (mm)",
+        "server_layer_name": "r7h_dekad"
+      },
+      {
+        "id": "rainfall_agg_8month",
+        "title": "8-month rainfall aggregate (mm)",
+        "server_layer_name": "r8h_dekad"
+      },
+      {
+        "id": "rainfall_agg_9month",
+        "title": "9-month rainfall aggregate (mm)",
+        "server_layer_name": "r9h_dekad"
+      },
+      {
+        "id": "rainfall_dekad",
+        "title": "10-day rainfall estimate (mm)",
+        "server_layer_name": "rfh_dekad"
+      },
+      {
+        "id": "spi_1m",
+        "title": "SPI - 1-month",
+        "server_layer_name": "r1s_dekad"
+      },
+      {
+        "id": "spi_1y",
+        "title": "SPI - 1-year",
+        "server_layer_name": "rys_dekad"
+      },
+      {
+        "id": "spi_2m",
+        "title": "SPI - 2-month",
+        "server_layer_name": "r2s_dekad"
+      },
+      {
+        "id": "spi_3m",
+        "title": "SPI - 3-month",
+        "server_layer_name": "r3s_dekad"
+      },
+      {
+        "id": "spi_6m",
+        "title": "SPI - 6-month",
+        "server_layer_name": "r6s_dekad"
+      },
+      {
+        "id": "spi_9m",
+        "title": "SPI - 9-month",
+        "server_layer_name": "r9s_dekad"
+      },
+      {
+        "id": "streak_dry_days",
+        "title": "Longest dry spell",
+        "server_layer_name": "dlx_dekad"
+      },
+      {
+        "id": "streak_extreme_rain",
+        "title": "Longest consecutive extreme rainfall days",
+        "server_layer_name": "xle_dekad"
+      },
+      {
+        "id": "streak_heavy_rain",
+        "title": "Longest consecutive heavy rainfall days",
+        "server_layer_name": "xlh_dekad"
+      },
+      {
+        "id": "streak_intense_rain",
+        "title": "Longest consecutive intense rainfall days",
+        "server_layer_name": "xli_dekad"
+      }
+    ],
+    "haiti": [
+      {
+        "id": "2m_water_anomaly",
+        "title": "2-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_2month"
+      },
+      {
+        "id": "3m_water_anomaly",
+        "title": "3-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_3month"
+      },
+      {
+        "id": "4m_water_anomaly",
+        "title": "4-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_4month"
+      },
+      {
+        "id": "5m_water_anomaly",
+        "title": "5-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_5month"
+      },
+      {
+        "id": "6m_water_anomaly",
+        "title": "6-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_6month"
+      },
+      {
+        "id": "daily_rainfall_forecast",
+        "title": "Rolling daily rainfall forecast",
+        "server_layer_name": "rfh_daily_forecast"
+      },
+      {
+        "id": "days_dry",
+        "title": "Days since last rain",
+        "server_layer_name": "dlc_dekad"
+      },
+      {
+        "id": "days_extreme_rain",
+        "title": "Number of days with extreme rainfall in the last 30 days",
+        "server_layer_name": "xne_dekad"
+      },
+      {
+        "id": "days_heavy_rain",
+        "title": "Number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xnh_dekad"
+      },
+      {
+        "id": "days_intense_rain",
+        "title": "Number of days with intense rainfall in the last 30 days",
+        "server_layer_name": "xni_dekad"
+      },
+      {
+        "id": "dekad_rainfall_anomaly_forecast",
+        "title": "10-day rainfall forecast anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "dekad_rainfall_forecast",
+        "title": "10-day rainfall forecast",
+        "server_layer_name": "rfh_dekad_forecast"
+      },
+      {
+        "id": "lst_amplitude",
+        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
+        "server_layer_name": "myd11a2_taa_dekad"
+      },
+      {
+        "id": "lst_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_day_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_daytime",
+        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_nighttime",
+        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "monthly_water_anomaly",
+        "title": "Monthly Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_dekad"
+      },
+      {
+        "id": "ndvi_dekad",
+        "title": "10-day NDVI (MODIS)",
+        "server_layer_name": "mxd13a2_vim_dekad"
+      },
+      {
+        "id": "ndvi_dekad_anomaly",
+        "title": "10-day NDVI anomaly (MODIS)",
+        "server_layer_name": "mxd13a2_viq_dekad"
+      },
+      {
+        "id": "rain_anomaly_1month",
+        "title": "Monthly rainfall anomaly",
+        "server_layer_name": "r1q_dekad"
+      },
+      {
+        "id": "rain_anomaly_1year",
+        "title": "1-year rainfall anomaly",
+        "server_layer_name": "ryq_dekad"
+      },
+      {
+        "id": "rain_anomaly_2month",
+        "title": "2-month rainfall anomaly",
+        "server_layer_name": "r2q_dekad"
+      },
+      {
+        "id": "rain_anomaly_3month",
+        "title": "3-month rainfall anomaly",
+        "server_layer_name": "r3q_dekad"
+      },
+      {
+        "id": "rain_anomaly_4month",
+        "title": "4-month rainfall anomaly",
+        "server_layer_name": "r4q_dekad"
+      },
+      {
+        "id": "rain_anomaly_5month",
+        "title": "5-month rainfall anomaly",
+        "server_layer_name": "r5q_dekad"
+      },
+      {
+        "id": "rain_anomaly_6month",
+        "title": "6-month rainfall anomaly",
+        "server_layer_name": "r6q_dekad"
+      },
+      {
+        "id": "rain_anomaly_7month",
+        "title": "7-month rainfall anomaly",
+        "server_layer_name": "r7q_dekad"
+      },
+      {
+        "id": "rain_anomaly_8month",
+        "title": "8-month rainfall anomaly",
+        "server_layer_name": "r8q_dekad"
+      },
+      {
+        "id": "rain_anomaly_9month",
+        "title": "9-month rainfall anomaly",
+        "server_layer_name": "r9q_dekad"
+      },
+      {
+        "id": "rain_anomaly_dekad",
+        "title": "10-day rainfall anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rainfall_agg_1month",
+        "title": "1-month rainfall aggregate (mm)",
+        "server_layer_name": "r1h_dekad"
+      },
+      {
+        "id": "rainfall_agg_1year",
+        "title": "1-year rainfall aggregate (mm)",
+        "server_layer_name": "ryh_dekad"
+      },
+      {
+        "id": "rainfall_agg_2month",
+        "title": "2-month rainfall aggregate (mm)",
+        "server_layer_name": "r2h_dekad"
+      },
+      {
+        "id": "rainfall_agg_3month",
+        "title": "3-month rainfall aggregate (mm)",
+        "server_layer_name": "r3h_dekad"
+      },
+      {
+        "id": "rainfall_agg_4month",
+        "title": "4-month rainfall aggregate (mm)",
+        "server_layer_name": "r4h_dekad"
+      },
+      {
+        "id": "rainfall_agg_5month",
+        "title": "5-month rainfall aggregate (mm)",
+        "server_layer_name": "r5h_dekad"
+      },
+      {
+        "id": "rainfall_agg_6month",
+        "title": "6-month rainfall aggregate (mm)",
+        "server_layer_name": "r6h_dekad"
+      },
+      {
+        "id": "rainfall_agg_7month",
+        "title": "7-month rainfall aggregate (mm)",
+        "server_layer_name": "r7h_dekad"
+      },
+      {
+        "id": "rainfall_agg_8month",
+        "title": "8-month rainfall aggregate (mm)",
+        "server_layer_name": "r8h_dekad"
+      },
+      {
+        "id": "rainfall_agg_9month",
+        "title": "9-month rainfall aggregate (mm)",
+        "server_layer_name": "r9h_dekad"
+      },
+      {
+        "id": "rainfall_dekad",
+        "title": "10-day rainfall estimate (mm)",
+        "server_layer_name": "rfh_dekad"
+      },
+      {
+        "id": "spi_1m",
+        "title": "SPI - 1-month",
+        "server_layer_name": "r1s_dekad"
+      },
+      {
+        "id": "spi_1y",
+        "title": "SPI - 1-year",
+        "server_layer_name": "rys_dekad"
+      },
+      {
+        "id": "spi_2m",
+        "title": "SPI - 2-month",
+        "server_layer_name": "r2s_dekad"
       },
       {
         "id": "spi_3m",
@@ -956,6 +2360,36 @@
     ],
     "indonesia": [
       {
+        "id": "2m_water_anomaly",
+        "title": "2-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_2month"
+      },
+      {
+        "id": "3m_water_anomaly",
+        "title": "3-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_3month"
+      },
+      {
+        "id": "4m_water_anomaly",
+        "title": "4-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_4month"
+      },
+      {
+        "id": "5m_water_anomaly",
+        "title": "5-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_5month"
+      },
+      {
+        "id": "6m_water_anomaly",
+        "title": "6-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_6month"
+      },
+      {
+        "id": "daily_rainfall_forecast",
+        "title": "Rolling daily rainfall forecast",
+        "server_layer_name": "rfh_daily_forecast"
+      },
+      {
         "id": "days_dry",
         "title": "Days since last rain",
         "server_layer_name": "dlc_dekad"
@@ -976,6 +2410,16 @@
         "server_layer_name": "xni_dekad"
       },
       {
+        "id": "dekad_rainfall_anomaly_forecast",
+        "title": "10-day rainfall forecast anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "dekad_rainfall_forecast",
+        "title": "10-day rainfall forecast",
+        "server_layer_name": "rfh_dekad_forecast"
+      },
+      {
         "id": "lst_amplitude",
         "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
         "server_layer_name": "myd11a2_taa_dekad"
@@ -983,6 +2427,11 @@
       {
         "id": "lst_anomaly",
         "title": "Daytime Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_day_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
         "server_layer_name": "myd11a2_txd_dekad"
       },
       {
@@ -994,6 +2443,11 @@
         "id": "lst_nighttime",
         "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
         "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "monthly_water_anomaly",
+        "title": "Monthly Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_dekad"
       },
       {
         "id": "ndvi_dekad",
@@ -1016,14 +2470,39 @@
         "server_layer_name": "ryq_dekad"
       },
       {
+        "id": "rain_anomaly_2month",
+        "title": "2-month rainfall anomaly",
+        "server_layer_name": "r2q_dekad"
+      },
+      {
         "id": "rain_anomaly_3month",
         "title": "CHIRPS 3-month rainfall anomaly",
         "server_layer_name": "r3q_dekad"
       },
       {
+        "id": "rain_anomaly_4month",
+        "title": "4-month rainfall anomaly",
+        "server_layer_name": "r4q_dekad"
+      },
+      {
+        "id": "rain_anomaly_5month",
+        "title": "5-month rainfall anomaly",
+        "server_layer_name": "r5q_dekad"
+      },
+      {
         "id": "rain_anomaly_6month",
         "title": "CHIRPS 6-month rainfall anomaly",
         "server_layer_name": "r6q_dekad"
+      },
+      {
+        "id": "rain_anomaly_7month",
+        "title": "7-month rainfall anomaly",
+        "server_layer_name": "r7q_dekad"
+      },
+      {
+        "id": "rain_anomaly_8month",
+        "title": "8-month rainfall anomaly",
+        "server_layer_name": "r8q_dekad"
       },
       {
         "id": "rain_anomaly_9month",
@@ -1046,14 +2525,39 @@
         "server_layer_name": "ryh_dekad"
       },
       {
+        "id": "rainfall_agg_2month",
+        "title": "2-month rainfall aggregate (mm)",
+        "server_layer_name": "r2h_dekad"
+      },
+      {
         "id": "rainfall_agg_3month",
         "title": "CHIRPS 3-month rainfall aggregate (mm)",
         "server_layer_name": "r3h_dekad"
       },
       {
+        "id": "rainfall_agg_4month",
+        "title": "4-month rainfall aggregate (mm)",
+        "server_layer_name": "r4h_dekad"
+      },
+      {
+        "id": "rainfall_agg_5month",
+        "title": "5-month rainfall aggregate (mm)",
+        "server_layer_name": "r5h_dekad"
+      },
+      {
         "id": "rainfall_agg_6month",
         "title": "CHIRPS 6-month rainfall aggregate (mm)",
         "server_layer_name": "r6h_dekad"
+      },
+      {
+        "id": "rainfall_agg_7month",
+        "title": "7-month rainfall aggregate (mm)",
+        "server_layer_name": "r7h_dekad"
+      },
+      {
+        "id": "rainfall_agg_8month",
+        "title": "8-month rainfall aggregate (mm)",
+        "server_layer_name": "r8h_dekad"
       },
       {
         "id": "rainfall_agg_9month",
@@ -1074,6 +2578,11 @@
         "id": "spi_1y",
         "title": "SPI - 1-year",
         "server_layer_name": "rys_dekad"
+      },
+      {
+        "id": "spi_2m",
+        "title": "SPI - 2-month",
+        "server_layer_name": "r2s_dekad"
       },
       {
         "id": "spi_3m",
@@ -1111,20 +2620,56 @@
         "server_layer_name": "xli_dekad"
       }
     ],
-    "jordan": [],
-    "kyrgyzstan": [
+    "jordan": [
       {
-        "id": "10day_NDVI_KDC",
-        "title": "10-day NDVI (SIBELIUS)",
-        "server_layer_name": "ModisIndices"
+        "id": "2m_water_anomaly",
+        "title": "2-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_2month"
       },
       {
-        "id": "active_fires",
-        "title": "Active fires in the past 24 hours"
+        "id": "3m_water_anomaly",
+        "title": "3-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_3month"
       },
       {
-        "id": "active_fires_7days",
-        "title": "Active fires in the past 7 days"
+        "id": "4m_water_anomaly",
+        "title": "4-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_4month"
+      },
+      {
+        "id": "5m_water_anomaly",
+        "title": "5-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_5month"
+      },
+      {
+        "id": "6m_water_anomaly",
+        "title": "6-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_6month"
+      },
+      {
+        "id": "daily_rainfall_forecast",
+        "title": "Rolling daily rainfall forecast",
+        "server_layer_name": "rfh_daily_forecast"
+      },
+      {
+        "id": "days_dry",
+        "title": "Days since last rain",
+        "server_layer_name": "dlc_dekad"
+      },
+      {
+        "id": "days_extreme_rain",
+        "title": "Number of days with extreme rainfall in the last 30 days",
+        "server_layer_name": "xne_dekad"
+      },
+      {
+        "id": "days_heavy_rain",
+        "title": "Number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xnh_dekad"
+      },
+      {
+        "id": "days_intense_rain",
+        "title": "Number of days with intense rainfall in the last 30 days",
+        "server_layer_name": "xni_dekad"
       },
       {
         "id": "dekad_rainfall_anomaly_forecast",
@@ -1132,89 +2677,1107 @@
         "server_layer_name": "rfq_dekad"
       },
       {
-        "id": "modis_snow_percentage",
-        "title": "Snow percentage",
-        "server_layer_name": "ModisSnowPercentage"
+        "id": "dekad_rainfall_forecast",
+        "title": "10-day rainfall forecast",
+        "server_layer_name": "rfh_dekad_forecast"
       },
       {
-        "id": "ModisNDWI",
-        "title": "10-day Water Index (NDWI - SIBELIUS)",
-        "server_layer_name": "ModisIndices"
+        "id": "lst_amplitude",
+        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
+        "server_layer_name": "myd11a2_taa_dekad"
       },
       {
-        "id": "ModisTCI",
-        "title": "Temperature Condition Index ",
-        "server_layer_name": "ModisTCI"
+        "id": "lst_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
       },
       {
-        "id": "ModisVCI",
-        "title": "Vegetation Condition Index",
-        "server_layer_name": "ModisVCI"
+        "id": "lst_day_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
       },
       {
-        "id": "ModisVHI",
-        "title": "Vegetation Health Index",
-        "server_layer_name": "ModisVHI"
+        "id": "lst_daytime",
+        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
       },
       {
-        "id": "pasture_anomaly",
-        "title": "10-day pasture anomaly",
-        "server_layer_name": "ModisAnomaly"
+        "id": "lst_nighttime",
+        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
       },
       {
-        "id": "snow_ndsi",
-        "title": "Snow index (NDSI)",
-        "server_layer_name": "ModisIndices"
+        "id": "monthly_water_anomaly",
+        "title": "Monthly Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_dekad"
+      },
+      {
+        "id": "ndvi_dekad",
+        "title": "10-day NDVI (MODIS)",
+        "server_layer_name": "mxd13a2_vim_dekad"
+      },
+      {
+        "id": "ndvi_dekad_anomaly",
+        "title": "10-day NDVI anomaly (MODIS)",
+        "server_layer_name": "mxd13a2_viq_dekad"
+      },
+      {
+        "id": "rain_anomaly_1month",
+        "title": "Monthly rainfall anomaly",
+        "server_layer_name": "r1q_dekad"
+      },
+      {
+        "id": "rain_anomaly_1year",
+        "title": "1-year rainfall anomaly",
+        "server_layer_name": "ryq_dekad"
+      },
+      {
+        "id": "rain_anomaly_2month",
+        "title": "2-month rainfall anomaly",
+        "server_layer_name": "r2q_dekad"
+      },
+      {
+        "id": "rain_anomaly_3month",
+        "title": "3-month rainfall anomaly",
+        "server_layer_name": "r3q_dekad"
+      },
+      {
+        "id": "rain_anomaly_4month",
+        "title": "4-month rainfall anomaly",
+        "server_layer_name": "r4q_dekad"
+      },
+      {
+        "id": "rain_anomaly_5month",
+        "title": "5-month rainfall anomaly",
+        "server_layer_name": "r5q_dekad"
+      },
+      {
+        "id": "rain_anomaly_6month",
+        "title": "6-month rainfall anomaly",
+        "server_layer_name": "r6q_dekad"
+      },
+      {
+        "id": "rain_anomaly_7month",
+        "title": "7-month rainfall anomaly",
+        "server_layer_name": "r7q_dekad"
+      },
+      {
+        "id": "rain_anomaly_8month",
+        "title": "8-month rainfall anomaly",
+        "server_layer_name": "r8q_dekad"
+      },
+      {
+        "id": "rain_anomaly_9month",
+        "title": "9-month rainfall anomaly",
+        "server_layer_name": "r9q_dekad"
+      },
+      {
+        "id": "rain_anomaly_dekad",
+        "title": "10-day rainfall anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rainfall_agg_1month",
+        "title": "1-month rainfall aggregate",
+        "server_layer_name": "r1h_dekad"
+      },
+      {
+        "id": "rainfall_agg_1year",
+        "title": "1-year rainfall aggregate (mm)",
+        "server_layer_name": "ryh_dekad"
+      },
+      {
+        "id": "rainfall_agg_2month",
+        "title": "2-month rainfall aggregate (mm)",
+        "server_layer_name": "r2h_dekad"
+      },
+      {
+        "id": "rainfall_agg_3month",
+        "title": "3-month rainfall aggregate (mm)",
+        "server_layer_name": "r3h_dekad"
+      },
+      {
+        "id": "rainfall_agg_4month",
+        "title": "4-month rainfall aggregate (mm)",
+        "server_layer_name": "r4h_dekad"
+      },
+      {
+        "id": "rainfall_agg_5month",
+        "title": "5-month rainfall aggregate (mm)",
+        "server_layer_name": "r5h_dekad"
+      },
+      {
+        "id": "rainfall_agg_6month",
+        "title": "6-month rainfall aggregate (mm)",
+        "server_layer_name": "r6h_dekad"
+      },
+      {
+        "id": "rainfall_agg_7month",
+        "title": "7-month rainfall aggregate (mm)",
+        "server_layer_name": "r7h_dekad"
+      },
+      {
+        "id": "rainfall_agg_8month",
+        "title": "8-month rainfall aggregate (mm)",
+        "server_layer_name": "r8h_dekad"
+      },
+      {
+        "id": "rainfall_agg_9month",
+        "title": "9-month rainfall aggregate (mm)",
+        "server_layer_name": "r9h_dekad"
+      },
+      {
+        "id": "rainfall_dekad",
+        "title": "10-day rainfall estimate (mm)",
+        "server_layer_name": "rfh_dekad"
+      },
+      {
+        "id": "spi_1m",
+        "title": "SPI - 1-month",
+        "server_layer_name": "r1s_dekad"
+      },
+      {
+        "id": "spi_1y",
+        "title": "SPI - 1-year",
+        "server_layer_name": "rys_dekad"
+      },
+      {
+        "id": "spi_2m",
+        "title": "SPI - 2-month",
+        "server_layer_name": "r2s_dekad"
+      },
+      {
+        "id": "spi_3m",
+        "title": "SPI - 3-month",
+        "server_layer_name": "r3s_dekad"
+      },
+      {
+        "id": "spi_6m",
+        "title": "SPI - 6-month",
+        "server_layer_name": "r6s_dekad"
+      },
+      {
+        "id": "spi_9m",
+        "title": "SPI - 9-month",
+        "server_layer_name": "r9s_dekad"
+      },
+      {
+        "id": "streak_dry_days",
+        "title": "Longest dry spell",
+        "server_layer_name": "dlx_dekad"
+      },
+      {
+        "id": "streak_extreme_rain",
+        "title": "Longest consecutive extreme rainfall days",
+        "server_layer_name": "xle_dekad"
+      },
+      {
+        "id": "streak_heavy_rain",
+        "title": "Longest consecutive heavy rainfall days",
+        "server_layer_name": "xlh_dekad"
+      },
+      {
+        "id": "streak_intense_rain",
+        "title": "Longest consecutive intense rainfall days",
+        "server_layer_name": "xli_dekad"
       }
     ],
-    "malawi": [],
+    "kyrgyzstan": [
+      {
+        "id": "2m_water_anomaly",
+        "title": "2-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_2month"
+      },
+      {
+        "id": "3m_water_anomaly",
+        "title": "3-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_3month"
+      },
+      {
+        "id": "4m_water_anomaly",
+        "title": "4-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_4month"
+      },
+      {
+        "id": "5m_water_anomaly",
+        "title": "5-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_5month"
+      },
+      {
+        "id": "6m_water_anomaly",
+        "title": "6-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_6month"
+      },
+      {
+        "id": "daily_rainfall_forecast",
+        "title": "Rolling daily rainfall forecast",
+        "server_layer_name": "rfh_daily_forecast"
+      },
+      {
+        "id": "days_dry",
+        "title": "Days since last rain",
+        "server_layer_name": "dlc_dekad"
+      },
+      {
+        "id": "days_extreme_rain",
+        "title": "Number of days with extreme rainfall in the last 30 days",
+        "server_layer_name": "xne_dekad"
+      },
+      {
+        "id": "days_heavy_rain",
+        "title": "Number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xnh_dekad"
+      },
+      {
+        "id": "days_intense_rain",
+        "title": "Number of days with intense rainfall in the last 30 days",
+        "server_layer_name": "xni_dekad"
+      },
+      {
+        "id": "dekad_rainfall_anomaly_forecast",
+        "title": "10-day rainfall forecast anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "dekad_rainfall_forecast",
+        "title": "10-day rainfall forecast",
+        "server_layer_name": "rfh_dekad_forecast"
+      },
+      {
+        "id": "lst_amplitude",
+        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
+        "server_layer_name": "myd11a2_taa_dekad"
+      },
+      {
+        "id": "lst_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_day_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_daytime",
+        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_nighttime",
+        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "monthly_water_anomaly",
+        "title": "Monthly Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_dekad"
+      },
+      {
+        "id": "ndvi_dekad",
+        "title": "10-day NDVI (MODIS)",
+        "server_layer_name": "mxd13a2_vim_dekad"
+      },
+      {
+        "id": "ndvi_dekad_anomaly",
+        "title": "10-day NDVI anomaly (MODIS)",
+        "server_layer_name": "mxd13a2_viq_dekad"
+      },
+      {
+        "id": "rain_anomaly_1month",
+        "title": "Monthly rainfall anomaly",
+        "server_layer_name": "r1q_dekad"
+      },
+      {
+        "id": "rain_anomaly_1year",
+        "title": "1-year rainfall anomaly",
+        "server_layer_name": "ryq_dekad"
+      },
+      {
+        "id": "rain_anomaly_2month",
+        "title": "2-month rainfall anomaly",
+        "server_layer_name": "r2q_dekad"
+      },
+      {
+        "id": "rain_anomaly_3month",
+        "title": "3-month rainfall anomaly",
+        "server_layer_name": "r3q_dekad"
+      },
+      {
+        "id": "rain_anomaly_4month",
+        "title": "4-month rainfall anomaly",
+        "server_layer_name": "r4q_dekad"
+      },
+      {
+        "id": "rain_anomaly_5month",
+        "title": "5-month rainfall anomaly",
+        "server_layer_name": "r5q_dekad"
+      },
+      {
+        "id": "rain_anomaly_6month",
+        "title": "6-month rainfall anomaly",
+        "server_layer_name": "r6q_dekad"
+      },
+      {
+        "id": "rain_anomaly_7month",
+        "title": "7-month rainfall anomaly",
+        "server_layer_name": "r7q_dekad"
+      },
+      {
+        "id": "rain_anomaly_8month",
+        "title": "8-month rainfall anomaly",
+        "server_layer_name": "r8q_dekad"
+      },
+      {
+        "id": "rain_anomaly_9month",
+        "title": "9-month rainfall anomaly",
+        "server_layer_name": "r9q_dekad"
+      },
+      {
+        "id": "rain_anomaly_dekad",
+        "title": "10-day rainfall anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rainfall_agg_1month",
+        "title": "1-month rainfall aggregate",
+        "server_layer_name": "r1h_dekad"
+      },
+      {
+        "id": "rainfall_agg_1year",
+        "title": "1-year rainfall aggregate (mm)",
+        "server_layer_name": "ryh_dekad"
+      },
+      {
+        "id": "rainfall_agg_2month",
+        "title": "2-month rainfall aggregate (mm)",
+        "server_layer_name": "r2h_dekad"
+      },
+      {
+        "id": "rainfall_agg_3month",
+        "title": "3-month rainfall aggregate (mm)",
+        "server_layer_name": "r3h_dekad"
+      },
+      {
+        "id": "rainfall_agg_4month",
+        "title": "4-month rainfall aggregate (mm)",
+        "server_layer_name": "r4h_dekad"
+      },
+      {
+        "id": "rainfall_agg_5month",
+        "title": "5-month rainfall aggregate (mm)",
+        "server_layer_name": "r5h_dekad"
+      },
+      {
+        "id": "rainfall_agg_6month",
+        "title": "6-month rainfall aggregate (mm)",
+        "server_layer_name": "r6h_dekad"
+      },
+      {
+        "id": "rainfall_agg_7month",
+        "title": "7-month rainfall aggregate (mm)",
+        "server_layer_name": "r7h_dekad"
+      },
+      {
+        "id": "rainfall_agg_8month",
+        "title": "8-month rainfall aggregate (mm)",
+        "server_layer_name": "r8h_dekad"
+      },
+      {
+        "id": "rainfall_agg_9month",
+        "title": "9-month rainfall aggregate (mm)",
+        "server_layer_name": "r9h_dekad"
+      },
+      {
+        "id": "rainfall_dekad",
+        "title": "10-day rainfall estimate (mm)",
+        "server_layer_name": "rfh_dekad"
+      },
+      {
+        "id": "spi_1m",
+        "title": "SPI - 1-month",
+        "server_layer_name": "r1s_dekad"
+      },
+      {
+        "id": "spi_1y",
+        "title": "SPI - 1-year",
+        "server_layer_name": "rys_dekad"
+      },
+      {
+        "id": "spi_2m",
+        "title": "SPI - 2-month",
+        "server_layer_name": "r2s_dekad"
+      },
+      {
+        "id": "spi_3m",
+        "title": "SPI - 3-month",
+        "server_layer_name": "r3s_dekad"
+      },
+      {
+        "id": "spi_6m",
+        "title": "SPI - 6-month",
+        "server_layer_name": "r6s_dekad"
+      },
+      {
+        "id": "spi_9m",
+        "title": "SPI - 9-month",
+        "server_layer_name": "r9s_dekad"
+      },
+      {
+        "id": "streak_dry_days",
+        "title": "Longest dry spell",
+        "server_layer_name": "dlx_dekad"
+      },
+      {
+        "id": "streak_extreme_rain",
+        "title": "Longest consecutive extreme rainfall days",
+        "server_layer_name": "xle_dekad"
+      },
+      {
+        "id": "streak_heavy_rain",
+        "title": "Longest consecutive heavy rainfall days",
+        "server_layer_name": "xlh_dekad"
+      },
+      {
+        "id": "streak_intense_rain",
+        "title": "Longest consecutive intense rainfall days",
+        "server_layer_name": "xli_dekad"
+      }
+    ],
+    "malawi": [
+      {
+        "id": "2m_water_anomaly",
+        "title": "2-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_2month"
+      },
+      {
+        "id": "3m_water_anomaly",
+        "title": "3-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_3month"
+      },
+      {
+        "id": "4m_water_anomaly",
+        "title": "4-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_4month"
+      },
+      {
+        "id": "5m_water_anomaly",
+        "title": "5-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_5month"
+      },
+      {
+        "id": "6m_water_anomaly",
+        "title": "6-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_6month"
+      },
+      {
+        "id": "daily_rainfall_forecast",
+        "title": "Rolling daily rainfall forecast",
+        "server_layer_name": "rfh_daily_forecast"
+      },
+      {
+        "id": "days_dry",
+        "title": "Days since last rain",
+        "server_layer_name": "dlc_dekad"
+      },
+      {
+        "id": "days_extreme_rain",
+        "title": "Number of days with extreme rainfall in the last 30 days",
+        "server_layer_name": "xne_dekad"
+      },
+      {
+        "id": "days_heavy_rain",
+        "title": "Number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xnh_dekad"
+      },
+      {
+        "id": "days_intense_rain",
+        "title": "Number of days with intense rainfall in the last 30 days",
+        "server_layer_name": "xni_dekad"
+      },
+      {
+        "id": "dekad_rainfall_anomaly_forecast",
+        "title": "10-day rainfall forecast anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "dekad_rainfall_forecast",
+        "title": "10-day rainfall forecast",
+        "server_layer_name": "rfh_dekad_forecast"
+      },
+      {
+        "id": "lst_amplitude",
+        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
+        "server_layer_name": "myd11a2_taa_dekad"
+      },
+      {
+        "id": "lst_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_day_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_daytime",
+        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_nighttime",
+        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "monthly_water_anomaly",
+        "title": "Monthly Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_dekad"
+      },
+      {
+        "id": "ndvi_dekad",
+        "title": "10-day NDVI (MODIS)",
+        "server_layer_name": "mxd13a2_vim_dekad"
+      },
+      {
+        "id": "ndvi_dekad_anomaly",
+        "title": "10-day NDVI anomaly (MODIS)",
+        "server_layer_name": "mxd13a2_viq_dekad"
+      },
+      {
+        "id": "rain_anomaly_1month",
+        "title": "Monthly rainfall anomaly",
+        "server_layer_name": "r1q_dekad"
+      },
+      {
+        "id": "rain_anomaly_1year",
+        "title": "1-year rainfall anomaly",
+        "server_layer_name": "ryq_dekad"
+      },
+      {
+        "id": "rain_anomaly_2month",
+        "title": "2-month rainfall anomaly",
+        "server_layer_name": "r2q_dekad"
+      },
+      {
+        "id": "rain_anomaly_3month",
+        "title": "3-month rainfall anomaly",
+        "server_layer_name": "r3q_dekad"
+      },
+      {
+        "id": "rain_anomaly_4month",
+        "title": "4-month rainfall anomaly",
+        "server_layer_name": "r4q_dekad"
+      },
+      {
+        "id": "rain_anomaly_5month",
+        "title": "5-month rainfall anomaly",
+        "server_layer_name": "r5q_dekad"
+      },
+      {
+        "id": "rain_anomaly_6month",
+        "title": "6-month rainfall anomaly",
+        "server_layer_name": "r6q_dekad"
+      },
+      {
+        "id": "rain_anomaly_7month",
+        "title": "7-month rainfall anomaly",
+        "server_layer_name": "r7q_dekad"
+      },
+      {
+        "id": "rain_anomaly_8month",
+        "title": "8-month rainfall anomaly",
+        "server_layer_name": "r8q_dekad"
+      },
+      {
+        "id": "rain_anomaly_9month",
+        "title": "9-month rainfall anomaly",
+        "server_layer_name": "r9q_dekad"
+      },
+      {
+        "id": "rain_anomaly_dekad",
+        "title": "10-day rainfall anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rainfall_agg_1month",
+        "title": "1-month rainfall aggregate",
+        "server_layer_name": "r1h_dekad"
+      },
+      {
+        "id": "rainfall_agg_1year",
+        "title": "1-year rainfall aggregate (mm)",
+        "server_layer_name": "ryh_dekad"
+      },
+      {
+        "id": "rainfall_agg_2month",
+        "title": "2-month rainfall aggregate (mm)",
+        "server_layer_name": "r2h_dekad"
+      },
+      {
+        "id": "rainfall_agg_3month",
+        "title": "3-month rainfall aggregate (mm)",
+        "server_layer_name": "r3h_dekad"
+      },
+      {
+        "id": "rainfall_agg_4month",
+        "title": "4-month rainfall aggregate (mm)",
+        "server_layer_name": "r4h_dekad"
+      },
+      {
+        "id": "rainfall_agg_5month",
+        "title": "5-month rainfall aggregate (mm)",
+        "server_layer_name": "r5h_dekad"
+      },
+      {
+        "id": "rainfall_agg_6month",
+        "title": "6-month rainfall aggregate (mm)",
+        "server_layer_name": "r6h_dekad"
+      },
+      {
+        "id": "rainfall_agg_7month",
+        "title": "7-month rainfall aggregate (mm)",
+        "server_layer_name": "r7h_dekad"
+      },
+      {
+        "id": "rainfall_agg_8month",
+        "title": "8-month rainfall aggregate (mm)",
+        "server_layer_name": "r8h_dekad"
+      },
+      {
+        "id": "rainfall_agg_9month",
+        "title": "9-month rainfall aggregate (mm)",
+        "server_layer_name": "r9h_dekad"
+      },
+      {
+        "id": "rainfall_dekad",
+        "title": "10-day rainfall estimate (mm)",
+        "server_layer_name": "rfh_dekad"
+      },
+      {
+        "id": "spi_1m",
+        "title": "SPI - 1-month",
+        "server_layer_name": "r1s_dekad"
+      },
+      {
+        "id": "spi_1y",
+        "title": "SPI - 1-year",
+        "server_layer_name": "rys_dekad"
+      },
+      {
+        "id": "spi_2m",
+        "title": "SPI - 2-month",
+        "server_layer_name": "r2s_dekad"
+      },
+      {
+        "id": "spi_3m",
+        "title": "SPI - 3-month",
+        "server_layer_name": "r3s_dekad"
+      },
+      {
+        "id": "spi_6m",
+        "title": "SPI - 6-month",
+        "server_layer_name": "r6s_dekad"
+      },
+      {
+        "id": "spi_9m",
+        "title": "SPI - 9-month",
+        "server_layer_name": "r9s_dekad"
+      },
+      {
+        "id": "streak_dry_days",
+        "title": "Longest dry spell",
+        "server_layer_name": "dlx_dekad"
+      },
+      {
+        "id": "streak_extreme_rain",
+        "title": "Longest consecutive extreme rainfall days",
+        "server_layer_name": "xle_dekad"
+      },
+      {
+        "id": "streak_heavy_rain",
+        "title": "Longest consecutive heavy rainfall days",
+        "server_layer_name": "xlh_dekad"
+      },
+      {
+        "id": "streak_intense_rain",
+        "title": "Longest consecutive intense rainfall days",
+        "server_layer_name": "xli_dekad"
+      }
+    ],
     "mongolia": [
       {
-        "id": "DzudRiskMap",
-        "title": "Dzud risk",
-        "server_layer_name": "DZUDRM12312"
+        "id": "2m_water_anomaly",
+        "title": "2-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_2month"
       },
       {
-        "id": "ModisLST",
-        "title": "Surface temperature",
-        "server_layer_name": "ModisLST"
+        "id": "3m_water_anomaly",
+        "title": "3-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_3month"
       },
       {
-        "id": "ModisSnowPercentage",
-        "title": "Snow cover (%)",
-        "server_layer_name": "ModisSnowPercentage"
+        "id": "4m_water_anomaly",
+        "title": "4-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_4month"
       },
       {
-        "id": "ModisVHI",
-        "title": "Agricultural drought (VHI)",
-        "server_layer_name": "ModisVHI"
+        "id": "5m_water_anomaly",
+        "title": "5-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_5month"
       },
       {
-        "id": "ndvi",
-        "title": "Vegetation index (NDVI)",
-        "server_layer_name": "ModisIndices"
+        "id": "6m_water_anomaly",
+        "title": "6-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_6month"
       },
       {
-        "id": "pasture_anomaly",
-        "title": "Pasture anomaly",
-        "server_layer_name": "ModisAnomaly"
+        "id": "daily_rainfall_forecast",
+        "title": "Rolling daily rainfall forecast",
+        "server_layer_name": "rfh_daily_forecast"
       },
       {
-        "id": "pasture_biomass",
-        "title": "Pasture biomass",
-        "server_layer_name": "ModisPastureBiomass"
+        "id": "days_dry",
+        "title": "Days since last rain",
+        "server_layer_name": "dlc_dekad"
+      },
+      {
+        "id": "days_extreme_rain",
+        "title": "Number of days with extreme rainfall in the last 30 days",
+        "server_layer_name": "xne_dekad"
+      },
+      {
+        "id": "days_heavy_rain",
+        "title": "Number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xnh_dekad"
+      },
+      {
+        "id": "days_intense_rain",
+        "title": "Number of days with intense rainfall in the last 30 days",
+        "server_layer_name": "xni_dekad"
+      },
+      {
+        "id": "dekad_rainfall_anomaly_forecast",
+        "title": "10-day rainfall forecast anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "dekad_rainfall_forecast",
+        "title": "10-day rainfall forecast",
+        "server_layer_name": "rfh_dekad_forecast"
+      },
+      {
+        "id": "lst_amplitude",
+        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
+        "server_layer_name": "myd11a2_taa_dekad"
+      },
+      {
+        "id": "lst_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_day_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_daytime",
+        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_nighttime",
+        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "monthly_water_anomaly",
+        "title": "Monthly Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_dekad"
+      },
+      {
+        "id": "ndvi_dekad",
+        "title": "10-day NDVI (MODIS)",
+        "server_layer_name": "mxd13a2_vim_dekad"
+      },
+      {
+        "id": "ndvi_dekad_anomaly",
+        "title": "10-day NDVI anomaly (MODIS)",
+        "server_layer_name": "mxd13a2_viq_dekad"
+      },
+      {
+        "id": "rain_anomaly_1month",
+        "title": "Monthly rainfall anomaly",
+        "server_layer_name": "r1q_dekad"
+      },
+      {
+        "id": "rain_anomaly_1year",
+        "title": "1-year rainfall anomaly",
+        "server_layer_name": "ryq_dekad"
+      },
+      {
+        "id": "rain_anomaly_2month",
+        "title": "2-month rainfall anomaly",
+        "server_layer_name": "r2q_dekad"
+      },
+      {
+        "id": "rain_anomaly_3month",
+        "title": "3-month rainfall anomaly",
+        "server_layer_name": "r3q_dekad"
+      },
+      {
+        "id": "rain_anomaly_4month",
+        "title": "4-month rainfall anomaly",
+        "server_layer_name": "r4q_dekad"
+      },
+      {
+        "id": "rain_anomaly_5month",
+        "title": "5-month rainfall anomaly",
+        "server_layer_name": "r5q_dekad"
+      },
+      {
+        "id": "rain_anomaly_6month",
+        "title": "6-month rainfall anomaly",
+        "server_layer_name": "r6q_dekad"
+      },
+      {
+        "id": "rain_anomaly_7month",
+        "title": "7-month rainfall anomaly",
+        "server_layer_name": "r7q_dekad"
+      },
+      {
+        "id": "rain_anomaly_8month",
+        "title": "8-month rainfall anomaly",
+        "server_layer_name": "r8q_dekad"
+      },
+      {
+        "id": "rain_anomaly_9month",
+        "title": "9-month rainfall anomaly",
+        "server_layer_name": "r9q_dekad"
+      },
+      {
+        "id": "rain_anomaly_dekad",
+        "title": "10-day rainfall anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rainfall_agg_1month",
+        "title": "1-month rainfall aggregate",
+        "server_layer_name": "r1h_dekad"
+      },
+      {
+        "id": "rainfall_agg_1year",
+        "title": "1-year rainfall aggregate (mm)",
+        "server_layer_name": "ryh_dekad"
+      },
+      {
+        "id": "rainfall_agg_2month",
+        "title": "2-month rainfall aggregate (mm)",
+        "server_layer_name": "r2h_dekad"
+      },
+      {
+        "id": "rainfall_agg_3month",
+        "title": "3-month rainfall aggregate (mm)",
+        "server_layer_name": "r3h_dekad"
+      },
+      {
+        "id": "rainfall_agg_4month",
+        "title": "4-month rainfall aggregate (mm)",
+        "server_layer_name": "r4h_dekad"
+      },
+      {
+        "id": "rainfall_agg_5month",
+        "title": "5-month rainfall aggregate (mm)",
+        "server_layer_name": "r5h_dekad"
+      },
+      {
+        "id": "rainfall_agg_6month",
+        "title": "6-month rainfall aggregate (mm)",
+        "server_layer_name": "r6h_dekad"
+      },
+      {
+        "id": "rainfall_agg_7month",
+        "title": "7-month rainfall aggregate (mm)",
+        "server_layer_name": "r7h_dekad"
+      },
+      {
+        "id": "rainfall_agg_8month",
+        "title": "8-month rainfall aggregate (mm)",
+        "server_layer_name": "r8h_dekad"
+      },
+      {
+        "id": "rainfall_agg_9month",
+        "title": "9-month rainfall aggregate (mm)",
+        "server_layer_name": "r9h_dekad"
+      },
+      {
+        "id": "rainfall_dekad",
+        "title": "10-day rainfall estimate (mm)",
+        "server_layer_name": "rfh_dekad"
+      },
+      {
+        "id": "spi_1m",
+        "title": "SPI - 1-month",
+        "server_layer_name": "r1s_dekad"
+      },
+      {
+        "id": "spi_1y",
+        "title": "SPI - 1-year",
+        "server_layer_name": "rys_dekad"
+      },
+      {
+        "id": "spi_2m",
+        "title": "SPI - 2-month",
+        "server_layer_name": "r2s_dekad"
+      },
+      {
+        "id": "spi_3m",
+        "title": "SPI - 3-month",
+        "server_layer_name": "r3s_dekad"
+      },
+      {
+        "id": "spi_6m",
+        "title": "SPI - 6-month",
+        "server_layer_name": "r6s_dekad"
+      },
+      {
+        "id": "spi_9m",
+        "title": "SPI - 9-month",
+        "server_layer_name": "r9s_dekad"
+      },
+      {
+        "id": "streak_dry_days",
+        "title": "Longest dry spell",
+        "server_layer_name": "dlx_dekad"
+      },
+      {
+        "id": "streak_extreme_rain",
+        "title": "Longest consecutive extreme rainfall days",
+        "server_layer_name": "xle_dekad"
+      },
+      {
+        "id": "streak_heavy_rain",
+        "title": "Longest consecutive heavy rainfall days",
+        "server_layer_name": "xlh_dekad"
+      },
+      {
+        "id": "streak_intense_rain",
+        "title": "Longest consecutive intense rainfall days",
+        "server_layer_name": "xli_dekad"
       }
     ],
     "mozambique": [
+      {
+        "id": "2m_water_anomaly",
+        "title": "2-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_2month"
+      },
+      {
+        "id": "3m_water_anomaly",
+        "title": "3-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_3month"
+      },
+      {
+        "id": "4m_water_anomaly",
+        "title": "4-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_4month"
+      },
+      {
+        "id": "5m_water_anomaly",
+        "title": "5-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_5month"
+      },
+      {
+        "id": "6m_water_anomaly",
+        "title": "6-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_6month"
+      },
+      {
+        "id": "daily_rainfall_forecast",
+        "title": "Rolling daily rainfall forecast",
+        "server_layer_name": "rfh_daily_forecast"
+      },
+      {
+        "id": "days_dry",
+        "title": "Days since last rain",
+        "server_layer_name": "dlc_dekad"
+      },
+      {
+        "id": "days_extreme_rain",
+        "title": "Number of days with extreme rainfall in the last 30 days",
+        "server_layer_name": "xne_dekad"
+      },
+      {
+        "id": "days_heavy_rain",
+        "title": "Number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xnh_dekad"
+      },
+      {
+        "id": "days_intense_rain",
+        "title": "Number of days with intense rainfall in the last 30 days",
+        "server_layer_name": "xni_dekad"
+      },
+      {
+        "id": "dekad_rainfall_anomaly_forecast",
+        "title": "10-day rainfall forecast anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "dekad_rainfall_forecast",
+        "title": "10-day rainfall forecast",
+        "server_layer_name": "rfh_dekad_forecast"
+      },
+      {
+        "id": "lst_amplitude",
+        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
+        "server_layer_name": "myd11a2_taa_dekad"
+      },
+      {
+        "id": "lst_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_day_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
       {
         "id": "lst_day_anomaly_blended",
         "title": "INAM mean maximum air temperature anomaly (10-day)",
         "server_layer_name": "myd11a2_blended_txd_moz_dekad"
       },
       {
+        "id": "lst_daytime",
+        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
         "id": "lst_daytime_blended",
         "title": "INAM mean maximum air temperature (10-day)",
         "server_layer_name": "myd11a2_blended_txb_moz_dekad"
+      },
+      {
+        "id": "lst_nighttime",
+        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "monthly_water_anomaly",
+        "title": "Monthly Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_dekad"
+      },
+      {
+        "id": "ndvi_dekad",
+        "title": "10-day NDVI (MODIS)",
+        "server_layer_name": "mxd13a2_vim_dekad"
+      },
+      {
+        "id": "ndvi_dekad_anomaly",
+        "title": "10-day NDVI anomaly (MODIS)",
+        "server_layer_name": "mxd13a2_viq_dekad"
       },
       {
         "id": "precip_blended_1m",
@@ -1327,6 +3890,146 @@
         "server_layer_name": "rfq_blended_moz_dekad"
       },
       {
+        "id": "rain_anomaly_1month",
+        "title": "CHIRPS 1-month rainfall anomaly",
+        "server_layer_name": "r1q_dekad"
+      },
+      {
+        "id": "rain_anomaly_1year",
+        "title": "CHIRPS 1-year rainfall anomaly",
+        "server_layer_name": "ryq_dekad"
+      },
+      {
+        "id": "rain_anomaly_2month",
+        "title": "2-month rainfall anomaly",
+        "server_layer_name": "r2q_dekad"
+      },
+      {
+        "id": "rain_anomaly_3month",
+        "title": "CHIRPS 3-month rainfall anomaly",
+        "server_layer_name": "r3q_dekad"
+      },
+      {
+        "id": "rain_anomaly_4month",
+        "title": "4-month rainfall anomaly",
+        "server_layer_name": "r4q_dekad"
+      },
+      {
+        "id": "rain_anomaly_5month",
+        "title": "5-month rainfall anomaly",
+        "server_layer_name": "r5q_dekad"
+      },
+      {
+        "id": "rain_anomaly_6month",
+        "title": "CHIRPS 6-month rainfall anomaly",
+        "server_layer_name": "r6q_dekad"
+      },
+      {
+        "id": "rain_anomaly_7month",
+        "title": "7-month rainfall anomaly",
+        "server_layer_name": "r7q_dekad"
+      },
+      {
+        "id": "rain_anomaly_8month",
+        "title": "8-month rainfall anomaly",
+        "server_layer_name": "r8q_dekad"
+      },
+      {
+        "id": "rain_anomaly_9month",
+        "title": "CHIRPS 9-month rainfall anomaly",
+        "server_layer_name": "r9q_dekad"
+      },
+      {
+        "id": "rain_anomaly_dekad",
+        "title": "CHIRPS 10-day rainfall anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rainfall_agg_1month",
+        "title": "CHIRPS 1-month rainfall aggregate",
+        "server_layer_name": "r1h_dekad"
+      },
+      {
+        "id": "rainfall_agg_1year",
+        "title": "CHIRPS 1-year rainfall aggregate (mm)",
+        "server_layer_name": "ryh_dekad"
+      },
+      {
+        "id": "rainfall_agg_2month",
+        "title": "2-month rainfall aggregate (mm)",
+        "server_layer_name": "r2h_dekad"
+      },
+      {
+        "id": "rainfall_agg_3month",
+        "title": "CHIRPS 3-month rainfall aggregate (mm)",
+        "server_layer_name": "r3h_dekad"
+      },
+      {
+        "id": "rainfall_agg_4month",
+        "title": "4-month rainfall aggregate (mm)",
+        "server_layer_name": "r4h_dekad"
+      },
+      {
+        "id": "rainfall_agg_5month",
+        "title": "5-month rainfall aggregate (mm)",
+        "server_layer_name": "r5h_dekad"
+      },
+      {
+        "id": "rainfall_agg_6month",
+        "title": "CHIRPS 6-month rainfall aggregate (mm)",
+        "server_layer_name": "r6h_dekad"
+      },
+      {
+        "id": "rainfall_agg_7month",
+        "title": "7-month rainfall aggregate (mm)",
+        "server_layer_name": "r7h_dekad"
+      },
+      {
+        "id": "rainfall_agg_8month",
+        "title": "8-month rainfall aggregate (mm)",
+        "server_layer_name": "r8h_dekad"
+      },
+      {
+        "id": "rainfall_agg_9month",
+        "title": "CHIRPS 9-month rainfall aggregate (mm)",
+        "server_layer_name": "r9h_dekad"
+      },
+      {
+        "id": "rainfall_dekad",
+        "title": "CHIRPS 10-day rainfall estimate (mm)",
+        "server_layer_name": "rfh_dekad"
+      },
+      {
+        "id": "spi_1m",
+        "title": "SPI - 1-month",
+        "server_layer_name": "r1s_dekad"
+      },
+      {
+        "id": "spi_1y",
+        "title": "SPI - 1-year",
+        "server_layer_name": "rys_dekad"
+      },
+      {
+        "id": "spi_2m",
+        "title": "SPI - 2-month",
+        "server_layer_name": "r2s_dekad"
+      },
+      {
+        "id": "spi_3m",
+        "title": "SPI - 3-month",
+        "server_layer_name": "r3s_dekad"
+      },
+      {
+        "id": "spi_6m",
+        "title": "SPI - 6-month",
+        "server_layer_name": "r6s_dekad"
+      },
+      {
+        "id": "spi_9m",
+        "title": "SPI - 9-month",
+        "server_layer_name": "r9s_dekad"
+      },
+      {
         "id": "spi_blended_1m",
         "title": "INAM SPI - 1-month",
         "server_layer_name": "rxs_blended_moz_dekad"
@@ -1370,395 +4073,6 @@
         "id": "spi_blended_9m",
         "title": "INAM SPI - 9-month",
         "server_layer_name": "rxs_blended_moz_dekad"
-      }
-    ],
-    "myanmar": [
-      {
-        "id": "days_dry",
-        "title": "Days since last rain",
-        "server_layer_name": "dlc_dekad"
-      },
-      {
-        "id": "days_extreme_rain",
-        "title": "Number of days with extreme rainfall in the last 30 days",
-        "server_layer_name": "xne_dekad"
-      },
-      {
-        "id": "days_heavy_rain",
-        "title": "Number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xnh_dekad"
-      },
-      {
-        "id": "days_intense_rain",
-        "title": "Number of days with intense rainfall in the last 30 days",
-        "server_layer_name": "xni_dekad"
-      },
-      {
-        "id": "flood_extent",
-        "title": "Flood extent",
-        "server_layer_name": "hf_water_mmr"
-      },
-      {
-        "id": "lst_amplitude",
-        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
-        "server_layer_name": "myd11a2_taa_dekad"
-      },
-      {
-        "id": "lst_anomaly",
-        "title": "Daytime Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_daytime",
-        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "ndvi_dekad",
-        "title": "10-day NDVI (MODIS)",
-        "server_layer_name": "mxd13a2_vim_dekad"
-      },
-      {
-        "id": "ndvi_dekad_anomaly",
-        "title": "10-day NDVI anomaly (MODIS)",
-        "server_layer_name": "mxd13a2_viq_dekad"
-      },
-      {
-        "id": "rain_anomaly_1month",
-        "title": "Monthly rainfall anomaly",
-        "server_layer_name": "r1q_dekad"
-      },
-      {
-        "id": "rain_anomaly_1year",
-        "title": "1-year rainfall anomaly",
-        "server_layer_name": "ryq_dekad"
-      },
-      {
-        "id": "rain_anomaly_3month",
-        "title": "3-month rainfall anomaly",
-        "server_layer_name": "r3q_dekad"
-      },
-      {
-        "id": "rain_anomaly_6month",
-        "title": "6-month rainfall anomaly",
-        "server_layer_name": "r6q_dekad"
-      },
-      {
-        "id": "rain_anomaly_9month",
-        "title": "9-month rainfall anomaly",
-        "server_layer_name": "r9q_dekad"
-      },
-      {
-        "id": "rain_anomaly_dekad",
-        "title": "10-day rainfall anomaly",
-        "server_layer_name": "rfq_dekad"
-      },
-      {
-        "id": "rainfall_agg_1month",
-        "title": "1-month rainfall aggregate",
-        "server_layer_name": "r1h_dekad"
-      },
-      {
-        "id": "rainfall_agg_1year",
-        "title": "1-year rainfall aggregate (mm)",
-        "server_layer_name": "ryh_dekad"
-      },
-      {
-        "id": "rainfall_agg_3month",
-        "title": "3-month rainfall aggregate (mm)",
-        "server_layer_name": "r3h_dekad"
-      },
-      {
-        "id": "rainfall_agg_6month",
-        "title": "6-month rainfall aggregate (mm)",
-        "server_layer_name": "r6h_dekad"
-      },
-      {
-        "id": "rainfall_agg_9month",
-        "title": "9-month rainfall aggregate (mm)",
-        "server_layer_name": "r9h_dekad"
-      },
-      {
-        "id": "rainfall_dekad",
-        "title": "10-day rainfall estimate (mm)",
-        "server_layer_name": "rfh_dekad"
-      },
-      {
-        "id": "spi_1m",
-        "title": "SPI - 1-month",
-        "server_layer_name": "r1s_dekad"
-      },
-      {
-        "id": "spi_1y",
-        "title": "SPI - 1-year",
-        "server_layer_name": "rys_dekad"
-      },
-      {
-        "id": "spi_3m",
-        "title": "SPI - 3-month",
-        "server_layer_name": "r3s_dekad"
-      },
-      {
-        "id": "spi_6m",
-        "title": "SPI - 6-month",
-        "server_layer_name": "r6s_dekad"
-      },
-      {
-        "id": "spi_9m",
-        "title": "SPI - 9-month",
-        "server_layer_name": "r9s_dekad"
-      },
-      {
-        "id": "streak_dry_days",
-        "title": "Longest number of consecutive dry days",
-        "server_layer_name": "dlx_dekad"
-      },
-      {
-        "id": "streak_extreme_rain",
-        "title": "Longest consecutive extreme rainfall days",
-        "server_layer_name": "xle_dekad"
-      },
-      {
-        "id": "streak_heavy_rain",
-        "title": "Longest consecutive number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xlh_dekad"
-      },
-      {
-        "id": "streak_intense_rain",
-        "title": "Longest consecutive intense rainfall days",
-        "server_layer_name": "xli_dekad"
-      },
-      {
-        "id": "wp_pop_icunadj",
-        "title": "population",
-        "server_layer_name": "wp_pop_icunadj"
-      }
-    ],
-    "namibia": [
-      {
-        "id": "ast_max",
-        "title": "Blended air temperature daily max (10-day)",
-        "server_layer_name": "myd11a2_blended_txb_dekad"
-      },
-      {
-        "id": "ast_max_anomaly",
-        "title": "Blended air temperature max anomaly (10-day)",
-        "server_layer_name": "myd11a2_blended_txd_dekad"
-      },
-      {
-        "id": "days_dry",
-        "title": "Days since last rain",
-        "server_layer_name": "dlc_dekad"
-      },
-      {
-        "id": "days_extreme_rain",
-        "title": "Number of days with extreme rainfall in the last 30 days",
-        "server_layer_name": "xne_dekad"
-      },
-      {
-        "id": "days_heavy_rain",
-        "title": "Number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xnh_dekad"
-      },
-      {
-        "id": "days_intense_rain",
-        "title": "Number of days with intense rainfall in the last 30 days",
-        "server_layer_name": "xni_dekad"
-      },
-      {
-        "id": "lst_amplitude",
-        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
-        "server_layer_name": "myd11a2_taa_dekad"
-      },
-      {
-        "id": "lst_day_anomaly",
-        "title": "Daytime Land Surface Temperature - 10-day Anomaly 1km (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_day_anomaly_blended",
-        "title": "Mean maximum air temperature anomaly (10-day)",
-        "server_layer_name": "myd11a2_blended_txd_dekad"
-      },
-      {
-        "id": "lst_daytime",
-        "title": "Daytime Land Surface Temperature - 10-day 1km (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "lst_daytime_blended",
-        "title": "Mean maximum air temperature (10-day)",
-        "server_layer_name": "myd11a2_blended_txb_dekad"
-      },
-      {
-        "id": "lst_nighttime",
-        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "ndvi_dekad",
-        "title": "10-day NDVI 1km (MODIS)",
-        "server_layer_name": "mxd13a2_vim_dekad"
-      },
-      {
-        "id": "ndvi_dekad_anomaly",
-        "title": "10-day NDVI anomaly 1km (MODIS)",
-        "server_layer_name": "mxd13a2_viq_dekad"
-      },
-      {
-        "id": "precip_blended_1m",
-        "title": "Blended rainfall aggregate (1-month)",
-        "server_layer_name": "rfb_blended_nam_dekad"
-      },
-      {
-        "id": "precip_blended_1y",
-        "title": "Blended rainfall aggregate (1-year)",
-        "server_layer_name": "rfb_blended_nam_dekad"
-      },
-      {
-        "id": "precip_blended_3m",
-        "title": "Blended rainfall aggregate (3-month)",
-        "server_layer_name": "rfb_blended_nam_dekad"
-      },
-      {
-        "id": "precip_blended_6m",
-        "title": "Blended rainfall aggregate (6-month)",
-        "server_layer_name": "rfb_blended_nam_dekad"
-      },
-      {
-        "id": "precip_blended_9m",
-        "title": "Blended rainfall aggregate (9-month)",
-        "server_layer_name": "rfb_blended_nam_dekad"
-      },
-      {
-        "id": "precip_blended_anomaly_1m",
-        "title": "Blended rainfall anomaly (1-month)",
-        "server_layer_name": "rfq_blended_nam_dekad"
-      },
-      {
-        "id": "precip_blended_anomaly_1y",
-        "title": "Blended rainfall anomaly (1-year)",
-        "server_layer_name": "rfq_blended_nam_dekad"
-      },
-      {
-        "id": "precip_blended_anomaly_3m",
-        "title": "Blended rainfall anomaly (3-month)",
-        "server_layer_name": "rfq_blended_nam_dekad"
-      },
-      {
-        "id": "precip_blended_anomaly_6m",
-        "title": "Blended rainfall anomaly (6-month)",
-        "server_layer_name": "rfq_blended_nam_dekad"
-      },
-      {
-        "id": "precip_blended_anomaly_9m",
-        "title": "Blended rainfall anomaly (9-month)",
-        "server_layer_name": "rfq_blended_nam_dekad"
-      },
-      {
-        "id": "precip_blended_dekad",
-        "title": "Blended rainfall estimates (10-day)",
-        "server_layer_name": "rfb_blended_nam_dekad"
-      },
-      {
-        "id": "precip_blended_dekad_agg",
-        "title": "Blended monthly aggregate rainfall",
-        "server_layer_name": "rnb_blended_dekad"
-      },
-      {
-        "id": "precip_blended_dekad_anomaly",
-        "title": "Blended rainfall anomaly (10-day)",
-        "server_layer_name": "rfq_blended_nam_dekad"
-      },
-      {
-        "id": "rain_anomaly_1month",
-        "title": "1-month rainfall anomaly",
-        "server_layer_name": "r1q_dekad"
-      },
-      {
-        "id": "rain_anomaly_1year",
-        "title": "1-year rainfall anomaly",
-        "server_layer_name": "ryq_dekad"
-      },
-      {
-        "id": "rain_anomaly_3month",
-        "title": "3-month rainfall anomaly",
-        "server_layer_name": "r3q_dekad"
-      },
-      {
-        "id": "rain_anomaly_6month",
-        "title": "6-month rainfall anomaly",
-        "server_layer_name": "r6q_dekad"
-      },
-      {
-        "id": "rain_anomaly_9month",
-        "title": "9-month rainfall anomaly",
-        "server_layer_name": "r9q_dekad"
-      },
-      {
-        "id": "rain_anomaly_dekad",
-        "title": "10-day rainfall anomaly",
-        "server_layer_name": "rfq_dekad"
-      },
-      {
-        "id": "rainfall_agg_1month",
-        "title": "1-month rainfall aggregate",
-        "server_layer_name": "r1h_dekad"
-      },
-      {
-        "id": "rainfall_agg_1year",
-        "title": "1-year rainfall aggregate (mm)",
-        "server_layer_name": "ryh_dekad"
-      },
-      {
-        "id": "rainfall_agg_2month",
-        "title": "2-month rainfall aggregate (mm)",
-        "server_layer_name": "r2h_dekad"
-      },
-      {
-        "id": "rainfall_agg_3month",
-        "title": "3-month rainfall aggregate (mm)",
-        "server_layer_name": "r3h_dekad"
-      },
-      {
-        "id": "rainfall_agg_6month",
-        "title": "6-month rainfall aggregate (mm)",
-        "server_layer_name": "r6h_dekad"
-      },
-      {
-        "id": "rainfall_agg_9month",
-        "title": "9-month rainfall aggregate (mm)",
-        "server_layer_name": "r9h_dekad"
-      },
-      {
-        "id": "rainfall_dekad",
-        "title": "10-day rainfall estimate (mm)",
-        "server_layer_name": "rfh_dekad"
-      },
-      {
-        "id": "spi_1m",
-        "title": "SPI - 1-month",
-        "server_layer_name": "r1s_dekad"
-      },
-      {
-        "id": "spi_1y",
-        "title": "SPI - 1-year",
-        "server_layer_name": "rys_dekad"
-      },
-      {
-        "id": "spi_3m",
-        "title": "SPI - 3-month",
-        "server_layer_name": "r3s_dekad"
-      },
-      {
-        "id": "spi_6m",
-        "title": "SPI - 6-month",
-        "server_layer_name": "r6s_dekad"
-      },
-      {
-        "id": "spi_9m",
-        "title": "SPI - 9-month",
-        "server_layer_name": "r9s_dekad"
       },
       {
         "id": "streak_dry_days",
@@ -1781,1297 +4095,31 @@
         "server_layer_name": "xli_dekad"
       }
     ],
-    "nepal": [
+    "myanmar": [
       {
-        "id": "days_dry",
-        "title": "Days since last rain",
-        "server_layer_name": "dlc_dekad"
+        "id": "2m_water_anomaly",
+        "title": "2-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_2month"
       },
       {
-        "id": "days_extreme_rain",
-        "title": "Number of days with extreme rainfall in the last 30 days",
-        "server_layer_name": "xne_dekad"
+        "id": "3m_water_anomaly",
+        "title": "3-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_3month"
       },
       {
-        "id": "days_heavy_rain",
-        "title": "Number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xnh_dekad"
+        "id": "4m_water_anomaly",
+        "title": "4-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_4month"
       },
       {
-        "id": "days_intense_rain",
-        "title": "Number of days with intense rainfall in the last 30 days",
-        "server_layer_name": "xni_dekad"
+        "id": "5m_water_anomaly",
+        "title": "5-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_5month"
       },
       {
-        "id": "lst_amplitude",
-        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
-        "server_layer_name": "myd11a2_taa_dekad"
-      },
-      {
-        "id": "lst_anomaly",
-        "title": "Daytime Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_daytime",
-        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "ndvi_dekad",
-        "title": "10-day NDVI (MODIS)",
-        "server_layer_name": "mxd13a2_vim_dekad"
-      },
-      {
-        "id": "ndvi_dekad_anomaly",
-        "title": "10-day NDVI anomaly (MODIS)",
-        "server_layer_name": "mxd13a2_viq_dekad"
-      },
-      {
-        "id": "precip_blended_1m",
-        "title": "Blended rainfall aggregate (1-month)",
-        "server_layer_name": "rfb_blended_lka_dekad"
-      },
-      {
-        "id": "precip_blended_1y",
-        "title": "Blended rainfall aggregate (1-year)",
-        "server_layer_name": "rfb_blended_lka_dekad"
-      },
-      {
-        "id": "precip_blended_3m",
-        "title": "Blended rainfall aggregate (3-month)",
-        "server_layer_name": "rfb_blended_lka_dekad"
-      },
-      {
-        "id": "precip_blended_6m",
-        "title": "Blended rainfall aggregate (6-month)",
-        "server_layer_name": "rfb_blended_lka_dekad"
-      },
-      {
-        "id": "precip_blended_9m",
-        "title": "Blended rainfall aggregate (9-month)",
-        "server_layer_name": "rfb_blended_lka_dekad"
-      },
-      {
-        "id": "precip_blended_anomaly_1m",
-        "title": "Blended rainfall anomaly (1-month)",
-        "server_layer_name": "rfq_blended_lka_dekad"
-      },
-      {
-        "id": "precip_blended_anomaly_1y",
-        "title": "Blended rainfall anomaly (1-year)",
-        "server_layer_name": "rfq_blended_lka_dekad"
-      },
-      {
-        "id": "precip_blended_anomaly_3m",
-        "title": "Blended rainfall anomaly (3-month)",
-        "server_layer_name": "rfq_blended_lka_dekad"
-      },
-      {
-        "id": "precip_blended_anomaly_6m",
-        "title": "Blended rainfall anomaly (6-month)",
-        "server_layer_name": "rfq_blended_lka_dekad"
-      },
-      {
-        "id": "precip_blended_anomaly_9m",
-        "title": "Blended rainfall anomaly (9-month)",
-        "server_layer_name": "rfq_blended_lka_dekad"
-      },
-      {
-        "id": "precip_blended_dekad",
-        "title": "Blended rainfall estimates (10-day)",
-        "server_layer_name": "rfb_blended_lka_dekad"
-      },
-      {
-        "id": "precip_blended_dekad_agg",
-        "title": "Blended monthly aggregate rainfall",
-        "server_layer_name": "rnb_blended_dekad"
-      },
-      {
-        "id": "precip_blended_dekad_anomaly",
-        "title": "Blended rainfall anomaly (10-day)",
-        "server_layer_name": "rfq_blended_lka_dekad"
-      },
-      {
-        "id": "rain_anomaly_1month",
-        "title": "Monthly rainfall anomaly",
-        "server_layer_name": "r1q_dekad"
-      },
-      {
-        "id": "rain_anomaly_1year",
-        "title": "1-year rainfall anomaly",
-        "server_layer_name": "ryq_dekad"
-      },
-      {
-        "id": "rain_anomaly_3month",
-        "title": "3-month rainfall anomaly",
-        "server_layer_name": "r3q_dekad"
-      },
-      {
-        "id": "rain_anomaly_6month",
-        "title": "6-month rainfall anomaly",
-        "server_layer_name": "r6q_dekad"
-      },
-      {
-        "id": "rain_anomaly_9month",
-        "title": "9-month rainfall anomaly",
-        "server_layer_name": "r9q_dekad"
-      },
-      {
-        "id": "rain_anomaly_dekad",
-        "title": "10-day rainfall anomaly",
-        "server_layer_name": "rfq_dekad"
-      },
-      {
-        "id": "rainfall_agg_1month",
-        "title": "1-month rainfall aggregate",
-        "server_layer_name": "r1h_dekad"
-      },
-      {
-        "id": "rainfall_agg_1year",
-        "title": "1-year rainfall aggregate (mm)",
-        "server_layer_name": "ryh_dekad"
-      },
-      {
-        "id": "rainfall_agg_3month",
-        "title": "3-month rainfall aggregate (mm)",
-        "server_layer_name": "r3h_dekad"
-      },
-      {
-        "id": "rainfall_agg_6month",
-        "title": "6-month rainfall aggregate (mm)",
-        "server_layer_name": "r6h_dekad"
-      },
-      {
-        "id": "rainfall_agg_9month",
-        "title": "9-month rainfall aggregate (mm)",
-        "server_layer_name": "r9h_dekad"
-      },
-      {
-        "id": "rainfall_dekad",
-        "title": "10-day rainfall estimate (mm)",
-        "server_layer_name": "rfh_dekad"
-      },
-      {
-        "id": "spi_1m",
-        "title": "SPI - 1-month",
-        "server_layer_name": "r1s_dekad"
-      },
-      {
-        "id": "spi_1y",
-        "title": "SPI - 1-year",
-        "server_layer_name": "rys_dekad"
-      },
-      {
-        "id": "spi_3m",
-        "title": "SPI - 3-month",
-        "server_layer_name": "r3s_dekad"
-      },
-      {
-        "id": "spi_6m",
-        "title": "SPI - 6-month",
-        "server_layer_name": "r6s_dekad"
-      },
-      {
-        "id": "spi_9m",
-        "title": "SPI - 9-month",
-        "server_layer_name": "r9s_dekad"
-      },
-      {
-        "id": "streak_dry_days",
-        "title": "Longest number of consecutive dry days",
-        "server_layer_name": "dlx_dekad"
-      },
-      {
-        "id": "streak_extreme_rain",
-        "title": "Longest consecutive extreme rainfall days",
-        "server_layer_name": "xle_dekad"
-      },
-      {
-        "id": "streak_heavy_rain",
-        "title": "Longest consecutive number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xlh_dekad"
-      },
-      {
-        "id": "streak_intense_rain",
-        "title": "Longest consecutive intense rainfall days",
-        "server_layer_name": "xli_dekad"
-      }
-    ],
-    "nigeria": [
-      {
-        "id": "days_dry",
-        "title": "Days since last rain",
-        "server_layer_name": "dlc_dekad"
-      },
-      {
-        "id": "days_extreme_rain",
-        "title": "Number of days with extreme rainfall in the last 30 days",
-        "server_layer_name": "xne_dekad"
-      },
-      {
-        "id": "days_heavy_rain",
-        "title": "Number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xnh_dekad"
-      },
-      {
-        "id": "days_intense_rain",
-        "title": "Number of days with intense rainfall in the last 30 days",
-        "server_layer_name": "xni_dekad"
-      },
-      {
-        "id": "lst_amplitude",
-        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
-        "server_layer_name": "myd11a2_taa_dekad"
-      },
-      {
-        "id": "lst_anomaly",
-        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_daytime",
-        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "ndvi_dekad",
-        "title": "10-day NDVI (MODIS)",
-        "server_layer_name": "mxd13a2_vim_dekad"
-      },
-      {
-        "id": "ndvi_dekad_anomaly",
-        "title": "10-day NDVI anomaly (MODIS)",
-        "server_layer_name": "mxd13a2_viq_dekad"
-      },
-      {
-        "id": "precip_blended_1m",
-        "title": "Blended rainfall aggregate (1-month)",
-        "server_layer_name": "rfb_blended_zwe_dekad"
-      },
-      {
-        "id": "precip_blended_1y",
-        "title": "Blended rainfall aggregate (1-year)",
-        "server_layer_name": "rfb_blended_zwe_dekad"
-      },
-      {
-        "id": "precip_blended_3m",
-        "title": "Blended rainfall aggregate (3-month)",
-        "server_layer_name": "rfb_blended_zwe_dekad"
-      },
-      {
-        "id": "precip_blended_6m",
-        "title": "Blended rainfall aggregate (6-month)",
-        "server_layer_name": "rfb_blended_zwe_dekad"
-      },
-      {
-        "id": "precip_blended_9m",
-        "title": "Blended rainfall aggregate (9-month)",
-        "server_layer_name": "rfb_blended_zwe_dekad"
-      },
-      {
-        "id": "precip_blended_anomaly_1m",
-        "title": "Blended rainfall anomaly (1-month)",
-        "server_layer_name": "rfq_blended_zwe_dekad"
-      },
-      {
-        "id": "precip_blended_anomaly_1y",
-        "title": "Blended rainfall anomaly (1-year)",
-        "server_layer_name": "rfq_blended_zwe_dekad"
-      },
-      {
-        "id": "precip_blended_anomaly_3m",
-        "title": "Blended rainfall anomaly (3-month)",
-        "server_layer_name": "rfq_blended_zwe_dekad"
-      },
-      {
-        "id": "precip_blended_anomaly_6m",
-        "title": "Blended rainfall anomaly (6-month)",
-        "server_layer_name": "rfq_blended_zwe_dekad"
-      },
-      {
-        "id": "precip_blended_anomaly_9m",
-        "title": "Blended rainfall anomaly (9-month)",
-        "server_layer_name": "rfq_blended_zwe_dekad"
-      },
-      {
-        "id": "precip_blended_dekad",
-        "title": "Blended rainfall aggregate (10-day)",
-        "server_layer_name": "rfb_blended_zwe_dekad"
-      },
-      {
-        "id": "precip_blended_dekad_anomaly",
-        "title": "Blended rainfall anomaly (10-day)",
-        "server_layer_name": "rfq_blended_zwe_dekad"
-      },
-      {
-        "id": "rain_anomaly_1month",
-        "title": "Monthly rainfall anomaly",
-        "server_layer_name": "r1q_dekad"
-      },
-      {
-        "id": "rain_anomaly_1year",
-        "title": "1-year rainfall anomaly",
-        "server_layer_name": "ryq_dekad"
-      },
-      {
-        "id": "rain_anomaly_3month",
-        "title": "3-month rainfall anomaly",
-        "server_layer_name": "r3q_dekad"
-      },
-      {
-        "id": "rain_anomaly_6month",
-        "title": "6-month rainfall anomaly",
-        "server_layer_name": "r6q_dekad"
-      },
-      {
-        "id": "rain_anomaly_9month",
-        "title": "9-month rainfall anomaly",
-        "server_layer_name": "r9q_dekad"
-      },
-      {
-        "id": "rain_anomaly_dekad",
-        "title": "10-day rainfall anomaly",
-        "server_layer_name": "rfq_dekad"
-      },
-      {
-        "id": "rainfall_agg_1month",
-        "title": "1-month rainfall aggregate (mm)",
-        "server_layer_name": "r1h_dekad"
-      },
-      {
-        "id": "rainfall_agg_1year",
-        "title": "1-year rainfall aggregate (mm)",
-        "server_layer_name": "ryh_dekad"
-      },
-      {
-        "id": "rainfall_agg_3month",
-        "title": "3-month rainfall aggregate (mm)",
-        "server_layer_name": "r3h_dekad"
-      },
-      {
-        "id": "rainfall_agg_6month",
-        "title": "6-month rainfall aggregate (mm)",
-        "server_layer_name": "r6h_dekad"
-      },
-      {
-        "id": "rainfall_agg_9month",
-        "title": "9-month rainfall aggregate (mm)",
-        "server_layer_name": "r9h_dekad"
-      },
-      {
-        "id": "rainfall_dekad",
-        "title": "10-day rainfall estimate (mm)",
-        "server_layer_name": "rfh_dekad"
-      },
-      {
-        "id": "spi_1m",
-        "title": "SPI - 1-month",
-        "server_layer_name": "r1s_dekad"
-      },
-      {
-        "id": "spi_1y",
-        "title": "SPI - 1-year",
-        "server_layer_name": "rys_dekad"
-      },
-      {
-        "id": "spi_3m",
-        "title": "SPI - 3-month",
-        "server_layer_name": "r3s_dekad"
-      },
-      {
-        "id": "spi_6m",
-        "title": "SPI - 6-month",
-        "server_layer_name": "r6s_dekad"
-      },
-      {
-        "id": "spi_9m",
-        "title": "SPI - 9-month",
-        "server_layer_name": "r9s_dekad"
-      },
-      {
-        "id": "streak_dry_days",
-        "title": "Longest number of consecutive dry days",
-        "server_layer_name": "dlx_dekad"
-      },
-      {
-        "id": "streak_extreme_rain",
-        "title": "Longest consecutive extreme rainfall days",
-        "server_layer_name": "xle_dekad"
-      },
-      {
-        "id": "streak_heavy_rain",
-        "title": "Longest consecutive number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xlh_dekad"
-      },
-      {
-        "id": "streak_intense_rain",
-        "title": "Longest consecutive intense rainfall days",
-        "server_layer_name": "xli_dekad"
-      }
-    ],
-    "rbd": [
-      {
-        "id": "daily_rainfall_forecast",
-        "title": "Rolling daily rainfall forecast",
-        "server_layer_name": "rfh_daily_forecast"
-      },
-      {
-        "id": "days_dry",
-        "title": "Days since last rain",
-        "server_layer_name": "dlc_dekad"
-      },
-      {
-        "id": "days_extreme_rain",
-        "title": "Number of days with extreme rainfall in the last 30 days",
-        "server_layer_name": "xne_dekad"
-      },
-      {
-        "id": "days_heavy_rain",
-        "title": "Number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xnh_dekad"
-      },
-      {
-        "id": "days_intense_rain",
-        "title": "Number of days with intense rainfall in the last 30 days",
-        "server_layer_name": "xni_dekad"
-      },
-      {
-        "id": "dekad_rainfall_forecast",
-        "title": "10-day rainfall forecast",
-        "server_layer_name": "rfh_dekad_forecast"
-      },
-      {
-        "id": "lst_amplitude",
-        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
-        "server_layer_name": "myd11a2_taa_dekad"
-      },
-      {
-        "id": "lst_anomaly",
-        "title": "Daytime Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_daytime",
-        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "lst_nighttime",
-        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "ndvi_dekad",
-        "title": "10-day NDVI (MODIS)",
-        "server_layer_name": "mxd13a2_vim_dekad"
-      },
-      {
-        "id": "ndvi_dekad_anomaly",
-        "title": "10-day NDVI anomaly (MODIS)",
-        "server_layer_name": "mxd13a2_viq_dekad"
-      },
-      {
-        "id": "rain_anomaly_1month",
-        "title": "1-month rainfall anomaly",
-        "server_layer_name": "r1q_dekad"
-      },
-      {
-        "id": "rain_anomaly_1year",
-        "title": "1-year rainfall anomaly",
-        "server_layer_name": "ryq_dekad"
-      },
-      {
-        "id": "rain_anomaly_3month",
-        "title": "3-month rainfall anomaly",
-        "server_layer_name": "r3q_dekad"
-      },
-      {
-        "id": "rain_anomaly_6month",
-        "title": "6-month rainfall anomaly",
-        "server_layer_name": "r6q_dekad"
-      },
-      {
-        "id": "rain_anomaly_9month",
-        "title": "9-month rainfall anomaly",
-        "server_layer_name": "r9q_dekad"
-      },
-      {
-        "id": "rain_anomaly_dekad",
-        "title": "10-day rainfall anomaly",
-        "server_layer_name": "rfq_dekad"
-      },
-      {
-        "id": "rainfall_agg_1month",
-        "title": "1-month rainfall aggregate (mm)",
-        "server_layer_name": "r1h_dekad"
-      },
-      {
-        "id": "rainfall_agg_1year",
-        "title": "1-year rainfall aggregate (mm)",
-        "server_layer_name": "ryh_dekad"
-      },
-      {
-        "id": "rainfall_agg_3month",
-        "title": "3-month rainfall aggregate (mm)",
-        "server_layer_name": "r3h_dekad"
-      },
-      {
-        "id": "rainfall_agg_6month",
-        "title": "6-month rainfall aggregate (mm)",
-        "server_layer_name": "r6h_dekad"
-      },
-      {
-        "id": "rainfall_agg_9month",
-        "title": "9-month rainfall aggregate (mm)",
-        "server_layer_name": "r9h_dekad"
-      },
-      {
-        "id": "rainfall_dekad",
-        "title": "10-day rainfall estimate (mm)",
-        "server_layer_name": "rfh_dekad"
-      },
-      {
-        "id": "spi_1m",
-        "title": "SPI - 1-month",
-        "server_layer_name": "r1s_dekad"
-      },
-      {
-        "id": "spi_1y",
-        "title": "SPI - 1-year",
-        "server_layer_name": "rys_dekad"
-      },
-      {
-        "id": "spi_3m",
-        "title": "SPI - 3-month",
-        "server_layer_name": "r3s_dekad"
-      },
-      {
-        "id": "spi_6m",
-        "title": "SPI - 6-month",
-        "server_layer_name": "r6s_dekad"
-      },
-      {
-        "id": "spi_9m",
-        "title": "SPI - 9-month",
-        "server_layer_name": "r9s_dekad"
-      },
-      {
-        "id": "streak_dry_days",
-        "title": "Longest number of consecutive dry days",
-        "server_layer_name": "dlx_dekad"
-      },
-      {
-        "id": "streak_extreme_rain",
-        "title": "Longest consecutive extreme rainfall days",
-        "server_layer_name": "xle_dekad"
-      },
-      {
-        "id": "streak_heavy_rain",
-        "title": "Longest consecutive number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xlh_dekad"
-      },
-      {
-        "id": "streak_intense_rain",
-        "title": "Longest consecutive intense rainfall days",
-        "server_layer_name": "xli_dekad"
-      }
-    ],
-    "sierraleone": [
-      {
-        "id": "days_dry",
-        "title": "Days since last rain",
-        "server_layer_name": "dlc_dekad"
-      },
-      {
-        "id": "days_extreme_rain",
-        "title": "Number of days with extreme rainfall in the last 30 days",
-        "server_layer_name": "xne_dekad"
-      },
-      {
-        "id": "days_heavy_rain",
-        "title": "Number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xnh_dekad"
-      },
-      {
-        "id": "days_intense_rain",
-        "title": "Number of days with intense rainfall in the last 30 days",
-        "server_layer_name": "xni_dekad"
-      },
-      {
-        "id": "lst_amplitude",
-        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
-        "server_layer_name": "myd11a2_taa_dekad"
-      },
-      {
-        "id": "lst_anomaly",
-        "title": "Daytime Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_daytime",
-        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "lst_nighttime",
-        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "ndvi_dekad",
-        "title": "10-day NDVI (MODIS)",
-        "server_layer_name": "mxd13a2_vim_dekad"
-      },
-      {
-        "id": "ndvi_dekad_anomaly",
-        "title": "10-day NDVI anomaly (MODIS)",
-        "server_layer_name": "mxd13a2_viq_dekad"
-      },
-      {
-        "id": "rain_anomaly_1month",
-        "title": "1-month rainfall anomaly",
-        "server_layer_name": "r1q_dekad"
-      },
-      {
-        "id": "rain_anomaly_1year",
-        "title": "1-year rainfall anomaly",
-        "server_layer_name": "ryq_dekad"
-      },
-      {
-        "id": "rain_anomaly_3month",
-        "title": "3-month rainfall anomaly",
-        "server_layer_name": "r3q_dekad"
-      },
-      {
-        "id": "rain_anomaly_6month",
-        "title": "6-month rainfall anomaly",
-        "server_layer_name": "r6q_dekad"
-      },
-      {
-        "id": "rain_anomaly_9month",
-        "title": "9-month rainfall anomaly",
-        "server_layer_name": "r9q_dekad"
-      },
-      {
-        "id": "rain_anomaly_dekad",
-        "title": "10-day rainfall anomaly",
-        "server_layer_name": "rfq_dekad"
-      },
-      {
-        "id": "rainfall_agg_1month",
-        "title": "1-month rainfall aggregate (mm)",
-        "server_layer_name": "r1h_dekad"
-      },
-      {
-        "id": "rainfall_agg_1year",
-        "title": "1-year rainfall aggregate (mm)",
-        "server_layer_name": "ryh_dekad"
-      },
-      {
-        "id": "rainfall_agg_3month",
-        "title": "3-month rainfall aggregate (mm)",
-        "server_layer_name": "r3h_dekad"
-      },
-      {
-        "id": "rainfall_agg_6month",
-        "title": "6-month rainfall aggregate (mm)",
-        "server_layer_name": "r6h_dekad"
-      },
-      {
-        "id": "rainfall_agg_9month",
-        "title": "9-month rainfall aggregate (mm)",
-        "server_layer_name": "r9h_dekad"
-      },
-      {
-        "id": "rainfall_dekad",
-        "title": "10-day rainfall estimate (mm)",
-        "server_layer_name": "rfh_dekad"
-      },
-      {
-        "id": "spi_1m",
-        "title": "SPI - 1-month",
-        "server_layer_name": "r1s_dekad"
-      },
-      {
-        "id": "spi_1y",
-        "title": "SPI - 1-year",
-        "server_layer_name": "rys_dekad"
-      },
-      {
-        "id": "spi_3m",
-        "title": "SPI - 3-month",
-        "server_layer_name": "r3s_dekad"
-      },
-      {
-        "id": "spi_6m",
-        "title": "SPI - 6-month",
-        "server_layer_name": "r6s_dekad"
-      },
-      {
-        "id": "spi_9m",
-        "title": "SPI - 9-month",
-        "server_layer_name": "r9s_dekad"
-      },
-      {
-        "id": "streak_dry_days",
-        "title": "Longest dry spell",
-        "server_layer_name": "dlx_dekad"
-      },
-      {
-        "id": "streak_extreme_rain",
-        "title": "Longest consecutive extreme rainfall days",
-        "server_layer_name": "xle_dekad"
-      },
-      {
-        "id": "streak_heavy_rain",
-        "title": "Longest consecutive number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xlh_dekad"
-      },
-      {
-        "id": "streak_intense_rain",
-        "title": "Longest consecutive intense rainfall days",
-        "server_layer_name": "xli_dekad"
-      }
-    ],
-    "somalia": [],
-    "southsudan": [
-      {
-        "id": "days_dry",
-        "title": "Days since last rain",
-        "server_layer_name": "dlc_dekad"
-      },
-      {
-        "id": "days_extreme_rain",
-        "title": "Number of days with extreme rainfall in the last 30 days",
-        "server_layer_name": "xne_dekad"
-      },
-      {
-        "id": "days_heavy_rain",
-        "title": "Number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xnh_dekad"
-      },
-      {
-        "id": "days_intense_rain",
-        "title": "Number of days with intense rainfall in the last 30 days",
-        "server_layer_name": "xni_dekad"
-      },
-      {
-        "id": "lst_amplitude",
-        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
-        "server_layer_name": "myd11a2_taa_dekad"
-      },
-      {
-        "id": "lst_anomaly",
-        "title": "Daytime Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_daytime",
-        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "lst_nighttime",
-        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "ndvi_dekad",
-        "title": "10-day NDVI (MODIS)",
-        "server_layer_name": "mxd13a2_vim_dekad"
-      },
-      {
-        "id": "ndvi_dekad_anomaly",
-        "title": "10-day NDVI anomaly (MODIS)",
-        "server_layer_name": "mxd13a2_viq_dekad"
-      },
-      {
-        "id": "rain_anomaly_1month",
-        "title": "1-month rainfall anomaly",
-        "server_layer_name": "r1q_dekad"
-      },
-      {
-        "id": "rain_anomaly_1year",
-        "title": "1-year rainfall anomaly",
-        "server_layer_name": "ryq_dekad"
-      },
-      {
-        "id": "rain_anomaly_3month",
-        "title": "3-month rainfall anomaly",
-        "server_layer_name": "r3q_dekad"
-      },
-      {
-        "id": "rain_anomaly_6month",
-        "title": "6-month rainfall anomaly",
-        "server_layer_name": "r6q_dekad"
-      },
-      {
-        "id": "rain_anomaly_9month",
-        "title": "9-month rainfall anomaly",
-        "server_layer_name": "r9q_dekad"
-      },
-      {
-        "id": "rain_anomaly_dekad",
-        "title": "10-day rainfall anomaly",
-        "server_layer_name": "rfq_dekad"
-      },
-      {
-        "id": "rainfall_agg_1month",
-        "title": "1-month rainfall aggregate (mm)",
-        "server_layer_name": "r1h_dekad"
-      },
-      {
-        "id": "rainfall_agg_1year",
-        "title": "1-year rainfall aggregate (mm)",
-        "server_layer_name": "ryh_dekad"
-      },
-      {
-        "id": "rainfall_agg_3month",
-        "title": "3-month rainfall aggregate (mm)",
-        "server_layer_name": "r3h_dekad"
-      },
-      {
-        "id": "rainfall_agg_6month",
-        "title": "6-month rainfall aggregate (mm)",
-        "server_layer_name": "r6h_dekad"
-      },
-      {
-        "id": "rainfall_agg_9month",
-        "title": "9-month rainfall aggregate (mm)",
-        "server_layer_name": "r9h_dekad"
-      },
-      {
-        "id": "rainfall_dekad",
-        "title": "10-day rainfall estimate (mm)",
-        "server_layer_name": "rfh_dekad"
-      },
-      {
-        "id": "spi_1m",
-        "title": "SPI - 1-month",
-        "server_layer_name": "r1s_dekad"
-      },
-      {
-        "id": "spi_1y",
-        "title": "SPI - 1-year",
-        "server_layer_name": "rys_dekad"
-      },
-      {
-        "id": "spi_3m",
-        "title": "SPI - 3-month",
-        "server_layer_name": "r3s_dekad"
-      },
-      {
-        "id": "spi_6m",
-        "title": "SPI - 6-month",
-        "server_layer_name": "r6s_dekad"
-      },
-      {
-        "id": "spi_9m",
-        "title": "SPI - 9-month",
-        "server_layer_name": "r9s_dekad"
-      },
-      {
-        "id": "streak_dry_days",
-        "title": "Longest dry spell",
-        "server_layer_name": "dlx_dekad"
-      },
-      {
-        "id": "streak_extreme_rain",
-        "title": "Longest consecutive extreme rainfall days",
-        "server_layer_name": "xle_dekad"
-      },
-      {
-        "id": "streak_heavy_rain",
-        "title": "Longest consecutive number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xlh_dekad"
-      },
-      {
-        "id": "streak_intense_rain",
-        "title": "Longest consecutive intense rainfall days",
-        "server_layer_name": "xli_dekad"
-      }
-    ],
-    "srilanka": [
-      {
-        "id": "days_dry",
-        "title": "Days since last rain",
-        "server_layer_name": "dlc_dekad"
-      },
-      {
-        "id": "days_extreme_rain",
-        "title": "Number of days with extreme rainfall in the last 30 days",
-        "server_layer_name": "xne_dekad"
-      },
-      {
-        "id": "days_heavy_rain",
-        "title": "Number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xnh_dekad"
-      },
-      {
-        "id": "days_intense_rain",
-        "title": "Number of days with intense rainfall in the last 30 days",
-        "server_layer_name": "xni_dekad"
-      },
-      {
-        "id": "lst_amplitude",
-        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
-        "server_layer_name": "myd11a2_taa_dekad"
-      },
-      {
-        "id": "lst_anomaly",
-        "title": "Daytime Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_daytime",
-        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "ndvi_dekad",
-        "title": "10-day NDVI (MODIS)",
-        "server_layer_name": "mxd13a2_vim_dekad"
-      },
-      {
-        "id": "ndvi_dekad_anomaly",
-        "title": "10-day NDVI anomaly (MODIS)",
-        "server_layer_name": "mxd13a2_viq_dekad"
-      },
-      {
-        "id": "precip_blended_1m",
-        "title": "Blended rainfall aggregate (1-month)",
-        "server_layer_name": "rfb_blended_lka_dekad"
-      },
-      {
-        "id": "precip_blended_1y",
-        "title": "Blended rainfall aggregate (1-year)",
-        "server_layer_name": "rfb_blended_lka_dekad"
-      },
-      {
-        "id": "precip_blended_3m",
-        "title": "Blended rainfall aggregate (3-month)",
-        "server_layer_name": "rfb_blended_lka_dekad"
-      },
-      {
-        "id": "precip_blended_6m",
-        "title": "Blended rainfall aggregate (6-month)",
-        "server_layer_name": "rfb_blended_lka_dekad"
-      },
-      {
-        "id": "precip_blended_9m",
-        "title": "Blended rainfall aggregate (9-month)",
-        "server_layer_name": "rfb_blended_lka_dekad"
-      },
-      {
-        "id": "precip_blended_anomaly_1m",
-        "title": "Blended rainfall anomaly (1-month)",
-        "server_layer_name": "rfq_blended_lka_dekad"
-      },
-      {
-        "id": "precip_blended_anomaly_1y",
-        "title": "Blended rainfall anomaly (1-year)",
-        "server_layer_name": "rfq_blended_lka_dekad"
-      },
-      {
-        "id": "precip_blended_anomaly_3m",
-        "title": "Blended rainfall anomaly (3-month)",
-        "server_layer_name": "rfq_blended_lka_dekad"
-      },
-      {
-        "id": "precip_blended_anomaly_6m",
-        "title": "Blended rainfall anomaly (6-month)",
-        "server_layer_name": "rfq_blended_lka_dekad"
-      },
-      {
-        "id": "precip_blended_anomaly_9m",
-        "title": "Blended rainfall anomaly (9-month)",
-        "server_layer_name": "rfq_blended_lka_dekad"
-      },
-      {
-        "id": "precip_blended_dekad",
-        "title": "Blended rainfall estimates (10-day)",
-        "server_layer_name": "rfb_blended_lka_dekad"
-      },
-      {
-        "id": "precip_blended_dekad_agg",
-        "title": "Blended monthly aggregate rainfall",
-        "server_layer_name": "rnb_blended_dekad"
-      },
-      {
-        "id": "precip_blended_dekad_anomaly",
-        "title": "Blended rainfall anomaly (10-day)",
-        "server_layer_name": "rfq_blended_lka_dekad"
-      },
-      {
-        "id": "rain_anomaly_1month",
-        "title": "Monthly rainfall anomaly",
-        "server_layer_name": "r1q_dekad"
-      },
-      {
-        "id": "rain_anomaly_1year",
-        "title": "1-year rainfall anomaly",
-        "server_layer_name": "ryq_dekad"
-      },
-      {
-        "id": "rain_anomaly_3month",
-        "title": "3-month rainfall anomaly",
-        "server_layer_name": "r3q_dekad"
-      },
-      {
-        "id": "rain_anomaly_6month",
-        "title": "6-month rainfall anomaly",
-        "server_layer_name": "r6q_dekad"
-      },
-      {
-        "id": "rain_anomaly_9month",
-        "title": "9-month rainfall anomaly",
-        "server_layer_name": "r9q_dekad"
-      },
-      {
-        "id": "rain_anomaly_dekad",
-        "title": "10-day rainfall anomaly",
-        "server_layer_name": "rfq_dekad"
-      },
-      {
-        "id": "rainfall_agg_1month",
-        "title": "1-month rainfall aggregate",
-        "server_layer_name": "r1h_dekad"
-      },
-      {
-        "id": "rainfall_agg_1year",
-        "title": "1-year rainfall aggregate (mm)",
-        "server_layer_name": "ryh_dekad"
-      },
-      {
-        "id": "rainfall_agg_3month",
-        "title": "3-month rainfall aggregate (mm)",
-        "server_layer_name": "r3h_dekad"
-      },
-      {
-        "id": "rainfall_agg_6month",
-        "title": "6-month rainfall aggregate (mm)",
-        "server_layer_name": "r6h_dekad"
-      },
-      {
-        "id": "rainfall_agg_9month",
-        "title": "9-month rainfall aggregate (mm)",
-        "server_layer_name": "r9h_dekad"
-      },
-      {
-        "id": "rainfall_dekad",
-        "title": "10-day rainfall estimate (mm)",
-        "server_layer_name": "rfh_dekad"
-      },
-      {
-        "id": "spi_1m",
-        "title": "SPI - 1-month",
-        "server_layer_name": "r1s_dekad"
-      },
-      {
-        "id": "spi_1y",
-        "title": "SPI - 1-year",
-        "server_layer_name": "rys_dekad"
-      },
-      {
-        "id": "spi_3m",
-        "title": "SPI - 3-month",
-        "server_layer_name": "r3s_dekad"
-      },
-      {
-        "id": "spi_6m",
-        "title": "SPI - 6-month",
-        "server_layer_name": "r6s_dekad"
-      },
-      {
-        "id": "spi_9m",
-        "title": "SPI - 9-month",
-        "server_layer_name": "r9s_dekad"
-      },
-      {
-        "id": "streak_dry_days",
-        "title": "Longest number of consecutive dry days",
-        "server_layer_name": "dlx_dekad"
-      },
-      {
-        "id": "streak_extreme_rain",
-        "title": "Longest consecutive extreme rainfall days",
-        "server_layer_name": "xle_dekad"
-      },
-      {
-        "id": "streak_heavy_rain",
-        "title": "Longest consecutive number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xlh_dekad"
-      },
-      {
-        "id": "streak_intense_rain",
-        "title": "Longest consecutive intense rainfall days",
-        "server_layer_name": "xli_dekad"
-      }
-    ],
-    "sudan": [],
-    "tajikistan": [
-      {
-        "id": "days_dry",
-        "title": "Days since last rain",
-        "server_layer_name": "dlc_dekad"
-      },
-      {
-        "id": "days_extreme_rain",
-        "title": "Number of days with extreme rainfall in the last 30 days",
-        "server_layer_name": "xne_dekad"
-      },
-      {
-        "id": "days_heavy_rain",
-        "title": "Number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xnh_dekad"
-      },
-      {
-        "id": "days_intense_rain",
-        "title": "Number of days with intense rainfall in the last 30 days",
-        "server_layer_name": "xni_dekad"
-      },
-      {
-        "id": "lst_amplitude",
-        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
-        "server_layer_name": "myd11a2_taa_dekad"
-      },
-      {
-        "id": "lst_anomaly",
-        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_daytime",
-        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "lst_nighttime",
-        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "ndvi_dekad",
-        "title": "10-day NDVI (MODIS)",
-        "server_layer_name": "mxd13a2_vim_dekad"
-      },
-      {
-        "id": "ndvi_dekad_anomaly",
-        "title": "10-day NDVI anomaly (MODIS)",
-        "server_layer_name": "mxd13a2_viq_dekad"
-      },
-      {
-        "id": "rain_anomaly_1month",
-        "title": "Monthly rainfall anomaly",
-        "server_layer_name": "rfq_dekad"
-      },
-      {
-        "id": "rain_anomaly_1year",
-        "title": "1-year rainfall anomaly",
-        "server_layer_name": "ryq_dekad"
-      },
-      {
-        "id": "rain_anomaly_3month",
-        "title": "3-month rainfall anomaly",
-        "server_layer_name": "r3q_dekad"
-      },
-      {
-        "id": "rain_anomaly_6month",
-        "title": "6-month rainfall anomaly",
-        "server_layer_name": "r6q_dekad"
-      },
-      {
-        "id": "rain_anomaly_9month",
-        "title": "9-month rainfall anomaly",
-        "server_layer_name": "r9q_dekad"
-      },
-      {
-        "id": "rain_anomaly_dekad",
-        "title": "10-day rainfall anomaly",
-        "server_layer_name": "r1q_dekad"
-      },
-      {
-        "id": "rainfall_agg_1month",
-        "title": "1-month rainfall aggregate",
-        "server_layer_name": "r1h_dekad"
-      },
-      {
-        "id": "rainfall_agg_1year",
-        "title": "1-year rainfall aggregate (mm)",
-        "server_layer_name": "ryh_dekad"
-      },
-      {
-        "id": "rainfall_agg_3month",
-        "title": "3-month rainfall aggregate (mm)",
-        "server_layer_name": "r3h_dekad"
-      },
-      {
-        "id": "rainfall_agg_6month",
-        "title": "6-month rainfall aggregate (mm)",
-        "server_layer_name": "r6h_dekad"
-      },
-      {
-        "id": "rainfall_agg_9month",
-        "title": "9-month rainfall aggregate (mm)",
-        "server_layer_name": "r9h_dekad"
-      },
-      {
-        "id": "rainfall_dekad",
-        "title": "10-day rainfall estimate (mm)",
-        "server_layer_name": "rfh_dekad"
-      },
-      {
-        "id": "spi_1m",
-        "title": "SPI - 1-month",
-        "server_layer_name": "r1s_dekad"
-      },
-      {
-        "id": "spi_1y",
-        "title": "SPI - 1-year",
-        "server_layer_name": "rys_dekad"
-      },
-      {
-        "id": "spi_3m",
-        "title": "SPI - 3-month",
-        "server_layer_name": "r3s_dekad"
-      },
-      {
-        "id": "spi_6m",
-        "title": "SPI - 6-month",
-        "server_layer_name": "r6s_dekad"
-      },
-      {
-        "id": "spi_9m",
-        "title": "SPI - 9-month",
-        "server_layer_name": "r9s_dekad"
-      },
-      {
-        "id": "streak_dry_days",
-        "title": "Longest number of consecutive dry days",
-        "server_layer_name": "dlx_dekad"
-      },
-      {
-        "id": "streak_extreme_rain",
-        "title": "Longest consecutive extreme rainfall days",
-        "server_layer_name": "xle_dekad"
-      },
-      {
-        "id": "streak_heavy_rain",
-        "title": "Longest consecutive number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xlh_dekad"
-      },
-      {
-        "id": "streak_intense_rain",
-        "title": "Longest consecutive intense rainfall days",
-        "server_layer_name": "xli_dekad"
-      }
-    ],
-    "tanzania": [
-      {
-        "id": "chirps_rainfall_daily",
-        "title": "CHIRPS daily rainfall estimate (mm)",
-        "server_layer_name": "rfh_daily"
+        "id": "6m_water_anomaly",
+        "title": "6-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_6month"
       },
       {
         "id": "daily_rainfall_forecast",
@@ -3115,6 +4163,11 @@
       },
       {
         "id": "lst_anomaly",
+        "title": "Daytime Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_day_anomaly",
         "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
         "server_layer_name": "myd11a2_txd_dekad"
       },
@@ -3122,6 +4175,16 @@
         "id": "lst_daytime",
         "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
         "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_nighttime",
+        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "monthly_water_anomaly",
+        "title": "Monthly Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_dekad"
       },
       {
         "id": "ndvi_dekad",
@@ -3169,6 +4232,16 @@
         "server_layer_name": "r6q_dekad"
       },
       {
+        "id": "rain_anomaly_7month",
+        "title": "7-month rainfall anomaly",
+        "server_layer_name": "r7q_dekad"
+      },
+      {
+        "id": "rain_anomaly_8month",
+        "title": "8-month rainfall anomaly",
+        "server_layer_name": "r8q_dekad"
+      },
+      {
         "id": "rain_anomaly_9month",
         "title": "9-month rainfall anomaly",
         "server_layer_name": "r9q_dekad"
@@ -3180,7 +4253,7 @@
       },
       {
         "id": "rainfall_agg_1month",
-        "title": "1-month rainfall aggregate (mm)",
+        "title": "1-month rainfall aggregate",
         "server_layer_name": "r1h_dekad"
       },
       {
@@ -3214,6 +4287,16 @@
         "server_layer_name": "r6h_dekad"
       },
       {
+        "id": "rainfall_agg_7month",
+        "title": "7-month rainfall aggregate (mm)",
+        "server_layer_name": "r7h_dekad"
+      },
+      {
+        "id": "rainfall_agg_8month",
+        "title": "8-month rainfall aggregate (mm)",
+        "server_layer_name": "r8h_dekad"
+      },
+      {
         "id": "rainfall_agg_9month",
         "title": "9-month rainfall aggregate (mm)",
         "server_layer_name": "r9h_dekad"
@@ -3232,6 +4315,11 @@
         "id": "spi_1y",
         "title": "SPI - 1-year",
         "server_layer_name": "rys_dekad"
+      },
+      {
+        "id": "spi_2m",
+        "title": "SPI - 2-month",
+        "server_layer_name": "r2s_dekad"
       },
       {
         "id": "spi_3m",
@@ -3269,150 +4357,32 @@
         "server_layer_name": "xli_dekad"
       }
     ],
-    "ukraine": [
+    "namibia": [
       {
-        "id": "days_dry",
-        "title": "Number of dry days",
-        "server_layer_name": "dlc_dekad"
+        "id": "2m_water_anomaly",
+        "title": "2-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_2month"
       },
       {
-        "id": "days_extreme_rain",
-        "title": "Number of days with extreme rainfall in the last 30 days",
-        "server_layer_name": "xne_dekad"
+        "id": "3m_water_anomaly",
+        "title": "3-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_3month"
       },
       {
-        "id": "days_heavy_rain",
-        "title": "Number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xnh_dekad"
+        "id": "4m_water_anomaly",
+        "title": "4-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_4month"
       },
       {
-        "id": "days_intense_rain",
-        "title": "Number of days with intense rainfall in the last 30 days",
-        "server_layer_name": "xni_dekad"
+        "id": "5m_water_anomaly",
+        "title": "5-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_5month"
       },
       {
-        "id": "lst_amplitude",
-        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
-        "server_layer_name": "myd11a2_taa_dekad"
+        "id": "6m_water_anomaly",
+        "title": "6-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_6month"
       },
-      {
-        "id": "lst_anomaly",
-        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_daytime",
-        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "lst_nighttime",
-        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "ndvi_dekad",
-        "title": "10-day NDVI (MODIS)",
-        "server_layer_name": "mxd13a2_vim_dekad"
-      },
-      {
-        "id": "ndvi_dekad_anomaly",
-        "title": "10-day NDVI anomaly (MODIS)",
-        "server_layer_name": "mxd13a2_viq_dekad"
-      },
-      {
-        "id": "rain_anomaly_1month",
-        "title": "Monthly rainfall anomaly",
-        "server_layer_name": "rfq_dekad"
-      },
-      {
-        "id": "rain_anomaly_1year",
-        "title": "1-year rainfall anomaly",
-        "server_layer_name": "ryq_dekad"
-      },
-      {
-        "id": "rain_anomaly_3month",
-        "title": "3-month rainfall anomaly",
-        "server_layer_name": "r3q_dekad"
-      },
-      {
-        "id": "rain_anomaly_6month",
-        "title": "6-month rainfall anomaly",
-        "server_layer_name": "r6q_dekad"
-      },
-      {
-        "id": "rain_anomaly_9month",
-        "title": "9-month rainfall anomaly",
-        "server_layer_name": "r9q_dekad"
-      },
-      {
-        "id": "rain_anomaly_dekad",
-        "title": "10-day rainfall anomaly",
-        "server_layer_name": "r1q_dekad"
-      },
-      {
-        "id": "rainfall_agg_1year",
-        "title": "1-year rainfall aggregate (mm)",
-        "server_layer_name": "ryh_dekad"
-      },
-      {
-        "id": "rainfall_agg_3month",
-        "title": "3-month rainfall aggregate (mm)",
-        "server_layer_name": "r3h_dekad"
-      },
-      {
-        "id": "rainfall_agg_6month",
-        "title": "6-month rainfall aggregate (mm)",
-        "server_layer_name": "r6h_dekad"
-      },
-      {
-        "id": "rainfall_agg_9month",
-        "title": "9-month rainfall aggregate (mm)",
-        "server_layer_name": "r9h_dekad"
-      },
-      {
-        "id": "rainfall_dekad",
-        "title": "10-day rainfall estimate (mm)",
-        "server_layer_name": "rfh_dekad"
-      },
-      {
-        "id": "spi_1m",
-        "title": "SPI - 1-month",
-        "server_layer_name": "r1s_dekad"
-      },
-      {
-        "id": "spi_1y",
-        "title": "SPI - 1-year",
-        "server_layer_name": "rys_dekad"
-      },
-      {
-        "id": "spi_3m",
-        "title": "SPI - 3-month",
-        "server_layer_name": "r3s_dekad"
-      },
-      {
-        "id": "spi_6m",
-        "title": "SPI - 6-month",
-        "server_layer_name": "r6s_dekad"
-      },
-      {
-        "id": "spi_9m",
-        "title": "SPI - 9-month",
-        "server_layer_name": "r9s_dekad"
-      },
-      {
-        "id": "streak_dry_days",
-        "title": "Longest number of consecutive dry days",
-        "server_layer_name": "dlx_dekad"
-      },
-      {
-        "id": "streak_heavy_rain",
-        "title": "Longest consecutive number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xlh_dekad"
-      }
-    ],
-    "zambia": [],
-    "zimbabwe": [
       {
         "id": "daily_rainfall_forecast",
         "title": "Rolling daily rainfall forecast",
@@ -3459,9 +4429,3495 @@
         "server_layer_name": "myd11a2_txd_dekad"
       },
       {
+        "id": "lst_day_anomaly",
+        "title": "Daytime Land Surface Temperature - 10-day Anomaly 1km (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_daytime",
+        "title": "Daytime Land Surface Temperature - 10-day 1km (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_nighttime",
+        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "monthly_water_anomaly",
+        "title": "Monthly Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_dekad"
+      },
+      {
+        "id": "ndvi_dekad",
+        "title": "10-day NDVI 1km (MODIS)",
+        "server_layer_name": "mxd13a2_vim_dekad"
+      },
+      {
+        "id": "ndvi_dekad_anomaly",
+        "title": "10-day NDVI anomaly 1km (MODIS)",
+        "server_layer_name": "mxd13a2_viq_dekad"
+      },
+      {
+        "id": "rain_anomaly_1month",
+        "title": "1-month rainfall anomaly",
+        "server_layer_name": "r1q_dekad"
+      },
+      {
+        "id": "rain_anomaly_1year",
+        "title": "1-year rainfall anomaly",
+        "server_layer_name": "ryq_dekad"
+      },
+      {
+        "id": "rain_anomaly_2month",
+        "title": "2-month rainfall anomaly",
+        "server_layer_name": "r2q_dekad"
+      },
+      {
+        "id": "rain_anomaly_3month",
+        "title": "3-month rainfall anomaly",
+        "server_layer_name": "r3q_dekad"
+      },
+      {
+        "id": "rain_anomaly_4month",
+        "title": "4-month rainfall anomaly",
+        "server_layer_name": "r4q_dekad"
+      },
+      {
+        "id": "rain_anomaly_5month",
+        "title": "5-month rainfall anomaly",
+        "server_layer_name": "r5q_dekad"
+      },
+      {
+        "id": "rain_anomaly_6month",
+        "title": "6-month rainfall anomaly",
+        "server_layer_name": "r6q_dekad"
+      },
+      {
+        "id": "rain_anomaly_7month",
+        "title": "7-month rainfall anomaly",
+        "server_layer_name": "r7q_dekad"
+      },
+      {
+        "id": "rain_anomaly_8month",
+        "title": "8-month rainfall anomaly",
+        "server_layer_name": "r8q_dekad"
+      },
+      {
+        "id": "rain_anomaly_9month",
+        "title": "9-month rainfall anomaly",
+        "server_layer_name": "r9q_dekad"
+      },
+      {
+        "id": "rain_anomaly_dekad",
+        "title": "10-day rainfall anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rainfall_agg_1month",
+        "title": "1-month rainfall aggregate",
+        "server_layer_name": "r1h_dekad"
+      },
+      {
+        "id": "rainfall_agg_1year",
+        "title": "1-year rainfall aggregate (mm)",
+        "server_layer_name": "ryh_dekad"
+      },
+      {
+        "id": "rainfall_agg_2month",
+        "title": "2-month rainfall aggregate (mm)",
+        "server_layer_name": "r2h_dekad"
+      },
+      {
+        "id": "rainfall_agg_3month",
+        "title": "3-month rainfall aggregate (mm)",
+        "server_layer_name": "r3h_dekad"
+      },
+      {
+        "id": "rainfall_agg_4month",
+        "title": "4-month rainfall aggregate (mm)",
+        "server_layer_name": "r4h_dekad"
+      },
+      {
+        "id": "rainfall_agg_5month",
+        "title": "5-month rainfall aggregate (mm)",
+        "server_layer_name": "r5h_dekad"
+      },
+      {
+        "id": "rainfall_agg_6month",
+        "title": "6-month rainfall aggregate (mm)",
+        "server_layer_name": "r6h_dekad"
+      },
+      {
+        "id": "rainfall_agg_7month",
+        "title": "7-month rainfall aggregate (mm)",
+        "server_layer_name": "r7h_dekad"
+      },
+      {
+        "id": "rainfall_agg_8month",
+        "title": "8-month rainfall aggregate (mm)",
+        "server_layer_name": "r8h_dekad"
+      },
+      {
+        "id": "rainfall_agg_9month",
+        "title": "9-month rainfall aggregate (mm)",
+        "server_layer_name": "r9h_dekad"
+      },
+      {
+        "id": "rainfall_dekad",
+        "title": "10-day rainfall estimate (mm)",
+        "server_layer_name": "rfh_dekad"
+      },
+      {
+        "id": "spi_1m",
+        "title": "SPI - 1-month",
+        "server_layer_name": "r1s_dekad"
+      },
+      {
+        "id": "spi_1y",
+        "title": "SPI - 1-year",
+        "server_layer_name": "rys_dekad"
+      },
+      {
+        "id": "spi_2m",
+        "title": "SPI - 2-month",
+        "server_layer_name": "r2s_dekad"
+      },
+      {
+        "id": "spi_3m",
+        "title": "SPI - 3-month",
+        "server_layer_name": "r3s_dekad"
+      },
+      {
+        "id": "spi_6m",
+        "title": "SPI - 6-month",
+        "server_layer_name": "r6s_dekad"
+      },
+      {
+        "id": "spi_9m",
+        "title": "SPI - 9-month",
+        "server_layer_name": "r9s_dekad"
+      },
+      {
+        "id": "streak_dry_days",
+        "title": "Longest dry spell",
+        "server_layer_name": "dlx_dekad"
+      },
+      {
+        "id": "streak_extreme_rain",
+        "title": "Longest consecutive extreme rainfall days",
+        "server_layer_name": "xle_dekad"
+      },
+      {
+        "id": "streak_heavy_rain",
+        "title": "Longest consecutive heavy rainfall days",
+        "server_layer_name": "xlh_dekad"
+      },
+      {
+        "id": "streak_intense_rain",
+        "title": "Longest consecutive intense rainfall days",
+        "server_layer_name": "xli_dekad"
+      }
+    ],
+    "nepal": [
+      {
+        "id": "2m_water_anomaly",
+        "title": "2-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_2month"
+      },
+      {
+        "id": "3m_water_anomaly",
+        "title": "3-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_3month"
+      },
+      {
+        "id": "4m_water_anomaly",
+        "title": "4-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_4month"
+      },
+      {
+        "id": "5m_water_anomaly",
+        "title": "5-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_5month"
+      },
+      {
+        "id": "6m_water_anomaly",
+        "title": "6-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_6month"
+      },
+      {
+        "id": "daily_rainfall_forecast",
+        "title": "Rolling daily rainfall forecast",
+        "server_layer_name": "rfh_daily_forecast"
+      },
+      {
+        "id": "days_dry",
+        "title": "Days since last rain",
+        "server_layer_name": "dlc_dekad"
+      },
+      {
+        "id": "days_extreme_rain",
+        "title": "Number of days with extreme rainfall in the last 30 days",
+        "server_layer_name": "xne_dekad"
+      },
+      {
+        "id": "days_heavy_rain",
+        "title": "Number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xnh_dekad"
+      },
+      {
+        "id": "days_intense_rain",
+        "title": "Number of days with intense rainfall in the last 30 days",
+        "server_layer_name": "xni_dekad"
+      },
+      {
+        "id": "dekad_rainfall_anomaly_forecast",
+        "title": "10-day rainfall forecast anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "dekad_rainfall_forecast",
+        "title": "10-day rainfall forecast",
+        "server_layer_name": "rfh_dekad_forecast"
+      },
+      {
+        "id": "lst_amplitude",
+        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
+        "server_layer_name": "myd11a2_taa_dekad"
+      },
+      {
+        "id": "lst_anomaly",
+        "title": "Daytime Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_day_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
         "id": "lst_daytime",
         "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
         "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_nighttime",
+        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "monthly_water_anomaly",
+        "title": "Monthly Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_dekad"
+      },
+      {
+        "id": "ndvi_dekad",
+        "title": "10-day NDVI (MODIS)",
+        "server_layer_name": "mxd13a2_vim_dekad"
+      },
+      {
+        "id": "ndvi_dekad_anomaly",
+        "title": "10-day NDVI anomaly (MODIS)",
+        "server_layer_name": "mxd13a2_viq_dekad"
+      },
+      {
+        "id": "rain_anomaly_1month",
+        "title": "Monthly rainfall anomaly",
+        "server_layer_name": "r1q_dekad"
+      },
+      {
+        "id": "rain_anomaly_1year",
+        "title": "1-year rainfall anomaly",
+        "server_layer_name": "ryq_dekad"
+      },
+      {
+        "id": "rain_anomaly_2month",
+        "title": "2-month rainfall anomaly",
+        "server_layer_name": "r2q_dekad"
+      },
+      {
+        "id": "rain_anomaly_3month",
+        "title": "3-month rainfall anomaly",
+        "server_layer_name": "r3q_dekad"
+      },
+      {
+        "id": "rain_anomaly_4month",
+        "title": "4-month rainfall anomaly",
+        "server_layer_name": "r4q_dekad"
+      },
+      {
+        "id": "rain_anomaly_5month",
+        "title": "5-month rainfall anomaly",
+        "server_layer_name": "r5q_dekad"
+      },
+      {
+        "id": "rain_anomaly_6month",
+        "title": "6-month rainfall anomaly",
+        "server_layer_name": "r6q_dekad"
+      },
+      {
+        "id": "rain_anomaly_7month",
+        "title": "7-month rainfall anomaly",
+        "server_layer_name": "r7q_dekad"
+      },
+      {
+        "id": "rain_anomaly_8month",
+        "title": "8-month rainfall anomaly",
+        "server_layer_name": "r8q_dekad"
+      },
+      {
+        "id": "rain_anomaly_9month",
+        "title": "9-month rainfall anomaly",
+        "server_layer_name": "r9q_dekad"
+      },
+      {
+        "id": "rain_anomaly_dekad",
+        "title": "10-day rainfall anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rainfall_agg_1month",
+        "title": "1-month rainfall aggregate",
+        "server_layer_name": "r1h_dekad"
+      },
+      {
+        "id": "rainfall_agg_1year",
+        "title": "1-year rainfall aggregate (mm)",
+        "server_layer_name": "ryh_dekad"
+      },
+      {
+        "id": "rainfall_agg_2month",
+        "title": "2-month rainfall aggregate (mm)",
+        "server_layer_name": "r2h_dekad"
+      },
+      {
+        "id": "rainfall_agg_3month",
+        "title": "3-month rainfall aggregate (mm)",
+        "server_layer_name": "r3h_dekad"
+      },
+      {
+        "id": "rainfall_agg_4month",
+        "title": "4-month rainfall aggregate (mm)",
+        "server_layer_name": "r4h_dekad"
+      },
+      {
+        "id": "rainfall_agg_5month",
+        "title": "5-month rainfall aggregate (mm)",
+        "server_layer_name": "r5h_dekad"
+      },
+      {
+        "id": "rainfall_agg_6month",
+        "title": "6-month rainfall aggregate (mm)",
+        "server_layer_name": "r6h_dekad"
+      },
+      {
+        "id": "rainfall_agg_7month",
+        "title": "7-month rainfall aggregate (mm)",
+        "server_layer_name": "r7h_dekad"
+      },
+      {
+        "id": "rainfall_agg_8month",
+        "title": "8-month rainfall aggregate (mm)",
+        "server_layer_name": "r8h_dekad"
+      },
+      {
+        "id": "rainfall_agg_9month",
+        "title": "9-month rainfall aggregate (mm)",
+        "server_layer_name": "r9h_dekad"
+      },
+      {
+        "id": "rainfall_dekad",
+        "title": "10-day rainfall estimate (mm)",
+        "server_layer_name": "rfh_dekad"
+      },
+      {
+        "id": "spi_1m",
+        "title": "SPI - 1-month",
+        "server_layer_name": "r1s_dekad"
+      },
+      {
+        "id": "spi_1y",
+        "title": "SPI - 1-year",
+        "server_layer_name": "rys_dekad"
+      },
+      {
+        "id": "spi_2m",
+        "title": "SPI - 2-month",
+        "server_layer_name": "r2s_dekad"
+      },
+      {
+        "id": "spi_3m",
+        "title": "SPI - 3-month",
+        "server_layer_name": "r3s_dekad"
+      },
+      {
+        "id": "spi_6m",
+        "title": "SPI - 6-month",
+        "server_layer_name": "r6s_dekad"
+      },
+      {
+        "id": "spi_9m",
+        "title": "SPI - 9-month",
+        "server_layer_name": "r9s_dekad"
+      },
+      {
+        "id": "streak_dry_days",
+        "title": "Longest number of consecutive dry days",
+        "server_layer_name": "dlx_dekad"
+      },
+      {
+        "id": "streak_extreme_rain",
+        "title": "Longest consecutive extreme rainfall days",
+        "server_layer_name": "xle_dekad"
+      },
+      {
+        "id": "streak_heavy_rain",
+        "title": "Longest consecutive number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xlh_dekad"
+      },
+      {
+        "id": "streak_intense_rain",
+        "title": "Longest consecutive intense rainfall days",
+        "server_layer_name": "xli_dekad"
+      }
+    ],
+    "nigeria": [
+      {
+        "id": "2m_water_anomaly",
+        "title": "2-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_2month"
+      },
+      {
+        "id": "3m_water_anomaly",
+        "title": "3-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_3month"
+      },
+      {
+        "id": "4m_water_anomaly",
+        "title": "4-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_4month"
+      },
+      {
+        "id": "5m_water_anomaly",
+        "title": "5-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_5month"
+      },
+      {
+        "id": "6m_water_anomaly",
+        "title": "6-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_6month"
+      },
+      {
+        "id": "daily_rainfall_forecast",
+        "title": "Rolling daily rainfall forecast",
+        "server_layer_name": "rfh_daily_forecast"
+      },
+      {
+        "id": "days_dry",
+        "title": "Days since last rain",
+        "server_layer_name": "dlc_dekad"
+      },
+      {
+        "id": "days_extreme_rain",
+        "title": "Number of days with extreme rainfall in the last 30 days",
+        "server_layer_name": "xne_dekad"
+      },
+      {
+        "id": "days_heavy_rain",
+        "title": "Number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xnh_dekad"
+      },
+      {
+        "id": "days_intense_rain",
+        "title": "Number of days with intense rainfall in the last 30 days",
+        "server_layer_name": "xni_dekad"
+      },
+      {
+        "id": "dekad_rainfall_anomaly_forecast",
+        "title": "10-day rainfall forecast anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "dekad_rainfall_forecast",
+        "title": "10-day rainfall forecast",
+        "server_layer_name": "rfh_dekad_forecast"
+      },
+      {
+        "id": "lst_amplitude",
+        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
+        "server_layer_name": "myd11a2_taa_dekad"
+      },
+      {
+        "id": "lst_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_day_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_daytime",
+        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_nighttime",
+        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "monthly_water_anomaly",
+        "title": "Monthly Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_dekad"
+      },
+      {
+        "id": "ndvi_dekad",
+        "title": "10-day NDVI (MODIS)",
+        "server_layer_name": "mxd13a2_vim_dekad"
+      },
+      {
+        "id": "ndvi_dekad_anomaly",
+        "title": "10-day NDVI anomaly (MODIS)",
+        "server_layer_name": "mxd13a2_viq_dekad"
+      },
+      {
+        "id": "rain_anomaly_1month",
+        "title": "Monthly rainfall anomaly",
+        "server_layer_name": "r1q_dekad"
+      },
+      {
+        "id": "rain_anomaly_1year",
+        "title": "1-year rainfall anomaly",
+        "server_layer_name": "ryq_dekad"
+      },
+      {
+        "id": "rain_anomaly_2month",
+        "title": "2-month rainfall anomaly",
+        "server_layer_name": "r2q_dekad"
+      },
+      {
+        "id": "rain_anomaly_3month",
+        "title": "3-month rainfall anomaly",
+        "server_layer_name": "r3q_dekad"
+      },
+      {
+        "id": "rain_anomaly_4month",
+        "title": "4-month rainfall anomaly",
+        "server_layer_name": "r4q_dekad"
+      },
+      {
+        "id": "rain_anomaly_5month",
+        "title": "5-month rainfall anomaly",
+        "server_layer_name": "r5q_dekad"
+      },
+      {
+        "id": "rain_anomaly_6month",
+        "title": "6-month rainfall anomaly",
+        "server_layer_name": "r6q_dekad"
+      },
+      {
+        "id": "rain_anomaly_7month",
+        "title": "7-month rainfall anomaly",
+        "server_layer_name": "r7q_dekad"
+      },
+      {
+        "id": "rain_anomaly_8month",
+        "title": "8-month rainfall anomaly",
+        "server_layer_name": "r8q_dekad"
+      },
+      {
+        "id": "rain_anomaly_9month",
+        "title": "9-month rainfall anomaly",
+        "server_layer_name": "r9q_dekad"
+      },
+      {
+        "id": "rain_anomaly_dekad",
+        "title": "10-day rainfall anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rainfall_agg_1month",
+        "title": "1-month rainfall aggregate (mm)",
+        "server_layer_name": "r1h_dekad"
+      },
+      {
+        "id": "rainfall_agg_1year",
+        "title": "1-year rainfall aggregate (mm)",
+        "server_layer_name": "ryh_dekad"
+      },
+      {
+        "id": "rainfall_agg_2month",
+        "title": "2-month rainfall aggregate (mm)",
+        "server_layer_name": "r2h_dekad"
+      },
+      {
+        "id": "rainfall_agg_3month",
+        "title": "3-month rainfall aggregate (mm)",
+        "server_layer_name": "r3h_dekad"
+      },
+      {
+        "id": "rainfall_agg_4month",
+        "title": "4-month rainfall aggregate (mm)",
+        "server_layer_name": "r4h_dekad"
+      },
+      {
+        "id": "rainfall_agg_5month",
+        "title": "5-month rainfall aggregate (mm)",
+        "server_layer_name": "r5h_dekad"
+      },
+      {
+        "id": "rainfall_agg_6month",
+        "title": "6-month rainfall aggregate (mm)",
+        "server_layer_name": "r6h_dekad"
+      },
+      {
+        "id": "rainfall_agg_7month",
+        "title": "7-month rainfall aggregate (mm)",
+        "server_layer_name": "r7h_dekad"
+      },
+      {
+        "id": "rainfall_agg_8month",
+        "title": "8-month rainfall aggregate (mm)",
+        "server_layer_name": "r8h_dekad"
+      },
+      {
+        "id": "rainfall_agg_9month",
+        "title": "9-month rainfall aggregate (mm)",
+        "server_layer_name": "r9h_dekad"
+      },
+      {
+        "id": "rainfall_dekad",
+        "title": "10-day rainfall estimate (mm)",
+        "server_layer_name": "rfh_dekad"
+      },
+      {
+        "id": "spi_1m",
+        "title": "SPI - 1-month",
+        "server_layer_name": "r1s_dekad"
+      },
+      {
+        "id": "spi_1y",
+        "title": "SPI - 1-year",
+        "server_layer_name": "rys_dekad"
+      },
+      {
+        "id": "spi_2m",
+        "title": "SPI - 2-month",
+        "server_layer_name": "r2s_dekad"
+      },
+      {
+        "id": "spi_3m",
+        "title": "SPI - 3-month",
+        "server_layer_name": "r3s_dekad"
+      },
+      {
+        "id": "spi_6m",
+        "title": "SPI - 6-month",
+        "server_layer_name": "r6s_dekad"
+      },
+      {
+        "id": "spi_9m",
+        "title": "SPI - 9-month",
+        "server_layer_name": "r9s_dekad"
+      },
+      {
+        "id": "streak_dry_days",
+        "title": "Longest number of consecutive dry days",
+        "server_layer_name": "dlx_dekad"
+      },
+      {
+        "id": "streak_extreme_rain",
+        "title": "Longest consecutive extreme rainfall days",
+        "server_layer_name": "xle_dekad"
+      },
+      {
+        "id": "streak_heavy_rain",
+        "title": "Longest consecutive number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xlh_dekad"
+      },
+      {
+        "id": "streak_intense_rain",
+        "title": "Longest consecutive intense rainfall days",
+        "server_layer_name": "xli_dekad"
+      }
+    ],
+    "rbd": [
+      {
+        "id": "2m_water_anomaly",
+        "title": "2-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_2month"
+      },
+      {
+        "id": "3m_water_anomaly",
+        "title": "3-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_3month"
+      },
+      {
+        "id": "4m_water_anomaly",
+        "title": "4-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_4month"
+      },
+      {
+        "id": "5m_water_anomaly",
+        "title": "5-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_5month"
+      },
+      {
+        "id": "6m_water_anomaly",
+        "title": "6-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_6month"
+      },
+      {
+        "id": "daily_rainfall_forecast",
+        "title": "Rolling daily rainfall forecast",
+        "server_layer_name": "rfh_daily_forecast"
+      },
+      {
+        "id": "days_dry",
+        "title": "Days since last rain",
+        "server_layer_name": "dlc_dekad"
+      },
+      {
+        "id": "days_extreme_rain",
+        "title": "Number of days with extreme rainfall in the last 30 days",
+        "server_layer_name": "xne_dekad"
+      },
+      {
+        "id": "days_heavy_rain",
+        "title": "Number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xnh_dekad"
+      },
+      {
+        "id": "days_intense_rain",
+        "title": "Number of days with intense rainfall in the last 30 days",
+        "server_layer_name": "xni_dekad"
+      },
+      {
+        "id": "dekad_rainfall_anomaly_forecast",
+        "title": "10-day rainfall forecast anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "dekad_rainfall_forecast",
+        "title": "10-day rainfall forecast",
+        "server_layer_name": "rfh_dekad_forecast"
+      },
+      {
+        "id": "lst_amplitude",
+        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
+        "server_layer_name": "myd11a2_taa_dekad"
+      },
+      {
+        "id": "lst_anomaly",
+        "title": "Daytime Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_day_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_daytime",
+        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_nighttime",
+        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "monthly_water_anomaly",
+        "title": "Monthly Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_dekad"
+      },
+      {
+        "id": "ndvi_dekad",
+        "title": "10-day NDVI (MODIS)",
+        "server_layer_name": "mxd13a2_vim_dekad"
+      },
+      {
+        "id": "ndvi_dekad_anomaly",
+        "title": "10-day NDVI anomaly (MODIS)",
+        "server_layer_name": "mxd13a2_viq_dekad"
+      },
+      {
+        "id": "rain_anomaly_1month",
+        "title": "1-month rainfall anomaly",
+        "server_layer_name": "r1q_dekad"
+      },
+      {
+        "id": "rain_anomaly_1year",
+        "title": "1-year rainfall anomaly",
+        "server_layer_name": "ryq_dekad"
+      },
+      {
+        "id": "rain_anomaly_2month",
+        "title": "2-month rainfall anomaly",
+        "server_layer_name": "r2q_dekad"
+      },
+      {
+        "id": "rain_anomaly_3month",
+        "title": "3-month rainfall anomaly",
+        "server_layer_name": "r3q_dekad"
+      },
+      {
+        "id": "rain_anomaly_4month",
+        "title": "4-month rainfall anomaly",
+        "server_layer_name": "r4q_dekad"
+      },
+      {
+        "id": "rain_anomaly_5month",
+        "title": "5-month rainfall anomaly",
+        "server_layer_name": "r5q_dekad"
+      },
+      {
+        "id": "rain_anomaly_6month",
+        "title": "6-month rainfall anomaly",
+        "server_layer_name": "r6q_dekad"
+      },
+      {
+        "id": "rain_anomaly_7month",
+        "title": "7-month rainfall anomaly",
+        "server_layer_name": "r7q_dekad"
+      },
+      {
+        "id": "rain_anomaly_8month",
+        "title": "8-month rainfall anomaly",
+        "server_layer_name": "r8q_dekad"
+      },
+      {
+        "id": "rain_anomaly_9month",
+        "title": "9-month rainfall anomaly",
+        "server_layer_name": "r9q_dekad"
+      },
+      {
+        "id": "rain_anomaly_dekad",
+        "title": "10-day rainfall anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rainfall_agg_1month",
+        "title": "1-month rainfall aggregate (mm)",
+        "server_layer_name": "r1h_dekad"
+      },
+      {
+        "id": "rainfall_agg_1year",
+        "title": "1-year rainfall aggregate (mm)",
+        "server_layer_name": "ryh_dekad"
+      },
+      {
+        "id": "rainfall_agg_2month",
+        "title": "2-month rainfall aggregate (mm)",
+        "server_layer_name": "r2h_dekad"
+      },
+      {
+        "id": "rainfall_agg_3month",
+        "title": "3-month rainfall aggregate (mm)",
+        "server_layer_name": "r3h_dekad"
+      },
+      {
+        "id": "rainfall_agg_4month",
+        "title": "4-month rainfall aggregate (mm)",
+        "server_layer_name": "r4h_dekad"
+      },
+      {
+        "id": "rainfall_agg_5month",
+        "title": "5-month rainfall aggregate (mm)",
+        "server_layer_name": "r5h_dekad"
+      },
+      {
+        "id": "rainfall_agg_6month",
+        "title": "6-month rainfall aggregate (mm)",
+        "server_layer_name": "r6h_dekad"
+      },
+      {
+        "id": "rainfall_agg_7month",
+        "title": "7-month rainfall aggregate (mm)",
+        "server_layer_name": "r7h_dekad"
+      },
+      {
+        "id": "rainfall_agg_8month",
+        "title": "8-month rainfall aggregate (mm)",
+        "server_layer_name": "r8h_dekad"
+      },
+      {
+        "id": "rainfall_agg_9month",
+        "title": "9-month rainfall aggregate (mm)",
+        "server_layer_name": "r9h_dekad"
+      },
+      {
+        "id": "rainfall_dekad",
+        "title": "10-day rainfall estimate (mm)",
+        "server_layer_name": "rfh_dekad"
+      },
+      {
+        "id": "spi_1m",
+        "title": "SPI - 1-month",
+        "server_layer_name": "r1s_dekad"
+      },
+      {
+        "id": "spi_1y",
+        "title": "SPI - 1-year",
+        "server_layer_name": "rys_dekad"
+      },
+      {
+        "id": "spi_2m",
+        "title": "SPI - 2-month",
+        "server_layer_name": "r2s_dekad"
+      },
+      {
+        "id": "spi_3m",
+        "title": "SPI - 3-month",
+        "server_layer_name": "r3s_dekad"
+      },
+      {
+        "id": "spi_6m",
+        "title": "SPI - 6-month",
+        "server_layer_name": "r6s_dekad"
+      },
+      {
+        "id": "spi_9m",
+        "title": "SPI - 9-month",
+        "server_layer_name": "r9s_dekad"
+      },
+      {
+        "id": "streak_dry_days",
+        "title": "Longest number of consecutive dry days",
+        "server_layer_name": "dlx_dekad"
+      },
+      {
+        "id": "streak_extreme_rain",
+        "title": "Longest consecutive extreme rainfall days",
+        "server_layer_name": "xle_dekad"
+      },
+      {
+        "id": "streak_heavy_rain",
+        "title": "Longest consecutive number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xlh_dekad"
+      },
+      {
+        "id": "streak_intense_rain",
+        "title": "Longest consecutive intense rainfall days",
+        "server_layer_name": "xli_dekad"
+      }
+    ],
+    "sierraleone": [
+      {
+        "id": "2m_water_anomaly",
+        "title": "2-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_2month"
+      },
+      {
+        "id": "3m_water_anomaly",
+        "title": "3-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_3month"
+      },
+      {
+        "id": "4m_water_anomaly",
+        "title": "4-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_4month"
+      },
+      {
+        "id": "5m_water_anomaly",
+        "title": "5-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_5month"
+      },
+      {
+        "id": "6m_water_anomaly",
+        "title": "6-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_6month"
+      },
+      {
+        "id": "daily_rainfall_forecast",
+        "title": "Rolling daily rainfall forecast",
+        "server_layer_name": "rfh_daily_forecast"
+      },
+      {
+        "id": "days_dry",
+        "title": "Days since last rain",
+        "server_layer_name": "dlc_dekad"
+      },
+      {
+        "id": "days_extreme_rain",
+        "title": "Number of days with extreme rainfall in the last 30 days",
+        "server_layer_name": "xne_dekad"
+      },
+      {
+        "id": "days_heavy_rain",
+        "title": "Number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xnh_dekad"
+      },
+      {
+        "id": "days_intense_rain",
+        "title": "Number of days with intense rainfall in the last 30 days",
+        "server_layer_name": "xni_dekad"
+      },
+      {
+        "id": "dekad_rainfall_anomaly_forecast",
+        "title": "10-day rainfall forecast anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "dekad_rainfall_forecast",
+        "title": "10-day rainfall forecast",
+        "server_layer_name": "rfh_dekad_forecast"
+      },
+      {
+        "id": "lst_amplitude",
+        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
+        "server_layer_name": "myd11a2_taa_dekad"
+      },
+      {
+        "id": "lst_anomaly",
+        "title": "Daytime Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_day_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_daytime",
+        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_nighttime",
+        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "monthly_water_anomaly",
+        "title": "Monthly Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_dekad"
+      },
+      {
+        "id": "ndvi_dekad",
+        "title": "10-day NDVI (MODIS)",
+        "server_layer_name": "mxd13a2_vim_dekad"
+      },
+      {
+        "id": "ndvi_dekad_anomaly",
+        "title": "10-day NDVI anomaly (MODIS)",
+        "server_layer_name": "mxd13a2_viq_dekad"
+      },
+      {
+        "id": "rain_anomaly_1month",
+        "title": "1-month rainfall anomaly",
+        "server_layer_name": "r1q_dekad"
+      },
+      {
+        "id": "rain_anomaly_1year",
+        "title": "1-year rainfall anomaly",
+        "server_layer_name": "ryq_dekad"
+      },
+      {
+        "id": "rain_anomaly_2month",
+        "title": "2-month rainfall anomaly",
+        "server_layer_name": "r2q_dekad"
+      },
+      {
+        "id": "rain_anomaly_3month",
+        "title": "3-month rainfall anomaly",
+        "server_layer_name": "r3q_dekad"
+      },
+      {
+        "id": "rain_anomaly_4month",
+        "title": "4-month rainfall anomaly",
+        "server_layer_name": "r4q_dekad"
+      },
+      {
+        "id": "rain_anomaly_5month",
+        "title": "5-month rainfall anomaly",
+        "server_layer_name": "r5q_dekad"
+      },
+      {
+        "id": "rain_anomaly_6month",
+        "title": "6-month rainfall anomaly",
+        "server_layer_name": "r6q_dekad"
+      },
+      {
+        "id": "rain_anomaly_7month",
+        "title": "7-month rainfall anomaly",
+        "server_layer_name": "r7q_dekad"
+      },
+      {
+        "id": "rain_anomaly_8month",
+        "title": "8-month rainfall anomaly",
+        "server_layer_name": "r8q_dekad"
+      },
+      {
+        "id": "rain_anomaly_9month",
+        "title": "9-month rainfall anomaly",
+        "server_layer_name": "r9q_dekad"
+      },
+      {
+        "id": "rain_anomaly_dekad",
+        "title": "10-day rainfall anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rainfall_agg_1month",
+        "title": "1-month rainfall aggregate (mm)",
+        "server_layer_name": "r1h_dekad"
+      },
+      {
+        "id": "rainfall_agg_1year",
+        "title": "1-year rainfall aggregate (mm)",
+        "server_layer_name": "ryh_dekad"
+      },
+      {
+        "id": "rainfall_agg_2month",
+        "title": "2-month rainfall aggregate (mm)",
+        "server_layer_name": "r2h_dekad"
+      },
+      {
+        "id": "rainfall_agg_3month",
+        "title": "3-month rainfall aggregate (mm)",
+        "server_layer_name": "r3h_dekad"
+      },
+      {
+        "id": "rainfall_agg_4month",
+        "title": "4-month rainfall aggregate (mm)",
+        "server_layer_name": "r4h_dekad"
+      },
+      {
+        "id": "rainfall_agg_5month",
+        "title": "5-month rainfall aggregate (mm)",
+        "server_layer_name": "r5h_dekad"
+      },
+      {
+        "id": "rainfall_agg_6month",
+        "title": "6-month rainfall aggregate (mm)",
+        "server_layer_name": "r6h_dekad"
+      },
+      {
+        "id": "rainfall_agg_7month",
+        "title": "7-month rainfall aggregate (mm)",
+        "server_layer_name": "r7h_dekad"
+      },
+      {
+        "id": "rainfall_agg_8month",
+        "title": "8-month rainfall aggregate (mm)",
+        "server_layer_name": "r8h_dekad"
+      },
+      {
+        "id": "rainfall_agg_9month",
+        "title": "9-month rainfall aggregate (mm)",
+        "server_layer_name": "r9h_dekad"
+      },
+      {
+        "id": "rainfall_dekad",
+        "title": "10-day rainfall estimate (mm)",
+        "server_layer_name": "rfh_dekad"
+      },
+      {
+        "id": "spi_1m",
+        "title": "SPI - 1-month",
+        "server_layer_name": "r1s_dekad"
+      },
+      {
+        "id": "spi_1y",
+        "title": "SPI - 1-year",
+        "server_layer_name": "rys_dekad"
+      },
+      {
+        "id": "spi_2m",
+        "title": "SPI - 2-month",
+        "server_layer_name": "r2s_dekad"
+      },
+      {
+        "id": "spi_3m",
+        "title": "SPI - 3-month",
+        "server_layer_name": "r3s_dekad"
+      },
+      {
+        "id": "spi_6m",
+        "title": "SPI - 6-month",
+        "server_layer_name": "r6s_dekad"
+      },
+      {
+        "id": "spi_9m",
+        "title": "SPI - 9-month",
+        "server_layer_name": "r9s_dekad"
+      },
+      {
+        "id": "streak_dry_days",
+        "title": "Longest dry spell",
+        "server_layer_name": "dlx_dekad"
+      },
+      {
+        "id": "streak_extreme_rain",
+        "title": "Longest consecutive extreme rainfall days",
+        "server_layer_name": "xle_dekad"
+      },
+      {
+        "id": "streak_heavy_rain",
+        "title": "Longest consecutive number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xlh_dekad"
+      },
+      {
+        "id": "streak_intense_rain",
+        "title": "Longest consecutive intense rainfall days",
+        "server_layer_name": "xli_dekad"
+      }
+    ],
+    "somalia": [
+      {
+        "id": "2m_water_anomaly",
+        "title": "2-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_2month"
+      },
+      {
+        "id": "3m_water_anomaly",
+        "title": "3-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_3month"
+      },
+      {
+        "id": "4m_water_anomaly",
+        "title": "4-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_4month"
+      },
+      {
+        "id": "5m_water_anomaly",
+        "title": "5-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_5month"
+      },
+      {
+        "id": "6m_water_anomaly",
+        "title": "6-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_6month"
+      },
+      {
+        "id": "daily_rainfall_forecast",
+        "title": "Rolling daily rainfall forecast",
+        "server_layer_name": "rfh_daily_forecast"
+      },
+      {
+        "id": "days_dry",
+        "title": "Days since last rain",
+        "server_layer_name": "dlc_dekad"
+      },
+      {
+        "id": "days_extreme_rain",
+        "title": "Number of days with extreme rainfall in the last 30 days",
+        "server_layer_name": "xne_dekad"
+      },
+      {
+        "id": "days_heavy_rain",
+        "title": "Number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xnh_dekad"
+      },
+      {
+        "id": "days_intense_rain",
+        "title": "Number of days with intense rainfall in the last 30 days",
+        "server_layer_name": "xni_dekad"
+      },
+      {
+        "id": "dekad_rainfall_anomaly_forecast",
+        "title": "10-day rainfall forecast anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "dekad_rainfall_forecast",
+        "title": "10-day rainfall forecast",
+        "server_layer_name": "rfh_dekad_forecast"
+      },
+      {
+        "id": "lst_amplitude",
+        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
+        "server_layer_name": "myd11a2_taa_dekad"
+      },
+      {
+        "id": "lst_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_day_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_daytime",
+        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_nighttime",
+        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "monthly_water_anomaly",
+        "title": "Monthly Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_dekad"
+      },
+      {
+        "id": "ndvi_dekad",
+        "title": "10-day NDVI (MODIS)",
+        "server_layer_name": "mxd13a2_vim_dekad"
+      },
+      {
+        "id": "ndvi_dekad_anomaly",
+        "title": "10-day NDVI anomaly (MODIS)",
+        "server_layer_name": "mxd13a2_viq_dekad"
+      },
+      {
+        "id": "rain_anomaly_1month",
+        "title": "Monthly rainfall anomaly",
+        "server_layer_name": "r1q_dekad"
+      },
+      {
+        "id": "rain_anomaly_1year",
+        "title": "1-year rainfall anomaly",
+        "server_layer_name": "ryq_dekad"
+      },
+      {
+        "id": "rain_anomaly_2month",
+        "title": "2-month rainfall anomaly",
+        "server_layer_name": "r2q_dekad"
+      },
+      {
+        "id": "rain_anomaly_3month",
+        "title": "3-month rainfall anomaly",
+        "server_layer_name": "r3q_dekad"
+      },
+      {
+        "id": "rain_anomaly_4month",
+        "title": "4-month rainfall anomaly",
+        "server_layer_name": "r4q_dekad"
+      },
+      {
+        "id": "rain_anomaly_5month",
+        "title": "5-month rainfall anomaly",
+        "server_layer_name": "r5q_dekad"
+      },
+      {
+        "id": "rain_anomaly_6month",
+        "title": "6-month rainfall anomaly",
+        "server_layer_name": "r6q_dekad"
+      },
+      {
+        "id": "rain_anomaly_7month",
+        "title": "7-month rainfall anomaly",
+        "server_layer_name": "r7q_dekad"
+      },
+      {
+        "id": "rain_anomaly_8month",
+        "title": "8-month rainfall anomaly",
+        "server_layer_name": "r8q_dekad"
+      },
+      {
+        "id": "rain_anomaly_9month",
+        "title": "9-month rainfall anomaly",
+        "server_layer_name": "r9q_dekad"
+      },
+      {
+        "id": "rain_anomaly_dekad",
+        "title": "10-day rainfall anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rainfall_agg_1month",
+        "title": "1-month rainfall aggregate",
+        "server_layer_name": "r1h_dekad"
+      },
+      {
+        "id": "rainfall_agg_1year",
+        "title": "1-year rainfall aggregate (mm)",
+        "server_layer_name": "ryh_dekad"
+      },
+      {
+        "id": "rainfall_agg_2month",
+        "title": "2-month rainfall aggregate (mm)",
+        "server_layer_name": "r2h_dekad"
+      },
+      {
+        "id": "rainfall_agg_3month",
+        "title": "3-month rainfall aggregate (mm)",
+        "server_layer_name": "r3h_dekad"
+      },
+      {
+        "id": "rainfall_agg_4month",
+        "title": "4-month rainfall aggregate (mm)",
+        "server_layer_name": "r4h_dekad"
+      },
+      {
+        "id": "rainfall_agg_5month",
+        "title": "5-month rainfall aggregate (mm)",
+        "server_layer_name": "r5h_dekad"
+      },
+      {
+        "id": "rainfall_agg_6month",
+        "title": "6-month rainfall aggregate (mm)",
+        "server_layer_name": "r6h_dekad"
+      },
+      {
+        "id": "rainfall_agg_7month",
+        "title": "7-month rainfall aggregate (mm)",
+        "server_layer_name": "r7h_dekad"
+      },
+      {
+        "id": "rainfall_agg_8month",
+        "title": "8-month rainfall aggregate (mm)",
+        "server_layer_name": "r8h_dekad"
+      },
+      {
+        "id": "rainfall_agg_9month",
+        "title": "9-month rainfall aggregate (mm)",
+        "server_layer_name": "r9h_dekad"
+      },
+      {
+        "id": "rainfall_dekad",
+        "title": "10-day rainfall estimate (mm)",
+        "server_layer_name": "rfh_dekad"
+      },
+      {
+        "id": "spi_1m",
+        "title": "SPI - 1-month",
+        "server_layer_name": "r1s_dekad"
+      },
+      {
+        "id": "spi_1y",
+        "title": "SPI - 1-year",
+        "server_layer_name": "rys_dekad"
+      },
+      {
+        "id": "spi_2m",
+        "title": "SPI - 2-month",
+        "server_layer_name": "r2s_dekad"
+      },
+      {
+        "id": "spi_3m",
+        "title": "SPI - 3-month",
+        "server_layer_name": "r3s_dekad"
+      },
+      {
+        "id": "spi_6m",
+        "title": "SPI - 6-month",
+        "server_layer_name": "r6s_dekad"
+      },
+      {
+        "id": "spi_9m",
+        "title": "SPI - 9-month",
+        "server_layer_name": "r9s_dekad"
+      },
+      {
+        "id": "streak_dry_days",
+        "title": "Longest dry spell",
+        "server_layer_name": "dlx_dekad"
+      },
+      {
+        "id": "streak_extreme_rain",
+        "title": "Longest consecutive extreme rainfall days",
+        "server_layer_name": "xle_dekad"
+      },
+      {
+        "id": "streak_heavy_rain",
+        "title": "Longest consecutive heavy rainfall days",
+        "server_layer_name": "xlh_dekad"
+      },
+      {
+        "id": "streak_intense_rain",
+        "title": "Longest consecutive intense rainfall days",
+        "server_layer_name": "xli_dekad"
+      }
+    ],
+    "southsudan": [
+      {
+        "id": "2m_water_anomaly",
+        "title": "2-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_2month"
+      },
+      {
+        "id": "3m_water_anomaly",
+        "title": "3-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_3month"
+      },
+      {
+        "id": "4m_water_anomaly",
+        "title": "4-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_4month"
+      },
+      {
+        "id": "5m_water_anomaly",
+        "title": "5-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_5month"
+      },
+      {
+        "id": "6m_water_anomaly",
+        "title": "6-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_6month"
+      },
+      {
+        "id": "daily_rainfall_forecast",
+        "title": "Rolling daily rainfall forecast",
+        "server_layer_name": "rfh_daily_forecast"
+      },
+      {
+        "id": "days_dry",
+        "title": "Days since last rain",
+        "server_layer_name": "dlc_dekad"
+      },
+      {
+        "id": "days_extreme_rain",
+        "title": "Number of days with extreme rainfall in the last 30 days",
+        "server_layer_name": "xne_dekad"
+      },
+      {
+        "id": "days_heavy_rain",
+        "title": "Number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xnh_dekad"
+      },
+      {
+        "id": "days_intense_rain",
+        "title": "Number of days with intense rainfall in the last 30 days",
+        "server_layer_name": "xni_dekad"
+      },
+      {
+        "id": "dekad_rainfall_anomaly_forecast",
+        "title": "10-day rainfall forecast anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "dekad_rainfall_forecast",
+        "title": "10-day rainfall forecast",
+        "server_layer_name": "rfh_dekad_forecast"
+      },
+      {
+        "id": "lst_amplitude",
+        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
+        "server_layer_name": "myd11a2_taa_dekad"
+      },
+      {
+        "id": "lst_anomaly",
+        "title": "Daytime Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_day_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_daytime",
+        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_nighttime",
+        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "monthly_water_anomaly",
+        "title": "Monthly Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_dekad"
+      },
+      {
+        "id": "ndvi_dekad",
+        "title": "10-day NDVI (MODIS)",
+        "server_layer_name": "mxd13a2_vim_dekad"
+      },
+      {
+        "id": "ndvi_dekad_anomaly",
+        "title": "10-day NDVI anomaly (MODIS)",
+        "server_layer_name": "mxd13a2_viq_dekad"
+      },
+      {
+        "id": "rain_anomaly_1month",
+        "title": "1-month rainfall anomaly",
+        "server_layer_name": "r1q_dekad"
+      },
+      {
+        "id": "rain_anomaly_1year",
+        "title": "1-year rainfall anomaly",
+        "server_layer_name": "ryq_dekad"
+      },
+      {
+        "id": "rain_anomaly_2month",
+        "title": "2-month rainfall anomaly",
+        "server_layer_name": "r2q_dekad"
+      },
+      {
+        "id": "rain_anomaly_3month",
+        "title": "3-month rainfall anomaly",
+        "server_layer_name": "r3q_dekad"
+      },
+      {
+        "id": "rain_anomaly_4month",
+        "title": "4-month rainfall anomaly",
+        "server_layer_name": "r4q_dekad"
+      },
+      {
+        "id": "rain_anomaly_5month",
+        "title": "5-month rainfall anomaly",
+        "server_layer_name": "r5q_dekad"
+      },
+      {
+        "id": "rain_anomaly_6month",
+        "title": "6-month rainfall anomaly",
+        "server_layer_name": "r6q_dekad"
+      },
+      {
+        "id": "rain_anomaly_7month",
+        "title": "7-month rainfall anomaly",
+        "server_layer_name": "r7q_dekad"
+      },
+      {
+        "id": "rain_anomaly_8month",
+        "title": "8-month rainfall anomaly",
+        "server_layer_name": "r8q_dekad"
+      },
+      {
+        "id": "rain_anomaly_9month",
+        "title": "9-month rainfall anomaly",
+        "server_layer_name": "r9q_dekad"
+      },
+      {
+        "id": "rain_anomaly_dekad",
+        "title": "10-day rainfall anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rainfall_agg_1month",
+        "title": "1-month rainfall aggregate (mm)",
+        "server_layer_name": "r1h_dekad"
+      },
+      {
+        "id": "rainfall_agg_1year",
+        "title": "1-year rainfall aggregate (mm)",
+        "server_layer_name": "ryh_dekad"
+      },
+      {
+        "id": "rainfall_agg_2month",
+        "title": "2-month rainfall aggregate (mm)",
+        "server_layer_name": "r2h_dekad"
+      },
+      {
+        "id": "rainfall_agg_3month",
+        "title": "3-month rainfall aggregate (mm)",
+        "server_layer_name": "r3h_dekad"
+      },
+      {
+        "id": "rainfall_agg_4month",
+        "title": "4-month rainfall aggregate (mm)",
+        "server_layer_name": "r4h_dekad"
+      },
+      {
+        "id": "rainfall_agg_5month",
+        "title": "5-month rainfall aggregate (mm)",
+        "server_layer_name": "r5h_dekad"
+      },
+      {
+        "id": "rainfall_agg_6month",
+        "title": "6-month rainfall aggregate (mm)",
+        "server_layer_name": "r6h_dekad"
+      },
+      {
+        "id": "rainfall_agg_7month",
+        "title": "7-month rainfall aggregate (mm)",
+        "server_layer_name": "r7h_dekad"
+      },
+      {
+        "id": "rainfall_agg_8month",
+        "title": "8-month rainfall aggregate (mm)",
+        "server_layer_name": "r8h_dekad"
+      },
+      {
+        "id": "rainfall_agg_9month",
+        "title": "9-month rainfall aggregate (mm)",
+        "server_layer_name": "r9h_dekad"
+      },
+      {
+        "id": "rainfall_dekad",
+        "title": "10-day rainfall estimate (mm)",
+        "server_layer_name": "rfh_dekad"
+      },
+      {
+        "id": "spi_1m",
+        "title": "SPI - 1-month",
+        "server_layer_name": "r1s_dekad"
+      },
+      {
+        "id": "spi_1y",
+        "title": "SPI - 1-year",
+        "server_layer_name": "rys_dekad"
+      },
+      {
+        "id": "spi_2m",
+        "title": "SPI - 2-month",
+        "server_layer_name": "r2s_dekad"
+      },
+      {
+        "id": "spi_3m",
+        "title": "SPI - 3-month",
+        "server_layer_name": "r3s_dekad"
+      },
+      {
+        "id": "spi_6m",
+        "title": "SPI - 6-month",
+        "server_layer_name": "r6s_dekad"
+      },
+      {
+        "id": "spi_9m",
+        "title": "SPI - 9-month",
+        "server_layer_name": "r9s_dekad"
+      },
+      {
+        "id": "streak_dry_days",
+        "title": "Longest dry spell",
+        "server_layer_name": "dlx_dekad"
+      },
+      {
+        "id": "streak_extreme_rain",
+        "title": "Longest consecutive extreme rainfall days",
+        "server_layer_name": "xle_dekad"
+      },
+      {
+        "id": "streak_heavy_rain",
+        "title": "Longest consecutive number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xlh_dekad"
+      },
+      {
+        "id": "streak_intense_rain",
+        "title": "Longest consecutive intense rainfall days",
+        "server_layer_name": "xli_dekad"
+      }
+    ],
+    "srilanka": [
+      {
+        "id": "2m_water_anomaly",
+        "title": "2-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_2month"
+      },
+      {
+        "id": "3m_water_anomaly",
+        "title": "3-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_3month"
+      },
+      {
+        "id": "4m_water_anomaly",
+        "title": "4-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_4month"
+      },
+      {
+        "id": "5m_water_anomaly",
+        "title": "5-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_5month"
+      },
+      {
+        "id": "6m_water_anomaly",
+        "title": "6-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_6month"
+      },
+      {
+        "id": "daily_rainfall_forecast",
+        "title": "Rolling daily rainfall forecast",
+        "server_layer_name": "rfh_daily_forecast"
+      },
+      {
+        "id": "days_dry",
+        "title": "Days since last rain",
+        "server_layer_name": "dlc_dekad"
+      },
+      {
+        "id": "days_extreme_rain",
+        "title": "Number of days with extreme rainfall in the last 30 days",
+        "server_layer_name": "xne_dekad"
+      },
+      {
+        "id": "days_heavy_rain",
+        "title": "Number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xnh_dekad"
+      },
+      {
+        "id": "days_intense_rain",
+        "title": "Number of days with intense rainfall in the last 30 days",
+        "server_layer_name": "xni_dekad"
+      },
+      {
+        "id": "dekad_rainfall_anomaly_forecast",
+        "title": "10-day rainfall forecast anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "dekad_rainfall_forecast",
+        "title": "10-day rainfall forecast",
+        "server_layer_name": "rfh_dekad_forecast"
+      },
+      {
+        "id": "lst_amplitude",
+        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
+        "server_layer_name": "myd11a2_taa_dekad"
+      },
+      {
+        "id": "lst_anomaly",
+        "title": "Daytime Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_day_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_daytime",
+        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_nighttime",
+        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "monthly_water_anomaly",
+        "title": "Monthly Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_dekad"
+      },
+      {
+        "id": "ndvi_dekad",
+        "title": "10-day NDVI (MODIS)",
+        "server_layer_name": "mxd13a2_vim_dekad"
+      },
+      {
+        "id": "ndvi_dekad_anomaly",
+        "title": "10-day NDVI anomaly (MODIS)",
+        "server_layer_name": "mxd13a2_viq_dekad"
+      },
+      {
+        "id": "precip_blended_1m",
+        "title": "Blended rainfall aggregate (1-month)",
+        "server_layer_name": "rfb_blended_lka_dekad"
+      },
+      {
+        "id": "precip_blended_1y",
+        "title": "Blended rainfall aggregate (1-year)",
+        "server_layer_name": "rfb_blended_lka_dekad"
+      },
+      {
+        "id": "precip_blended_3m",
+        "title": "Blended rainfall aggregate (3-month)",
+        "server_layer_name": "rfb_blended_lka_dekad"
+      },
+      {
+        "id": "precip_blended_6m",
+        "title": "Blended rainfall aggregate (6-month)",
+        "server_layer_name": "rfb_blended_lka_dekad"
+      },
+      {
+        "id": "precip_blended_9m",
+        "title": "Blended rainfall aggregate (9-month)",
+        "server_layer_name": "rfb_blended_lka_dekad"
+      },
+      {
+        "id": "precip_blended_anomaly_1m",
+        "title": "Blended rainfall anomaly (1-month)",
+        "server_layer_name": "rfq_blended_lka_dekad"
+      },
+      {
+        "id": "precip_blended_anomaly_1y",
+        "title": "Blended rainfall anomaly (1-year)",
+        "server_layer_name": "rfq_blended_lka_dekad"
+      },
+      {
+        "id": "precip_blended_anomaly_3m",
+        "title": "Blended rainfall anomaly (3-month)",
+        "server_layer_name": "rfq_blended_lka_dekad"
+      },
+      {
+        "id": "precip_blended_anomaly_6m",
+        "title": "Blended rainfall anomaly (6-month)",
+        "server_layer_name": "rfq_blended_lka_dekad"
+      },
+      {
+        "id": "precip_blended_anomaly_9m",
+        "title": "Blended rainfall anomaly (9-month)",
+        "server_layer_name": "rfq_blended_lka_dekad"
+      },
+      {
+        "id": "precip_blended_dekad",
+        "title": "Blended rainfall estimates (10-day)",
+        "server_layer_name": "rfb_blended_lka_dekad"
+      },
+      {
+        "id": "precip_blended_dekad_agg",
+        "title": "Blended monthly aggregate rainfall",
+        "server_layer_name": "rnb_blended_dekad"
+      },
+      {
+        "id": "precip_blended_dekad_anomaly",
+        "title": "Blended rainfall anomaly (10-day)",
+        "server_layer_name": "rfq_blended_lka_dekad"
+      },
+      {
+        "id": "rain_anomaly_1month",
+        "title": "Monthly rainfall anomaly",
+        "server_layer_name": "r1q_dekad"
+      },
+      {
+        "id": "rain_anomaly_1year",
+        "title": "1-year rainfall anomaly",
+        "server_layer_name": "ryq_dekad"
+      },
+      {
+        "id": "rain_anomaly_2month",
+        "title": "2-month rainfall anomaly",
+        "server_layer_name": "r2q_dekad"
+      },
+      {
+        "id": "rain_anomaly_3month",
+        "title": "3-month rainfall anomaly",
+        "server_layer_name": "r3q_dekad"
+      },
+      {
+        "id": "rain_anomaly_4month",
+        "title": "4-month rainfall anomaly",
+        "server_layer_name": "r4q_dekad"
+      },
+      {
+        "id": "rain_anomaly_5month",
+        "title": "5-month rainfall anomaly",
+        "server_layer_name": "r5q_dekad"
+      },
+      {
+        "id": "rain_anomaly_6month",
+        "title": "6-month rainfall anomaly",
+        "server_layer_name": "r6q_dekad"
+      },
+      {
+        "id": "rain_anomaly_7month",
+        "title": "7-month rainfall anomaly",
+        "server_layer_name": "r7q_dekad"
+      },
+      {
+        "id": "rain_anomaly_8month",
+        "title": "8-month rainfall anomaly",
+        "server_layer_name": "r8q_dekad"
+      },
+      {
+        "id": "rain_anomaly_9month",
+        "title": "9-month rainfall anomaly",
+        "server_layer_name": "r9q_dekad"
+      },
+      {
+        "id": "rain_anomaly_dekad",
+        "title": "10-day rainfall anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rainfall_agg_1month",
+        "title": "1-month rainfall aggregate",
+        "server_layer_name": "r1h_dekad"
+      },
+      {
+        "id": "rainfall_agg_1year",
+        "title": "1-year rainfall aggregate (mm)",
+        "server_layer_name": "ryh_dekad"
+      },
+      {
+        "id": "rainfall_agg_2month",
+        "title": "2-month rainfall aggregate (mm)",
+        "server_layer_name": "r2h_dekad"
+      },
+      {
+        "id": "rainfall_agg_3month",
+        "title": "3-month rainfall aggregate (mm)",
+        "server_layer_name": "r3h_dekad"
+      },
+      {
+        "id": "rainfall_agg_4month",
+        "title": "4-month rainfall aggregate (mm)",
+        "server_layer_name": "r4h_dekad"
+      },
+      {
+        "id": "rainfall_agg_5month",
+        "title": "5-month rainfall aggregate (mm)",
+        "server_layer_name": "r5h_dekad"
+      },
+      {
+        "id": "rainfall_agg_6month",
+        "title": "6-month rainfall aggregate (mm)",
+        "server_layer_name": "r6h_dekad"
+      },
+      {
+        "id": "rainfall_agg_7month",
+        "title": "7-month rainfall aggregate (mm)",
+        "server_layer_name": "r7h_dekad"
+      },
+      {
+        "id": "rainfall_agg_8month",
+        "title": "8-month rainfall aggregate (mm)",
+        "server_layer_name": "r8h_dekad"
+      },
+      {
+        "id": "rainfall_agg_9month",
+        "title": "9-month rainfall aggregate (mm)",
+        "server_layer_name": "r9h_dekad"
+      },
+      {
+        "id": "rainfall_dekad",
+        "title": "10-day rainfall estimate (mm)",
+        "server_layer_name": "rfh_dekad"
+      },
+      {
+        "id": "spi_1m",
+        "title": "SPI - 1-month",
+        "server_layer_name": "r1s_dekad"
+      },
+      {
+        "id": "spi_1y",
+        "title": "SPI - 1-year",
+        "server_layer_name": "rys_dekad"
+      },
+      {
+        "id": "spi_2m",
+        "title": "SPI - 2-month",
+        "server_layer_name": "r2s_dekad"
+      },
+      {
+        "id": "spi_3m",
+        "title": "SPI - 3-month",
+        "server_layer_name": "r3s_dekad"
+      },
+      {
+        "id": "spi_6m",
+        "title": "SPI - 6-month",
+        "server_layer_name": "r6s_dekad"
+      },
+      {
+        "id": "spi_9m",
+        "title": "SPI - 9-month",
+        "server_layer_name": "r9s_dekad"
+      },
+      {
+        "id": "streak_dry_days",
+        "title": "Longest number of consecutive dry days",
+        "server_layer_name": "dlx_dekad"
+      },
+      {
+        "id": "streak_extreme_rain",
+        "title": "Longest consecutive extreme rainfall days",
+        "server_layer_name": "xle_dekad"
+      },
+      {
+        "id": "streak_heavy_rain",
+        "title": "Longest consecutive number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xlh_dekad"
+      },
+      {
+        "id": "streak_intense_rain",
+        "title": "Longest consecutive intense rainfall days",
+        "server_layer_name": "xli_dekad"
+      }
+    ],
+    "sudan": [
+      {
+        "id": "2m_water_anomaly",
+        "title": "2-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_2month"
+      },
+      {
+        "id": "3m_water_anomaly",
+        "title": "3-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_3month"
+      },
+      {
+        "id": "4m_water_anomaly",
+        "title": "4-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_4month"
+      },
+      {
+        "id": "5m_water_anomaly",
+        "title": "5-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_5month"
+      },
+      {
+        "id": "6m_water_anomaly",
+        "title": "6-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_6month"
+      },
+      {
+        "id": "daily_rainfall_forecast",
+        "title": "Rolling daily rainfall forecast",
+        "server_layer_name": "rfh_daily_forecast"
+      },
+      {
+        "id": "days_dry",
+        "title": "Days since last rain",
+        "server_layer_name": "dlc_dekad"
+      },
+      {
+        "id": "days_extreme_rain",
+        "title": "Number of days with extreme rainfall in the last 30 days",
+        "server_layer_name": "xne_dekad"
+      },
+      {
+        "id": "days_heavy_rain",
+        "title": "Number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xnh_dekad"
+      },
+      {
+        "id": "days_intense_rain",
+        "title": "Number of days with intense rainfall in the last 30 days",
+        "server_layer_name": "xni_dekad"
+      },
+      {
+        "id": "dekad_rainfall_anomaly_forecast",
+        "title": "10-day rainfall forecast anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "dekad_rainfall_forecast",
+        "title": "10-day rainfall forecast",
+        "server_layer_name": "rfh_dekad_forecast"
+      },
+      {
+        "id": "lst_amplitude",
+        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
+        "server_layer_name": "myd11a2_taa_dekad"
+      },
+      {
+        "id": "lst_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_day_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_daytime",
+        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_nighttime",
+        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "monthly_water_anomaly",
+        "title": "Monthly Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_dekad"
+      },
+      {
+        "id": "ndvi_dekad",
+        "title": "10-day NDVI (MODIS)",
+        "server_layer_name": "mxd13a2_vim_dekad"
+      },
+      {
+        "id": "ndvi_dekad_anomaly",
+        "title": "10-day NDVI anomaly (MODIS)",
+        "server_layer_name": "mxd13a2_viq_dekad"
+      },
+      {
+        "id": "rain_anomaly_1month",
+        "title": "Monthly rainfall anomaly",
+        "server_layer_name": "r1q_dekad"
+      },
+      {
+        "id": "rain_anomaly_1year",
+        "title": "1-year rainfall anomaly",
+        "server_layer_name": "ryq_dekad"
+      },
+      {
+        "id": "rain_anomaly_2month",
+        "title": "2-month rainfall anomaly",
+        "server_layer_name": "r2q_dekad"
+      },
+      {
+        "id": "rain_anomaly_3month",
+        "title": "3-month rainfall anomaly",
+        "server_layer_name": "r3q_dekad"
+      },
+      {
+        "id": "rain_anomaly_4month",
+        "title": "4-month rainfall anomaly",
+        "server_layer_name": "r4q_dekad"
+      },
+      {
+        "id": "rain_anomaly_5month",
+        "title": "5-month rainfall anomaly",
+        "server_layer_name": "r5q_dekad"
+      },
+      {
+        "id": "rain_anomaly_6month",
+        "title": "6-month rainfall anomaly",
+        "server_layer_name": "r6q_dekad"
+      },
+      {
+        "id": "rain_anomaly_7month",
+        "title": "7-month rainfall anomaly",
+        "server_layer_name": "r7q_dekad"
+      },
+      {
+        "id": "rain_anomaly_8month",
+        "title": "8-month rainfall anomaly",
+        "server_layer_name": "r8q_dekad"
+      },
+      {
+        "id": "rain_anomaly_9month",
+        "title": "9-month rainfall anomaly",
+        "server_layer_name": "r9q_dekad"
+      },
+      {
+        "id": "rain_anomaly_dekad",
+        "title": "10-day rainfall anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rainfall_agg_1month",
+        "title": "1-month rainfall aggregate",
+        "server_layer_name": "r1h_dekad"
+      },
+      {
+        "id": "rainfall_agg_1year",
+        "title": "1-year rainfall aggregate (mm)",
+        "server_layer_name": "ryh_dekad"
+      },
+      {
+        "id": "rainfall_agg_2month",
+        "title": "2-month rainfall aggregate (mm)",
+        "server_layer_name": "r2h_dekad"
+      },
+      {
+        "id": "rainfall_agg_3month",
+        "title": "3-month rainfall aggregate (mm)",
+        "server_layer_name": "r3h_dekad"
+      },
+      {
+        "id": "rainfall_agg_4month",
+        "title": "4-month rainfall aggregate (mm)",
+        "server_layer_name": "r4h_dekad"
+      },
+      {
+        "id": "rainfall_agg_5month",
+        "title": "5-month rainfall aggregate (mm)",
+        "server_layer_name": "r5h_dekad"
+      },
+      {
+        "id": "rainfall_agg_6month",
+        "title": "6-month rainfall aggregate (mm)",
+        "server_layer_name": "r6h_dekad"
+      },
+      {
+        "id": "rainfall_agg_7month",
+        "title": "7-month rainfall aggregate (mm)",
+        "server_layer_name": "r7h_dekad"
+      },
+      {
+        "id": "rainfall_agg_8month",
+        "title": "8-month rainfall aggregate (mm)",
+        "server_layer_name": "r8h_dekad"
+      },
+      {
+        "id": "rainfall_agg_9month",
+        "title": "9-month rainfall aggregate (mm)",
+        "server_layer_name": "r9h_dekad"
+      },
+      {
+        "id": "rainfall_dekad",
+        "title": "10-day rainfall estimate (mm)",
+        "server_layer_name": "rfh_dekad"
+      },
+      {
+        "id": "spi_1m",
+        "title": "SPI - 1-month",
+        "server_layer_name": "r1s_dekad"
+      },
+      {
+        "id": "spi_1y",
+        "title": "SPI - 1-year",
+        "server_layer_name": "rys_dekad"
+      },
+      {
+        "id": "spi_2m",
+        "title": "SPI - 2-month",
+        "server_layer_name": "r2s_dekad"
+      },
+      {
+        "id": "spi_3m",
+        "title": "SPI - 3-month",
+        "server_layer_name": "r3s_dekad"
+      },
+      {
+        "id": "spi_6m",
+        "title": "SPI - 6-month",
+        "server_layer_name": "r6s_dekad"
+      },
+      {
+        "id": "spi_9m",
+        "title": "SPI - 9-month",
+        "server_layer_name": "r9s_dekad"
+      },
+      {
+        "id": "streak_dry_days",
+        "title": "Longest dry spell",
+        "server_layer_name": "dlx_dekad"
+      },
+      {
+        "id": "streak_extreme_rain",
+        "title": "Longest consecutive extreme rainfall days",
+        "server_layer_name": "xle_dekad"
+      },
+      {
+        "id": "streak_heavy_rain",
+        "title": "Longest consecutive heavy rainfall days",
+        "server_layer_name": "xlh_dekad"
+      },
+      {
+        "id": "streak_intense_rain",
+        "title": "Longest consecutive intense rainfall days",
+        "server_layer_name": "xli_dekad"
+      }
+    ],
+    "tajikistan": [
+      {
+        "id": "2m_water_anomaly",
+        "title": "2-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_2month"
+      },
+      {
+        "id": "3m_water_anomaly",
+        "title": "3-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_3month"
+      },
+      {
+        "id": "4m_water_anomaly",
+        "title": "4-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_4month"
+      },
+      {
+        "id": "5m_water_anomaly",
+        "title": "5-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_5month"
+      },
+      {
+        "id": "6m_water_anomaly",
+        "title": "6-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_6month"
+      },
+      {
+        "id": "daily_rainfall_forecast",
+        "title": "Rolling daily rainfall forecast",
+        "server_layer_name": "rfh_daily_forecast"
+      },
+      {
+        "id": "days_dry",
+        "title": "Days since last rain",
+        "server_layer_name": "dlc_dekad"
+      },
+      {
+        "id": "days_extreme_rain",
+        "title": "Number of days with extreme rainfall in the last 30 days",
+        "server_layer_name": "xne_dekad"
+      },
+      {
+        "id": "days_heavy_rain",
+        "title": "Number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xnh_dekad"
+      },
+      {
+        "id": "days_intense_rain",
+        "title": "Number of days with intense rainfall in the last 30 days",
+        "server_layer_name": "xni_dekad"
+      },
+      {
+        "id": "dekad_rainfall_anomaly_forecast",
+        "title": "10-day rainfall forecast anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "dekad_rainfall_forecast",
+        "title": "10-day rainfall forecast",
+        "server_layer_name": "rfh_dekad_forecast"
+      },
+      {
+        "id": "lst_amplitude",
+        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
+        "server_layer_name": "myd11a2_taa_dekad"
+      },
+      {
+        "id": "lst_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_day_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_daytime",
+        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_nighttime",
+        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "monthly_water_anomaly",
+        "title": "Monthly Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_dekad"
+      },
+      {
+        "id": "ndvi_dekad",
+        "title": "10-day NDVI (MODIS)",
+        "server_layer_name": "mxd13a2_vim_dekad"
+      },
+      {
+        "id": "ndvi_dekad_anomaly",
+        "title": "10-day NDVI anomaly (MODIS)",
+        "server_layer_name": "mxd13a2_viq_dekad"
+      },
+      {
+        "id": "rain_anomaly_1month",
+        "title": "Monthly rainfall anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rain_anomaly_1year",
+        "title": "1-year rainfall anomaly",
+        "server_layer_name": "ryq_dekad"
+      },
+      {
+        "id": "rain_anomaly_2month",
+        "title": "2-month rainfall anomaly",
+        "server_layer_name": "r2q_dekad"
+      },
+      {
+        "id": "rain_anomaly_3month",
+        "title": "3-month rainfall anomaly",
+        "server_layer_name": "r3q_dekad"
+      },
+      {
+        "id": "rain_anomaly_4month",
+        "title": "4-month rainfall anomaly",
+        "server_layer_name": "r4q_dekad"
+      },
+      {
+        "id": "rain_anomaly_5month",
+        "title": "5-month rainfall anomaly",
+        "server_layer_name": "r5q_dekad"
+      },
+      {
+        "id": "rain_anomaly_6month",
+        "title": "6-month rainfall anomaly",
+        "server_layer_name": "r6q_dekad"
+      },
+      {
+        "id": "rain_anomaly_7month",
+        "title": "7-month rainfall anomaly",
+        "server_layer_name": "r7q_dekad"
+      },
+      {
+        "id": "rain_anomaly_8month",
+        "title": "8-month rainfall anomaly",
+        "server_layer_name": "r8q_dekad"
+      },
+      {
+        "id": "rain_anomaly_9month",
+        "title": "9-month rainfall anomaly",
+        "server_layer_name": "r9q_dekad"
+      },
+      {
+        "id": "rain_anomaly_dekad",
+        "title": "10-day rainfall anomaly",
+        "server_layer_name": "r1q_dekad"
+      },
+      {
+        "id": "rainfall_agg_1month",
+        "title": "1-month rainfall aggregate",
+        "server_layer_name": "r1h_dekad"
+      },
+      {
+        "id": "rainfall_agg_1year",
+        "title": "1-year rainfall aggregate (mm)",
+        "server_layer_name": "ryh_dekad"
+      },
+      {
+        "id": "rainfall_agg_2month",
+        "title": "2-month rainfall aggregate (mm)",
+        "server_layer_name": "r2h_dekad"
+      },
+      {
+        "id": "rainfall_agg_3month",
+        "title": "3-month rainfall aggregate (mm)",
+        "server_layer_name": "r3h_dekad"
+      },
+      {
+        "id": "rainfall_agg_4month",
+        "title": "4-month rainfall aggregate (mm)",
+        "server_layer_name": "r4h_dekad"
+      },
+      {
+        "id": "rainfall_agg_5month",
+        "title": "5-month rainfall aggregate (mm)",
+        "server_layer_name": "r5h_dekad"
+      },
+      {
+        "id": "rainfall_agg_6month",
+        "title": "6-month rainfall aggregate (mm)",
+        "server_layer_name": "r6h_dekad"
+      },
+      {
+        "id": "rainfall_agg_7month",
+        "title": "7-month rainfall aggregate (mm)",
+        "server_layer_name": "r7h_dekad"
+      },
+      {
+        "id": "rainfall_agg_8month",
+        "title": "8-month rainfall aggregate (mm)",
+        "server_layer_name": "r8h_dekad"
+      },
+      {
+        "id": "rainfall_agg_9month",
+        "title": "9-month rainfall aggregate (mm)",
+        "server_layer_name": "r9h_dekad"
+      },
+      {
+        "id": "rainfall_dekad",
+        "title": "10-day rainfall estimate (mm)",
+        "server_layer_name": "rfh_dekad"
+      },
+      {
+        "id": "spi_1m",
+        "title": "SPI - 1-month",
+        "server_layer_name": "r1s_dekad"
+      },
+      {
+        "id": "spi_1y",
+        "title": "SPI - 1-year",
+        "server_layer_name": "rys_dekad"
+      },
+      {
+        "id": "spi_2m",
+        "title": "SPI - 2-month",
+        "server_layer_name": "r2s_dekad"
+      },
+      {
+        "id": "spi_3m",
+        "title": "SPI - 3-month",
+        "server_layer_name": "r3s_dekad"
+      },
+      {
+        "id": "spi_6m",
+        "title": "SPI - 6-month",
+        "server_layer_name": "r6s_dekad"
+      },
+      {
+        "id": "spi_9m",
+        "title": "SPI - 9-month",
+        "server_layer_name": "r9s_dekad"
+      },
+      {
+        "id": "streak_dry_days",
+        "title": "Longest number of consecutive dry days",
+        "server_layer_name": "dlx_dekad"
+      },
+      {
+        "id": "streak_extreme_rain",
+        "title": "Longest consecutive extreme rainfall days",
+        "server_layer_name": "xle_dekad"
+      },
+      {
+        "id": "streak_heavy_rain",
+        "title": "Longest consecutive number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xlh_dekad"
+      },
+      {
+        "id": "streak_intense_rain",
+        "title": "Longest consecutive intense rainfall days",
+        "server_layer_name": "xli_dekad"
+      }
+    ],
+    "tanzania": [
+      {
+        "id": "2m_water_anomaly",
+        "title": "2-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_2month"
+      },
+      {
+        "id": "3m_water_anomaly",
+        "title": "3-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_3month"
+      },
+      {
+        "id": "4m_water_anomaly",
+        "title": "4-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_4month"
+      },
+      {
+        "id": "5m_water_anomaly",
+        "title": "5-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_5month"
+      },
+      {
+        "id": "6m_water_anomaly",
+        "title": "6-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_6month"
+      },
+      {
+        "id": "daily_rainfall_forecast",
+        "title": "Rolling daily rainfall forecast",
+        "server_layer_name": "rfh_daily_forecast"
+      },
+      {
+        "id": "days_dry",
+        "title": "Days since last rain",
+        "server_layer_name": "dlc_dekad"
+      },
+      {
+        "id": "days_extreme_rain",
+        "title": "Number of days with extreme rainfall in the last 30 days",
+        "server_layer_name": "xne_dekad"
+      },
+      {
+        "id": "days_heavy_rain",
+        "title": "Number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xnh_dekad"
+      },
+      {
+        "id": "days_intense_rain",
+        "title": "Number of days with intense rainfall in the last 30 days",
+        "server_layer_name": "xni_dekad"
+      },
+      {
+        "id": "dekad_rainfall_anomaly_forecast",
+        "title": "10-day rainfall forecast anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "dekad_rainfall_forecast",
+        "title": "10-day rainfall forecast",
+        "server_layer_name": "rfh_dekad_forecast"
+      },
+      {
+        "id": "lst_amplitude",
+        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
+        "server_layer_name": "myd11a2_taa_dekad"
+      },
+      {
+        "id": "lst_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_day_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_daytime",
+        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_nighttime",
+        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "monthly_water_anomaly",
+        "title": "Monthly Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_dekad"
+      },
+      {
+        "id": "ndvi_dekad",
+        "title": "10-day NDVI (MODIS)",
+        "server_layer_name": "mxd13a2_vim_dekad"
+      },
+      {
+        "id": "ndvi_dekad_anomaly",
+        "title": "10-day NDVI anomaly (MODIS)",
+        "server_layer_name": "mxd13a2_viq_dekad"
+      },
+      {
+        "id": "rain_anomaly_1month",
+        "title": "Monthly rainfall anomaly",
+        "server_layer_name": "r1q_dekad"
+      },
+      {
+        "id": "rain_anomaly_1year",
+        "title": "1-year rainfall anomaly",
+        "server_layer_name": "ryq_dekad"
+      },
+      {
+        "id": "rain_anomaly_2month",
+        "title": "2-month rainfall anomaly",
+        "server_layer_name": "r2q_dekad"
+      },
+      {
+        "id": "rain_anomaly_3month",
+        "title": "3-month rainfall anomaly",
+        "server_layer_name": "r3q_dekad"
+      },
+      {
+        "id": "rain_anomaly_4month",
+        "title": "4-month rainfall anomaly",
+        "server_layer_name": "r4q_dekad"
+      },
+      {
+        "id": "rain_anomaly_5month",
+        "title": "5-month rainfall anomaly",
+        "server_layer_name": "r5q_dekad"
+      },
+      {
+        "id": "rain_anomaly_6month",
+        "title": "6-month rainfall anomaly",
+        "server_layer_name": "r6q_dekad"
+      },
+      {
+        "id": "rain_anomaly_7month",
+        "title": "7-month rainfall anomaly",
+        "server_layer_name": "r7q_dekad"
+      },
+      {
+        "id": "rain_anomaly_8month",
+        "title": "8-month rainfall anomaly",
+        "server_layer_name": "r8q_dekad"
+      },
+      {
+        "id": "rain_anomaly_9month",
+        "title": "9-month rainfall anomaly",
+        "server_layer_name": "r9q_dekad"
+      },
+      {
+        "id": "rain_anomaly_dekad",
+        "title": "10-day rainfall anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rainfall_agg_1month",
+        "title": "1-month rainfall aggregate (mm)",
+        "server_layer_name": "r1h_dekad"
+      },
+      {
+        "id": "rainfall_agg_1year",
+        "title": "1-year rainfall aggregate (mm)",
+        "server_layer_name": "ryh_dekad"
+      },
+      {
+        "id": "rainfall_agg_2month",
+        "title": "2-month rainfall aggregate (mm)",
+        "server_layer_name": "r2h_dekad"
+      },
+      {
+        "id": "rainfall_agg_3month",
+        "title": "3-month rainfall aggregate (mm)",
+        "server_layer_name": "r3h_dekad"
+      },
+      {
+        "id": "rainfall_agg_4month",
+        "title": "4-month rainfall aggregate (mm)",
+        "server_layer_name": "r4h_dekad"
+      },
+      {
+        "id": "rainfall_agg_5month",
+        "title": "5-month rainfall aggregate (mm)",
+        "server_layer_name": "r5h_dekad"
+      },
+      {
+        "id": "rainfall_agg_6month",
+        "title": "6-month rainfall aggregate (mm)",
+        "server_layer_name": "r6h_dekad"
+      },
+      {
+        "id": "rainfall_agg_7month",
+        "title": "7-month rainfall aggregate (mm)",
+        "server_layer_name": "r7h_dekad"
+      },
+      {
+        "id": "rainfall_agg_8month",
+        "title": "8-month rainfall aggregate (mm)",
+        "server_layer_name": "r8h_dekad"
+      },
+      {
+        "id": "rainfall_agg_9month",
+        "title": "9-month rainfall aggregate (mm)",
+        "server_layer_name": "r9h_dekad"
+      },
+      {
+        "id": "rainfall_dekad",
+        "title": "10-day rainfall estimate (mm)",
+        "server_layer_name": "rfh_dekad"
+      },
+      {
+        "id": "spi_1m",
+        "title": "SPI - 1-month",
+        "server_layer_name": "r1s_dekad"
+      },
+      {
+        "id": "spi_1y",
+        "title": "SPI - 1-year",
+        "server_layer_name": "rys_dekad"
+      },
+      {
+        "id": "spi_2m",
+        "title": "SPI - 2-month",
+        "server_layer_name": "r2s_dekad"
+      },
+      {
+        "id": "spi_3m",
+        "title": "SPI - 3-month",
+        "server_layer_name": "r3s_dekad"
+      },
+      {
+        "id": "spi_6m",
+        "title": "SPI - 6-month",
+        "server_layer_name": "r6s_dekad"
+      },
+      {
+        "id": "spi_9m",
+        "title": "SPI - 9-month",
+        "server_layer_name": "r9s_dekad"
+      },
+      {
+        "id": "streak_dry_days",
+        "title": "Longest number of consecutive dry days",
+        "server_layer_name": "dlx_dekad"
+      },
+      {
+        "id": "streak_extreme_rain",
+        "title": "Longest consecutive extreme rainfall days",
+        "server_layer_name": "xle_dekad"
+      },
+      {
+        "id": "streak_heavy_rain",
+        "title": "Longest consecutive number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xlh_dekad"
+      },
+      {
+        "id": "streak_intense_rain",
+        "title": "Longest consecutive intense rainfall days",
+        "server_layer_name": "xli_dekad"
+      }
+    ],
+    "ukraine": [
+      {
+        "id": "2m_water_anomaly",
+        "title": "2-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_2month"
+      },
+      {
+        "id": "3m_water_anomaly",
+        "title": "3-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_3month"
+      },
+      {
+        "id": "4m_water_anomaly",
+        "title": "4-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_4month"
+      },
+      {
+        "id": "5m_water_anomaly",
+        "title": "5-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_5month"
+      },
+      {
+        "id": "6m_water_anomaly",
+        "title": "6-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_6month"
+      },
+      {
+        "id": "daily_rainfall_forecast",
+        "title": "Rolling daily rainfall forecast",
+        "server_layer_name": "rfh_daily_forecast"
+      },
+      {
+        "id": "days_dry",
+        "title": "Number of dry days",
+        "server_layer_name": "dlc_dekad"
+      },
+      {
+        "id": "days_extreme_rain",
+        "title": "Number of days with extreme rainfall in the last 30 days",
+        "server_layer_name": "xne_dekad"
+      },
+      {
+        "id": "days_heavy_rain",
+        "title": "Number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xnh_dekad"
+      },
+      {
+        "id": "days_intense_rain",
+        "title": "Number of days with intense rainfall in the last 30 days",
+        "server_layer_name": "xni_dekad"
+      },
+      {
+        "id": "dekad_rainfall_anomaly_forecast",
+        "title": "10-day rainfall forecast anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "dekad_rainfall_forecast",
+        "title": "10-day rainfall forecast",
+        "server_layer_name": "rfh_dekad_forecast"
+      },
+      {
+        "id": "lst_amplitude",
+        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
+        "server_layer_name": "myd11a2_taa_dekad"
+      },
+      {
+        "id": "lst_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_day_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_daytime",
+        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_nighttime",
+        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "monthly_water_anomaly",
+        "title": "Monthly Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_dekad"
+      },
+      {
+        "id": "ndvi_dekad",
+        "title": "10-day NDVI (MODIS)",
+        "server_layer_name": "mxd13a2_vim_dekad"
+      },
+      {
+        "id": "ndvi_dekad_anomaly",
+        "title": "10-day NDVI anomaly (MODIS)",
+        "server_layer_name": "mxd13a2_viq_dekad"
+      },
+      {
+        "id": "rain_anomaly_1month",
+        "title": "Monthly rainfall anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rain_anomaly_1year",
+        "title": "1-year rainfall anomaly",
+        "server_layer_name": "ryq_dekad"
+      },
+      {
+        "id": "rain_anomaly_2month",
+        "title": "2-month rainfall anomaly",
+        "server_layer_name": "r2q_dekad"
+      },
+      {
+        "id": "rain_anomaly_3month",
+        "title": "3-month rainfall anomaly",
+        "server_layer_name": "r3q_dekad"
+      },
+      {
+        "id": "rain_anomaly_4month",
+        "title": "4-month rainfall anomaly",
+        "server_layer_name": "r4q_dekad"
+      },
+      {
+        "id": "rain_anomaly_5month",
+        "title": "5-month rainfall anomaly",
+        "server_layer_name": "r5q_dekad"
+      },
+      {
+        "id": "rain_anomaly_6month",
+        "title": "6-month rainfall anomaly",
+        "server_layer_name": "r6q_dekad"
+      },
+      {
+        "id": "rain_anomaly_7month",
+        "title": "7-month rainfall anomaly",
+        "server_layer_name": "r7q_dekad"
+      },
+      {
+        "id": "rain_anomaly_8month",
+        "title": "8-month rainfall anomaly",
+        "server_layer_name": "r8q_dekad"
+      },
+      {
+        "id": "rain_anomaly_9month",
+        "title": "9-month rainfall anomaly",
+        "server_layer_name": "r9q_dekad"
+      },
+      {
+        "id": "rain_anomaly_dekad",
+        "title": "10-day rainfall anomaly",
+        "server_layer_name": "r1q_dekad"
+      },
+      {
+        "id": "rainfall_agg_1month",
+        "title": "1-month rainfall aggregate",
+        "server_layer_name": "r1h_dekad"
+      },
+      {
+        "id": "rainfall_agg_1year",
+        "title": "1-year rainfall aggregate (mm)",
+        "server_layer_name": "ryh_dekad"
+      },
+      {
+        "id": "rainfall_agg_2month",
+        "title": "2-month rainfall aggregate (mm)",
+        "server_layer_name": "r2h_dekad"
+      },
+      {
+        "id": "rainfall_agg_3month",
+        "title": "3-month rainfall aggregate (mm)",
+        "server_layer_name": "r3h_dekad"
+      },
+      {
+        "id": "rainfall_agg_4month",
+        "title": "4-month rainfall aggregate (mm)",
+        "server_layer_name": "r4h_dekad"
+      },
+      {
+        "id": "rainfall_agg_5month",
+        "title": "5-month rainfall aggregate (mm)",
+        "server_layer_name": "r5h_dekad"
+      },
+      {
+        "id": "rainfall_agg_6month",
+        "title": "6-month rainfall aggregate (mm)",
+        "server_layer_name": "r6h_dekad"
+      },
+      {
+        "id": "rainfall_agg_7month",
+        "title": "7-month rainfall aggregate (mm)",
+        "server_layer_name": "r7h_dekad"
+      },
+      {
+        "id": "rainfall_agg_8month",
+        "title": "8-month rainfall aggregate (mm)",
+        "server_layer_name": "r8h_dekad"
+      },
+      {
+        "id": "rainfall_agg_9month",
+        "title": "9-month rainfall aggregate (mm)",
+        "server_layer_name": "r9h_dekad"
+      },
+      {
+        "id": "rainfall_dekad",
+        "title": "10-day rainfall estimate (mm)",
+        "server_layer_name": "rfh_dekad"
+      },
+      {
+        "id": "spi_1m",
+        "title": "SPI - 1-month",
+        "server_layer_name": "r1s_dekad"
+      },
+      {
+        "id": "spi_1y",
+        "title": "SPI - 1-year",
+        "server_layer_name": "rys_dekad"
+      },
+      {
+        "id": "spi_2m",
+        "title": "SPI - 2-month",
+        "server_layer_name": "r2s_dekad"
+      },
+      {
+        "id": "spi_3m",
+        "title": "SPI - 3-month",
+        "server_layer_name": "r3s_dekad"
+      },
+      {
+        "id": "spi_6m",
+        "title": "SPI - 6-month",
+        "server_layer_name": "r6s_dekad"
+      },
+      {
+        "id": "spi_9m",
+        "title": "SPI - 9-month",
+        "server_layer_name": "r9s_dekad"
+      },
+      {
+        "id": "streak_dry_days",
+        "title": "Longest number of consecutive dry days",
+        "server_layer_name": "dlx_dekad"
+      },
+      {
+        "id": "streak_extreme_rain",
+        "title": "Longest consecutive extreme rainfall days",
+        "server_layer_name": "xle_dekad"
+      },
+      {
+        "id": "streak_heavy_rain",
+        "title": "Longest consecutive number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xlh_dekad"
+      },
+      {
+        "id": "streak_intense_rain",
+        "title": "Longest consecutive intense rainfall days",
+        "server_layer_name": "xli_dekad"
+      }
+    ],
+    "zambia": [
+      {
+        "id": "2m_water_anomaly",
+        "title": "2-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_2month"
+      },
+      {
+        "id": "3m_water_anomaly",
+        "title": "3-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_3month"
+      },
+      {
+        "id": "4m_water_anomaly",
+        "title": "4-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_4month"
+      },
+      {
+        "id": "5m_water_anomaly",
+        "title": "5-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_5month"
+      },
+      {
+        "id": "6m_water_anomaly",
+        "title": "6-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_6month"
+      },
+      {
+        "id": "daily_rainfall_forecast",
+        "title": "Rolling daily rainfall forecast",
+        "server_layer_name": "rfh_daily_forecast"
+      },
+      {
+        "id": "days_dry",
+        "title": "Days since last rain",
+        "server_layer_name": "dlc_dekad"
+      },
+      {
+        "id": "days_extreme_rain",
+        "title": "Number of days with extreme rainfall in the last 30 days",
+        "server_layer_name": "xne_dekad"
+      },
+      {
+        "id": "days_heavy_rain",
+        "title": "Number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xnh_dekad"
+      },
+      {
+        "id": "days_intense_rain",
+        "title": "Number of days with intense rainfall in the last 30 days",
+        "server_layer_name": "xni_dekad"
+      },
+      {
+        "id": "dekad_rainfall_anomaly_forecast",
+        "title": "10-day rainfall forecast anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "dekad_rainfall_forecast",
+        "title": "10-day rainfall forecast",
+        "server_layer_name": "rfh_dekad_forecast"
+      },
+      {
+        "id": "lst_amplitude",
+        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
+        "server_layer_name": "myd11a2_taa_dekad"
+      },
+      {
+        "id": "lst_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_day_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_daytime",
+        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_nighttime",
+        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "monthly_water_anomaly",
+        "title": "Monthly Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_dekad"
+      },
+      {
+        "id": "ndvi_dekad",
+        "title": "10-day NDVI (MODIS)",
+        "server_layer_name": "mxd13a2_vim_dekad"
+      },
+      {
+        "id": "ndvi_dekad_anomaly",
+        "title": "10-day NDVI anomaly (MODIS)",
+        "server_layer_name": "mxd13a2_viq_dekad"
+      },
+      {
+        "id": "rain_anomaly_1month",
+        "title": "Monthly rainfall anomaly",
+        "server_layer_name": "r1q_dekad"
+      },
+      {
+        "id": "rain_anomaly_1year",
+        "title": "1-year rainfall anomaly",
+        "server_layer_name": "ryq_dekad"
+      },
+      {
+        "id": "rain_anomaly_2month",
+        "title": "2-month rainfall anomaly",
+        "server_layer_name": "r2q_dekad"
+      },
+      {
+        "id": "rain_anomaly_3month",
+        "title": "3-month rainfall anomaly",
+        "server_layer_name": "r3q_dekad"
+      },
+      {
+        "id": "rain_anomaly_4month",
+        "title": "4-month rainfall anomaly",
+        "server_layer_name": "r4q_dekad"
+      },
+      {
+        "id": "rain_anomaly_5month",
+        "title": "5-month rainfall anomaly",
+        "server_layer_name": "r5q_dekad"
+      },
+      {
+        "id": "rain_anomaly_6month",
+        "title": "6-month rainfall anomaly",
+        "server_layer_name": "r6q_dekad"
+      },
+      {
+        "id": "rain_anomaly_7month",
+        "title": "7-month rainfall anomaly",
+        "server_layer_name": "r7q_dekad"
+      },
+      {
+        "id": "rain_anomaly_8month",
+        "title": "8-month rainfall anomaly",
+        "server_layer_name": "r8q_dekad"
+      },
+      {
+        "id": "rain_anomaly_9month",
+        "title": "9-month rainfall anomaly",
+        "server_layer_name": "r9q_dekad"
+      },
+      {
+        "id": "rain_anomaly_dekad",
+        "title": "10-day rainfall anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rainfall_agg_1month",
+        "title": "1-month rainfall aggregate",
+        "server_layer_name": "r1h_dekad"
+      },
+      {
+        "id": "rainfall_agg_1year",
+        "title": "1-year rainfall aggregate (mm)",
+        "server_layer_name": "ryh_dekad"
+      },
+      {
+        "id": "rainfall_agg_2month",
+        "title": "2-month rainfall aggregate (mm)",
+        "server_layer_name": "r2h_dekad"
+      },
+      {
+        "id": "rainfall_agg_3month",
+        "title": "3-month rainfall aggregate (mm)",
+        "server_layer_name": "r3h_dekad"
+      },
+      {
+        "id": "rainfall_agg_4month",
+        "title": "4-month rainfall aggregate (mm)",
+        "server_layer_name": "r4h_dekad"
+      },
+      {
+        "id": "rainfall_agg_5month",
+        "title": "5-month rainfall aggregate (mm)",
+        "server_layer_name": "r5h_dekad"
+      },
+      {
+        "id": "rainfall_agg_6month",
+        "title": "6-month rainfall aggregate (mm)",
+        "server_layer_name": "r6h_dekad"
+      },
+      {
+        "id": "rainfall_agg_7month",
+        "title": "7-month rainfall aggregate (mm)",
+        "server_layer_name": "r7h_dekad"
+      },
+      {
+        "id": "rainfall_agg_8month",
+        "title": "8-month rainfall aggregate (mm)",
+        "server_layer_name": "r8h_dekad"
+      },
+      {
+        "id": "rainfall_agg_9month",
+        "title": "9-month rainfall aggregate (mm)",
+        "server_layer_name": "r9h_dekad"
+      },
+      {
+        "id": "rainfall_dekad",
+        "title": "10-day rainfall estimate (mm)",
+        "server_layer_name": "rfh_dekad"
+      },
+      {
+        "id": "spi_1m",
+        "title": "SPI - 1-month",
+        "server_layer_name": "r1s_dekad"
+      },
+      {
+        "id": "spi_1y",
+        "title": "SPI - 1-year",
+        "server_layer_name": "rys_dekad"
+      },
+      {
+        "id": "spi_2m",
+        "title": "SPI - 2-month",
+        "server_layer_name": "r2s_dekad"
+      },
+      {
+        "id": "spi_3m",
+        "title": "SPI - 3-month",
+        "server_layer_name": "r3s_dekad"
+      },
+      {
+        "id": "spi_6m",
+        "title": "SPI - 6-month",
+        "server_layer_name": "r6s_dekad"
+      },
+      {
+        "id": "spi_9m",
+        "title": "SPI - 9-month",
+        "server_layer_name": "r9s_dekad"
+      },
+      {
+        "id": "streak_dry_days",
+        "title": "Longest dry spell",
+        "server_layer_name": "dlx_dekad"
+      },
+      {
+        "id": "streak_extreme_rain",
+        "title": "Longest consecutive extreme rainfall days",
+        "server_layer_name": "xle_dekad"
+      },
+      {
+        "id": "streak_heavy_rain",
+        "title": "Longest consecutive heavy rainfall days",
+        "server_layer_name": "xlh_dekad"
+      },
+      {
+        "id": "streak_intense_rain",
+        "title": "Longest consecutive intense rainfall days",
+        "server_layer_name": "xli_dekad"
+      }
+    ],
+    "zimbabwe": [
+      {
+        "id": "2m_water_anomaly",
+        "title": "2-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_2month"
+      },
+      {
+        "id": "3m_water_anomaly",
+        "title": "3-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_3month"
+      },
+      {
+        "id": "4m_water_anomaly",
+        "title": "4-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_4month"
+      },
+      {
+        "id": "5m_water_anomaly",
+        "title": "5-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_5month"
+      },
+      {
+        "id": "6m_water_anomaly",
+        "title": "6-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_6month"
+      },
+      {
+        "id": "daily_rainfall_forecast",
+        "title": "Rolling daily rainfall forecast",
+        "server_layer_name": "rfh_daily_forecast"
+      },
+      {
+        "id": "days_dry",
+        "title": "Days since last rain",
+        "server_layer_name": "dlc_dekad"
+      },
+      {
+        "id": "days_extreme_rain",
+        "title": "Number of days with extreme rainfall in the last 30 days",
+        "server_layer_name": "xne_dekad"
+      },
+      {
+        "id": "days_heavy_rain",
+        "title": "Number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xnh_dekad"
+      },
+      {
+        "id": "days_intense_rain",
+        "title": "Number of days with intense rainfall in the last 30 days",
+        "server_layer_name": "xni_dekad"
+      },
+      {
+        "id": "dekad_rainfall_anomaly_forecast",
+        "title": "10-day rainfall forecast anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "dekad_rainfall_forecast",
+        "title": "10-day rainfall forecast",
+        "server_layer_name": "rfh_dekad_forecast"
+      },
+      {
+        "id": "lst_amplitude",
+        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
+        "server_layer_name": "myd11a2_taa_dekad"
+      },
+      {
+        "id": "lst_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_day_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_daytime",
+        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_nighttime",
+        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "monthly_water_anomaly",
+        "title": "Monthly Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_dekad"
       },
       {
         "id": "ndvi_dekad",
@@ -3609,6 +8065,16 @@
         "server_layer_name": "r6q_dekad"
       },
       {
+        "id": "rain_anomaly_7month",
+        "title": "7-month rainfall anomaly",
+        "server_layer_name": "r7q_dekad"
+      },
+      {
+        "id": "rain_anomaly_8month",
+        "title": "8-month rainfall anomaly",
+        "server_layer_name": "r8q_dekad"
+      },
+      {
         "id": "rain_anomaly_9month",
         "title": "9-month rainfall anomaly",
         "server_layer_name": "r9q_dekad"
@@ -3654,6 +8120,16 @@
         "server_layer_name": "r6h_dekad"
       },
       {
+        "id": "rainfall_agg_7month",
+        "title": "7-month rainfall aggregate (mm)",
+        "server_layer_name": "r7h_dekad"
+      },
+      {
+        "id": "rainfall_agg_8month",
+        "title": "8-month rainfall aggregate (mm)",
+        "server_layer_name": "r8h_dekad"
+      },
+      {
         "id": "rainfall_agg_9month",
         "title": "9-month rainfall aggregate (mm)",
         "server_layer_name": "r9h_dekad"
@@ -3672,6 +8148,11 @@
         "id": "spi_1y",
         "title": "SPI - 1-year",
         "server_layer_name": "rys_dekad"
+      },
+      {
+        "id": "spi_2m",
+        "title": "SPI - 2-month",
+        "server_layer_name": "r2s_dekad"
       },
       {
         "id": "spi_3m",

--- a/api/prism_app/data/schedule_layer_manifest.json
+++ b/api/prism_app/data/schedule_layer_manifest.json
@@ -2,6 +2,241 @@
   "countries": {
     "afghanistan": [
       {
+        "id": "rain_anomaly_dekad",
+        "title": "10-day rainfall anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rain_anomaly_1month",
+        "title": "Monthly rainfall anomaly",
+        "server_layer_name": "r1q_dekad"
+      },
+      {
+        "id": "rain_anomaly_3month",
+        "title": "3-month rainfall anomaly",
+        "server_layer_name": "r3q_dekad"
+      },
+      {
+        "id": "rainfall_dekad",
+        "title": "10-day rainfall estimate (mm)",
+        "server_layer_name": "rfh_dekad"
+      },
+      {
+        "id": "rainfall_agg_1month",
+        "title": "1-month rainfall aggregate",
+        "server_layer_name": "r1h_dekad"
+      },
+      {
+        "id": "rainfall_agg_3month",
+        "title": "3-month rainfall aggregate (mm)",
+        "server_layer_name": "r3h_dekad"
+      },
+      {
+        "id": "ndvi_dekad",
+        "title": "10-day NDVI (MODIS)",
+        "server_layer_name": "mxd13a2_vim_dekad"
+      },
+      {
+        "id": "ndvi_dekad_anomaly",
+        "title": "10-day NDVI anomaly (MODIS)",
+        "server_layer_name": "mxd13a2_viq_dekad"
+      },
+      {
+        "id": "daily_rainfall_forecast",
+        "title": "Rolling daily rainfall forecast",
+        "server_layer_name": "rfh_daily_forecast"
+      },
+      {
+        "id": "dekad_rainfall_forecast",
+        "title": "10-day rainfall forecast",
+        "server_layer_name": "rfh_dekad_forecast"
+      },
+      {
+        "id": "dekad_rainfall_anomaly_forecast",
+        "title": "10-day rainfall forecast anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rainfall_agg_2month",
+        "title": "2-month rainfall aggregate (mm)",
+        "server_layer_name": "r2h_dekad"
+      },
+      {
+        "id": "rain_anomaly_2month",
+        "title": "2-month rainfall anomaly",
+        "server_layer_name": "r2q_dekad"
+      },
+      {
+        "id": "rainfall_agg_4month",
+        "title": "4-month rainfall aggregate (mm)",
+        "server_layer_name": "r4h_dekad"
+      },
+      {
+        "id": "rain_anomaly_4month",
+        "title": "4-month rainfall anomaly",
+        "server_layer_name": "r4q_dekad"
+      },
+      {
+        "id": "rainfall_agg_5month",
+        "title": "5-month rainfall aggregate (mm)",
+        "server_layer_name": "r5h_dekad"
+      },
+      {
+        "id": "rain_anomaly_5month",
+        "title": "5-month rainfall anomaly",
+        "server_layer_name": "r5q_dekad"
+      },
+      {
+        "id": "rainfall_agg_6month",
+        "title": "6-month rainfall aggregate (mm)",
+        "server_layer_name": "r6h_dekad"
+      },
+      {
+        "id": "rain_anomaly_6month",
+        "title": "6-month rainfall anomaly",
+        "server_layer_name": "r6q_dekad"
+      },
+      {
+        "id": "rainfall_agg_7month",
+        "title": "7-month rainfall aggregate (mm)",
+        "server_layer_name": "r7h_dekad"
+      },
+      {
+        "id": "rain_anomaly_7month",
+        "title": "7-month rainfall anomaly",
+        "server_layer_name": "r7q_dekad"
+      },
+      {
+        "id": "rainfall_agg_8month",
+        "title": "8-month rainfall aggregate (mm)",
+        "server_layer_name": "r8h_dekad"
+      },
+      {
+        "id": "rain_anomaly_8month",
+        "title": "8-month rainfall anomaly",
+        "server_layer_name": "r8q_dekad"
+      },
+      {
+        "id": "rainfall_agg_9month",
+        "title": "9-month rainfall aggregate (mm)",
+        "server_layer_name": "r9h_dekad"
+      },
+      {
+        "id": "rain_anomaly_9month",
+        "title": "9-month rainfall anomaly",
+        "server_layer_name": "r9q_dekad"
+      },
+      {
+        "id": "rainfall_agg_1year",
+        "title": "1-year rainfall aggregate (mm)",
+        "server_layer_name": "ryh_dekad"
+      },
+      {
+        "id": "rain_anomaly_1year",
+        "title": "1-year rainfall anomaly",
+        "server_layer_name": "ryq_dekad"
+      },
+      {
+        "id": "spi_1m",
+        "title": "SPI - 1-month",
+        "server_layer_name": "r1s_dekad"
+      },
+      {
+        "id": "spi_2m",
+        "title": "SPI - 2-month",
+        "server_layer_name": "r2s_dekad"
+      },
+      {
+        "id": "spi_3m",
+        "title": "SPI - 3-month",
+        "server_layer_name": "r3s_dekad"
+      },
+      {
+        "id": "spi_6m",
+        "title": "SPI - 6-month",
+        "server_layer_name": "r6s_dekad"
+      },
+      {
+        "id": "spi_9m",
+        "title": "SPI - 9-month",
+        "server_layer_name": "r9s_dekad"
+      },
+      {
+        "id": "spi_1y",
+        "title": "SPI - 1-year",
+        "server_layer_name": "rys_dekad"
+      },
+      {
+        "id": "days_dry",
+        "title": "Days since last rain",
+        "server_layer_name": "dlc_dekad"
+      },
+      {
+        "id": "streak_dry_days",
+        "title": "Longest dry spell",
+        "server_layer_name": "dlx_dekad"
+      },
+      {
+        "id": "days_heavy_rain",
+        "title": "Number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xnh_dekad"
+      },
+      {
+        "id": "days_intense_rain",
+        "title": "Number of days with intense rainfall in the last 30 days",
+        "server_layer_name": "xni_dekad"
+      },
+      {
+        "id": "days_extreme_rain",
+        "title": "Number of days with extreme rainfall in the last 30 days",
+        "server_layer_name": "xne_dekad"
+      },
+      {
+        "id": "streak_heavy_rain",
+        "title": "Longest consecutive heavy rainfall days",
+        "server_layer_name": "xlh_dekad"
+      },
+      {
+        "id": "streak_intense_rain",
+        "title": "Longest consecutive intense rainfall days",
+        "server_layer_name": "xli_dekad"
+      },
+      {
+        "id": "streak_extreme_rain",
+        "title": "Longest consecutive extreme rainfall days",
+        "server_layer_name": "xle_dekad"
+      },
+      {
+        "id": "lst_amplitude",
+        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
+        "server_layer_name": "myd11a2_taa_dekad"
+      },
+      {
+        "id": "lst_daytime",
+        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_nighttime",
+        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_day_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "monthly_water_anomaly",
+        "title": "Monthly Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_dekad"
+      },
+      {
         "id": "2m_water_anomaly",
         "title": "2-Month Water Anomaly Index (WAI)",
         "server_layer_name": "wai_seasonal_2month"
@@ -25,245 +260,245 @@
         "id": "6m_water_anomaly",
         "title": "6-Month Water Anomaly Index (WAI)",
         "server_layer_name": "wai_seasonal_6month"
-      },
-      {
-        "id": "daily_rainfall_forecast",
-        "title": "Rolling daily rainfall forecast",
-        "server_layer_name": "rfh_daily_forecast"
-      },
-      {
-        "id": "days_dry",
-        "title": "Days since last rain",
-        "server_layer_name": "dlc_dekad"
-      },
-      {
-        "id": "days_extreme_rain",
-        "title": "Number of days with extreme rainfall in the last 30 days",
-        "server_layer_name": "xne_dekad"
-      },
-      {
-        "id": "days_heavy_rain",
-        "title": "Number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xnh_dekad"
-      },
-      {
-        "id": "days_intense_rain",
-        "title": "Number of days with intense rainfall in the last 30 days",
-        "server_layer_name": "xni_dekad"
-      },
-      {
-        "id": "dekad_rainfall_anomaly_forecast",
-        "title": "10-day rainfall forecast anomaly",
-        "server_layer_name": "rfq_dekad"
-      },
-      {
-        "id": "dekad_rainfall_forecast",
-        "title": "10-day rainfall forecast",
-        "server_layer_name": "rfh_dekad_forecast"
-      },
-      {
-        "id": "lst_amplitude",
-        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
-        "server_layer_name": "myd11a2_taa_dekad"
-      },
-      {
-        "id": "lst_anomaly",
-        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_day_anomaly",
-        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_daytime",
-        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "lst_nighttime",
-        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "monthly_water_anomaly",
-        "title": "Monthly Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_dekad"
-      },
-      {
-        "id": "ndvi_dekad",
-        "title": "10-day NDVI (MODIS)",
-        "server_layer_name": "mxd13a2_vim_dekad"
-      },
-      {
-        "id": "ndvi_dekad_anomaly",
-        "title": "10-day NDVI anomaly (MODIS)",
-        "server_layer_name": "mxd13a2_viq_dekad"
-      },
-      {
-        "id": "rain_anomaly_1month",
-        "title": "Monthly rainfall anomaly",
-        "server_layer_name": "r1q_dekad"
-      },
-      {
-        "id": "rain_anomaly_1year",
-        "title": "1-year rainfall anomaly",
-        "server_layer_name": "ryq_dekad"
-      },
-      {
-        "id": "rain_anomaly_2month",
-        "title": "2-month rainfall anomaly",
-        "server_layer_name": "r2q_dekad"
-      },
-      {
-        "id": "rain_anomaly_3month",
-        "title": "3-month rainfall anomaly",
-        "server_layer_name": "r3q_dekad"
-      },
-      {
-        "id": "rain_anomaly_4month",
-        "title": "4-month rainfall anomaly",
-        "server_layer_name": "r4q_dekad"
-      },
-      {
-        "id": "rain_anomaly_5month",
-        "title": "5-month rainfall anomaly",
-        "server_layer_name": "r5q_dekad"
-      },
-      {
-        "id": "rain_anomaly_6month",
-        "title": "6-month rainfall anomaly",
-        "server_layer_name": "r6q_dekad"
-      },
-      {
-        "id": "rain_anomaly_7month",
-        "title": "7-month rainfall anomaly",
-        "server_layer_name": "r7q_dekad"
-      },
-      {
-        "id": "rain_anomaly_8month",
-        "title": "8-month rainfall anomaly",
-        "server_layer_name": "r8q_dekad"
-      },
-      {
-        "id": "rain_anomaly_9month",
-        "title": "9-month rainfall anomaly",
-        "server_layer_name": "r9q_dekad"
-      },
-      {
-        "id": "rain_anomaly_dekad",
-        "title": "10-day rainfall anomaly",
-        "server_layer_name": "rfq_dekad"
-      },
-      {
-        "id": "rainfall_agg_1month",
-        "title": "1-month rainfall aggregate",
-        "server_layer_name": "r1h_dekad"
-      },
-      {
-        "id": "rainfall_agg_1year",
-        "title": "1-year rainfall aggregate (mm)",
-        "server_layer_name": "ryh_dekad"
-      },
-      {
-        "id": "rainfall_agg_2month",
-        "title": "2-month rainfall aggregate (mm)",
-        "server_layer_name": "r2h_dekad"
-      },
-      {
-        "id": "rainfall_agg_3month",
-        "title": "3-month rainfall aggregate (mm)",
-        "server_layer_name": "r3h_dekad"
-      },
-      {
-        "id": "rainfall_agg_4month",
-        "title": "4-month rainfall aggregate (mm)",
-        "server_layer_name": "r4h_dekad"
-      },
-      {
-        "id": "rainfall_agg_5month",
-        "title": "5-month rainfall aggregate (mm)",
-        "server_layer_name": "r5h_dekad"
-      },
-      {
-        "id": "rainfall_agg_6month",
-        "title": "6-month rainfall aggregate (mm)",
-        "server_layer_name": "r6h_dekad"
-      },
-      {
-        "id": "rainfall_agg_7month",
-        "title": "7-month rainfall aggregate (mm)",
-        "server_layer_name": "r7h_dekad"
-      },
-      {
-        "id": "rainfall_agg_8month",
-        "title": "8-month rainfall aggregate (mm)",
-        "server_layer_name": "r8h_dekad"
-      },
-      {
-        "id": "rainfall_agg_9month",
-        "title": "9-month rainfall aggregate (mm)",
-        "server_layer_name": "r9h_dekad"
-      },
-      {
-        "id": "rainfall_dekad",
-        "title": "10-day rainfall estimate (mm)",
-        "server_layer_name": "rfh_dekad"
-      },
-      {
-        "id": "spi_1m",
-        "title": "SPI - 1-month",
-        "server_layer_name": "r1s_dekad"
-      },
-      {
-        "id": "spi_1y",
-        "title": "SPI - 1-year",
-        "server_layer_name": "rys_dekad"
-      },
-      {
-        "id": "spi_2m",
-        "title": "SPI - 2-month",
-        "server_layer_name": "r2s_dekad"
-      },
-      {
-        "id": "spi_3m",
-        "title": "SPI - 3-month",
-        "server_layer_name": "r3s_dekad"
-      },
-      {
-        "id": "spi_6m",
-        "title": "SPI - 6-month",
-        "server_layer_name": "r6s_dekad"
-      },
-      {
-        "id": "spi_9m",
-        "title": "SPI - 9-month",
-        "server_layer_name": "r9s_dekad"
-      },
-      {
-        "id": "streak_dry_days",
-        "title": "Longest dry spell",
-        "server_layer_name": "dlx_dekad"
-      },
-      {
-        "id": "streak_extreme_rain",
-        "title": "Longest consecutive extreme rainfall days",
-        "server_layer_name": "xle_dekad"
-      },
-      {
-        "id": "streak_heavy_rain",
-        "title": "Longest consecutive heavy rainfall days",
-        "server_layer_name": "xlh_dekad"
-      },
-      {
-        "id": "streak_intense_rain",
-        "title": "Longest consecutive intense rainfall days",
-        "server_layer_name": "xli_dekad"
       }
     ],
     "bhutan": [
       {
+        "id": "rainfall_dekad",
+        "title": "10-day rainfall estimate (mm)",
+        "server_layer_name": "rfh_dekad"
+      },
+      {
+        "id": "rain_anomaly_dekad",
+        "title": "10-day rainfall anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rainfall_agg_1month",
+        "title": "1-month rainfall aggregate",
+        "server_layer_name": "r1h_dekad"
+      },
+      {
+        "id": "rain_anomaly_1month",
+        "title": "Monthly rainfall anomaly",
+        "server_layer_name": "r1q_dekad"
+      },
+      {
+        "id": "rainfall_agg_3month",
+        "title": "3-month rainfall aggregate (mm)",
+        "server_layer_name": "r3h_dekad"
+      },
+      {
+        "id": "rain_anomaly_3month",
+        "title": "3-month rainfall anomaly",
+        "server_layer_name": "r3q_dekad"
+      },
+      {
+        "id": "ndvi_dekad",
+        "title": "10-day NDVI (MODIS)",
+        "server_layer_name": "mxd13a2_vim_dekad"
+      },
+      {
+        "id": "ndvi_dekad_anomaly",
+        "title": "10-day NDVI anomaly (MODIS)",
+        "server_layer_name": "mxd13a2_viq_dekad"
+      },
+      {
+        "id": "daily_rainfall_forecast",
+        "title": "Rolling daily rainfall forecast",
+        "server_layer_name": "rfh_daily_forecast"
+      },
+      {
+        "id": "dekad_rainfall_forecast",
+        "title": "10-day rainfall forecast",
+        "server_layer_name": "rfh_dekad_forecast"
+      },
+      {
+        "id": "dekad_rainfall_anomaly_forecast",
+        "title": "10-day rainfall forecast anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rainfall_agg_2month",
+        "title": "2-month rainfall aggregate (mm)",
+        "server_layer_name": "r2h_dekad"
+      },
+      {
+        "id": "rain_anomaly_2month",
+        "title": "2-month rainfall anomaly",
+        "server_layer_name": "r2q_dekad"
+      },
+      {
+        "id": "rainfall_agg_4month",
+        "title": "4-month rainfall aggregate (mm)",
+        "server_layer_name": "r4h_dekad"
+      },
+      {
+        "id": "rain_anomaly_4month",
+        "title": "4-month rainfall anomaly",
+        "server_layer_name": "r4q_dekad"
+      },
+      {
+        "id": "rainfall_agg_5month",
+        "title": "5-month rainfall aggregate (mm)",
+        "server_layer_name": "r5h_dekad"
+      },
+      {
+        "id": "rain_anomaly_5month",
+        "title": "5-month rainfall anomaly",
+        "server_layer_name": "r5q_dekad"
+      },
+      {
+        "id": "rainfall_agg_6month",
+        "title": "6-month rainfall aggregate (mm)",
+        "server_layer_name": "r6h_dekad"
+      },
+      {
+        "id": "rain_anomaly_6month",
+        "title": "6-month rainfall anomaly",
+        "server_layer_name": "r6q_dekad"
+      },
+      {
+        "id": "rainfall_agg_7month",
+        "title": "7-month rainfall aggregate (mm)",
+        "server_layer_name": "r7h_dekad"
+      },
+      {
+        "id": "rain_anomaly_7month",
+        "title": "7-month rainfall anomaly",
+        "server_layer_name": "r7q_dekad"
+      },
+      {
+        "id": "rainfall_agg_8month",
+        "title": "8-month rainfall aggregate (mm)",
+        "server_layer_name": "r8h_dekad"
+      },
+      {
+        "id": "rain_anomaly_8month",
+        "title": "8-month rainfall anomaly",
+        "server_layer_name": "r8q_dekad"
+      },
+      {
+        "id": "rainfall_agg_9month",
+        "title": "9-month rainfall aggregate (mm)",
+        "server_layer_name": "r9h_dekad"
+      },
+      {
+        "id": "rain_anomaly_9month",
+        "title": "9-month rainfall anomaly",
+        "server_layer_name": "r9q_dekad"
+      },
+      {
+        "id": "rainfall_agg_1year",
+        "title": "1-year rainfall aggregate (mm)",
+        "server_layer_name": "ryh_dekad"
+      },
+      {
+        "id": "rain_anomaly_1year",
+        "title": "1-year rainfall anomaly",
+        "server_layer_name": "ryq_dekad"
+      },
+      {
+        "id": "spi_1m",
+        "title": "SPI - 1-month",
+        "server_layer_name": "r1s_dekad"
+      },
+      {
+        "id": "spi_2m",
+        "title": "SPI - 2-month",
+        "server_layer_name": "r2s_dekad"
+      },
+      {
+        "id": "spi_3m",
+        "title": "SPI - 3-month",
+        "server_layer_name": "r3s_dekad"
+      },
+      {
+        "id": "spi_6m",
+        "title": "SPI - 6-month",
+        "server_layer_name": "r6s_dekad"
+      },
+      {
+        "id": "spi_9m",
+        "title": "SPI - 9-month",
+        "server_layer_name": "r9s_dekad"
+      },
+      {
+        "id": "spi_1y",
+        "title": "SPI - 1-year",
+        "server_layer_name": "rys_dekad"
+      },
+      {
+        "id": "days_dry",
+        "title": "Days since last rain",
+        "server_layer_name": "dlc_dekad"
+      },
+      {
+        "id": "streak_dry_days",
+        "title": "Longest dry spell",
+        "server_layer_name": "dlx_dekad"
+      },
+      {
+        "id": "days_heavy_rain",
+        "title": "Number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xnh_dekad"
+      },
+      {
+        "id": "days_intense_rain",
+        "title": "Number of days with intense rainfall in the last 30 days",
+        "server_layer_name": "xni_dekad"
+      },
+      {
+        "id": "days_extreme_rain",
+        "title": "Number of days with extreme rainfall in the last 30 days",
+        "server_layer_name": "xne_dekad"
+      },
+      {
+        "id": "streak_heavy_rain",
+        "title": "Longest consecutive heavy rainfall days",
+        "server_layer_name": "xlh_dekad"
+      },
+      {
+        "id": "streak_intense_rain",
+        "title": "Longest consecutive intense rainfall days",
+        "server_layer_name": "xli_dekad"
+      },
+      {
+        "id": "streak_extreme_rain",
+        "title": "Longest consecutive extreme rainfall days",
+        "server_layer_name": "xle_dekad"
+      },
+      {
+        "id": "lst_amplitude",
+        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
+        "server_layer_name": "myd11a2_taa_dekad"
+      },
+      {
+        "id": "lst_daytime",
+        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_nighttime",
+        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_day_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "monthly_water_anomaly",
+        "title": "Monthly Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_dekad"
+      },
+      {
         "id": "2m_water_anomaly",
         "title": "2-Month Water Anomaly Index (WAI)",
         "server_layer_name": "wai_seasonal_2month"
@@ -287,245 +522,245 @@
         "id": "6m_water_anomaly",
         "title": "6-Month Water Anomaly Index (WAI)",
         "server_layer_name": "wai_seasonal_6month"
-      },
-      {
-        "id": "daily_rainfall_forecast",
-        "title": "Rolling daily rainfall forecast",
-        "server_layer_name": "rfh_daily_forecast"
-      },
-      {
-        "id": "days_dry",
-        "title": "Days since last rain",
-        "server_layer_name": "dlc_dekad"
-      },
-      {
-        "id": "days_extreme_rain",
-        "title": "Number of days with extreme rainfall in the last 30 days",
-        "server_layer_name": "xne_dekad"
-      },
-      {
-        "id": "days_heavy_rain",
-        "title": "Number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xnh_dekad"
-      },
-      {
-        "id": "days_intense_rain",
-        "title": "Number of days with intense rainfall in the last 30 days",
-        "server_layer_name": "xni_dekad"
-      },
-      {
-        "id": "dekad_rainfall_anomaly_forecast",
-        "title": "10-day rainfall forecast anomaly",
-        "server_layer_name": "rfq_dekad"
-      },
-      {
-        "id": "dekad_rainfall_forecast",
-        "title": "10-day rainfall forecast",
-        "server_layer_name": "rfh_dekad_forecast"
-      },
-      {
-        "id": "lst_amplitude",
-        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
-        "server_layer_name": "myd11a2_taa_dekad"
-      },
-      {
-        "id": "lst_anomaly",
-        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_day_anomaly",
-        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_daytime",
-        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "lst_nighttime",
-        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "monthly_water_anomaly",
-        "title": "Monthly Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_dekad"
-      },
-      {
-        "id": "ndvi_dekad",
-        "title": "10-day NDVI (MODIS)",
-        "server_layer_name": "mxd13a2_vim_dekad"
-      },
-      {
-        "id": "ndvi_dekad_anomaly",
-        "title": "10-day NDVI anomaly (MODIS)",
-        "server_layer_name": "mxd13a2_viq_dekad"
-      },
-      {
-        "id": "rain_anomaly_1month",
-        "title": "Monthly rainfall anomaly",
-        "server_layer_name": "r1q_dekad"
-      },
-      {
-        "id": "rain_anomaly_1year",
-        "title": "1-year rainfall anomaly",
-        "server_layer_name": "ryq_dekad"
-      },
-      {
-        "id": "rain_anomaly_2month",
-        "title": "2-month rainfall anomaly",
-        "server_layer_name": "r2q_dekad"
-      },
-      {
-        "id": "rain_anomaly_3month",
-        "title": "3-month rainfall anomaly",
-        "server_layer_name": "r3q_dekad"
-      },
-      {
-        "id": "rain_anomaly_4month",
-        "title": "4-month rainfall anomaly",
-        "server_layer_name": "r4q_dekad"
-      },
-      {
-        "id": "rain_anomaly_5month",
-        "title": "5-month rainfall anomaly",
-        "server_layer_name": "r5q_dekad"
-      },
-      {
-        "id": "rain_anomaly_6month",
-        "title": "6-month rainfall anomaly",
-        "server_layer_name": "r6q_dekad"
-      },
-      {
-        "id": "rain_anomaly_7month",
-        "title": "7-month rainfall anomaly",
-        "server_layer_name": "r7q_dekad"
-      },
-      {
-        "id": "rain_anomaly_8month",
-        "title": "8-month rainfall anomaly",
-        "server_layer_name": "r8q_dekad"
-      },
-      {
-        "id": "rain_anomaly_9month",
-        "title": "9-month rainfall anomaly",
-        "server_layer_name": "r9q_dekad"
-      },
-      {
-        "id": "rain_anomaly_dekad",
-        "title": "10-day rainfall anomaly",
-        "server_layer_name": "rfq_dekad"
-      },
-      {
-        "id": "rainfall_agg_1month",
-        "title": "1-month rainfall aggregate",
-        "server_layer_name": "r1h_dekad"
-      },
-      {
-        "id": "rainfall_agg_1year",
-        "title": "1-year rainfall aggregate (mm)",
-        "server_layer_name": "ryh_dekad"
-      },
-      {
-        "id": "rainfall_agg_2month",
-        "title": "2-month rainfall aggregate (mm)",
-        "server_layer_name": "r2h_dekad"
-      },
-      {
-        "id": "rainfall_agg_3month",
-        "title": "3-month rainfall aggregate (mm)",
-        "server_layer_name": "r3h_dekad"
-      },
-      {
-        "id": "rainfall_agg_4month",
-        "title": "4-month rainfall aggregate (mm)",
-        "server_layer_name": "r4h_dekad"
-      },
-      {
-        "id": "rainfall_agg_5month",
-        "title": "5-month rainfall aggregate (mm)",
-        "server_layer_name": "r5h_dekad"
-      },
-      {
-        "id": "rainfall_agg_6month",
-        "title": "6-month rainfall aggregate (mm)",
-        "server_layer_name": "r6h_dekad"
-      },
-      {
-        "id": "rainfall_agg_7month",
-        "title": "7-month rainfall aggregate (mm)",
-        "server_layer_name": "r7h_dekad"
-      },
-      {
-        "id": "rainfall_agg_8month",
-        "title": "8-month rainfall aggregate (mm)",
-        "server_layer_name": "r8h_dekad"
-      },
-      {
-        "id": "rainfall_agg_9month",
-        "title": "9-month rainfall aggregate (mm)",
-        "server_layer_name": "r9h_dekad"
-      },
-      {
-        "id": "rainfall_dekad",
-        "title": "10-day rainfall estimate (mm)",
-        "server_layer_name": "rfh_dekad"
-      },
-      {
-        "id": "spi_1m",
-        "title": "SPI - 1-month",
-        "server_layer_name": "r1s_dekad"
-      },
-      {
-        "id": "spi_1y",
-        "title": "SPI - 1-year",
-        "server_layer_name": "rys_dekad"
-      },
-      {
-        "id": "spi_2m",
-        "title": "SPI - 2-month",
-        "server_layer_name": "r2s_dekad"
-      },
-      {
-        "id": "spi_3m",
-        "title": "SPI - 3-month",
-        "server_layer_name": "r3s_dekad"
-      },
-      {
-        "id": "spi_6m",
-        "title": "SPI - 6-month",
-        "server_layer_name": "r6s_dekad"
-      },
-      {
-        "id": "spi_9m",
-        "title": "SPI - 9-month",
-        "server_layer_name": "r9s_dekad"
-      },
-      {
-        "id": "streak_dry_days",
-        "title": "Longest dry spell",
-        "server_layer_name": "dlx_dekad"
-      },
-      {
-        "id": "streak_extreme_rain",
-        "title": "Longest consecutive extreme rainfall days",
-        "server_layer_name": "xle_dekad"
-      },
-      {
-        "id": "streak_heavy_rain",
-        "title": "Longest consecutive heavy rainfall days",
-        "server_layer_name": "xlh_dekad"
-      },
-      {
-        "id": "streak_intense_rain",
-        "title": "Longest consecutive intense rainfall days",
-        "server_layer_name": "xli_dekad"
       }
     ],
     "cambodia": [
       {
+        "id": "rainfall_dekad",
+        "title": "10-day rainfall estimate (mm)",
+        "server_layer_name": "rfh_dekad"
+      },
+      {
+        "id": "rain_anomaly_dekad",
+        "title": "10-day rainfall anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rain_anomaly_1month",
+        "title": "Monthly rainfall anomaly",
+        "server_layer_name": "r1q_dekad"
+      },
+      {
+        "id": "rain_anomaly_3month",
+        "title": "3-month rainfall anomaly",
+        "server_layer_name": "r3q_dekad"
+      },
+      {
+        "id": "rain_anomaly_6month",
+        "title": "6-month rainfall anomaly",
+        "server_layer_name": "r6q_dekad"
+      },
+      {
+        "id": "rain_anomaly_9month",
+        "title": "9-month rainfall anomaly",
+        "server_layer_name": "r9q_dekad"
+      },
+      {
+        "id": "rain_anomaly_1year",
+        "title": "1-year rainfall anomaly",
+        "server_layer_name": "ryq_dekad"
+      },
+      {
+        "id": "rainfall_agg_1month",
+        "title": "1-month rainfall aggregate",
+        "server_layer_name": "r1h_dekad"
+      },
+      {
+        "id": "rainfall_agg_3month",
+        "title": "3-month rainfall aggregate (mm)",
+        "server_layer_name": "r3h_dekad"
+      },
+      {
+        "id": "rainfall_agg_6month",
+        "title": "6-month rainfall aggregate (mm)",
+        "server_layer_name": "r6h_dekad"
+      },
+      {
+        "id": "rainfall_agg_9month",
+        "title": "9-month rainfall aggregate (mm)",
+        "server_layer_name": "r9h_dekad"
+      },
+      {
+        "id": "rainfall_agg_1year",
+        "title": "1-year rainfall aggregate (mm)",
+        "server_layer_name": "ryh_dekad"
+      },
+      {
+        "id": "spi_1m",
+        "title": "SPI - 1-month",
+        "server_layer_name": "r1s_dekad"
+      },
+      {
+        "id": "spi_3m",
+        "title": "SPI - 3-month",
+        "server_layer_name": "r3s_dekad"
+      },
+      {
+        "id": "spi_6m",
+        "title": "SPI - 6-month",
+        "server_layer_name": "r6s_dekad"
+      },
+      {
+        "id": "spi_9m",
+        "title": "SPI - 9-month",
+        "server_layer_name": "r9s_dekad"
+      },
+      {
+        "id": "spi_1y",
+        "title": "SPI - 1-year",
+        "server_layer_name": "rys_dekad"
+      },
+      {
+        "id": "days_dry",
+        "title": "Days since last rain",
+        "server_layer_name": "dlc_dekad"
+      },
+      {
+        "id": "streak_dry_days",
+        "title": "Longest number of consecutive dry days",
+        "server_layer_name": "dlx_dekad"
+      },
+      {
+        "id": "days_heavy_rain",
+        "title": "Number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xnh_dekad"
+      },
+      {
+        "id": "days_intense_rain",
+        "title": "Number of days with intense rainfall in the last 30 days",
+        "server_layer_name": "xni_dekad"
+      },
+      {
+        "id": "days_extreme_rain",
+        "title": "Number of days with extreme rainfall in the last 30 days",
+        "server_layer_name": "xne_dekad"
+      },
+      {
+        "id": "streak_heavy_rain",
+        "title": "Longest consecutive number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xlh_dekad"
+      },
+      {
+        "id": "streak_intense_rain",
+        "title": "Longest consecutive intense rainfall days",
+        "server_layer_name": "xli_dekad"
+      },
+      {
+        "id": "streak_extreme_rain",
+        "title": "Longest consecutive extreme rainfall days",
+        "server_layer_name": "xle_dekad"
+      },
+      {
+        "id": "ndvi_dekad",
+        "title": "10-day NDVI (MODIS)",
+        "server_layer_name": "mxd13a2_vim_dekad"
+      },
+      {
+        "id": "ndvi_dekad_anomaly",
+        "title": "10-day NDVI anomaly (MODIS)",
+        "server_layer_name": "mxd13a2_viq_dekad"
+      },
+      {
+        "id": "lst_amplitude",
+        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
+        "server_layer_name": "myd11a2_taa_dekad"
+      },
+      {
+        "id": "lst_daytime",
+        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_anomaly",
+        "title": "Daytime Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "daily_rainfall_forecast",
+        "title": "Rolling daily rainfall forecast",
+        "server_layer_name": "rfh_daily_forecast"
+      },
+      {
+        "id": "dekad_rainfall_forecast",
+        "title": "10-day rainfall forecast",
+        "server_layer_name": "rfh_dekad_forecast"
+      },
+      {
+        "id": "dekad_rainfall_anomaly_forecast",
+        "title": "10-day rainfall forecast anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rainfall_agg_2month",
+        "title": "2-month rainfall aggregate (mm)",
+        "server_layer_name": "r2h_dekad"
+      },
+      {
+        "id": "rain_anomaly_2month",
+        "title": "2-month rainfall anomaly",
+        "server_layer_name": "r2q_dekad"
+      },
+      {
+        "id": "rainfall_agg_4month",
+        "title": "4-month rainfall aggregate (mm)",
+        "server_layer_name": "r4h_dekad"
+      },
+      {
+        "id": "rain_anomaly_4month",
+        "title": "4-month rainfall anomaly",
+        "server_layer_name": "r4q_dekad"
+      },
+      {
+        "id": "rainfall_agg_5month",
+        "title": "5-month rainfall aggregate (mm)",
+        "server_layer_name": "r5h_dekad"
+      },
+      {
+        "id": "rain_anomaly_5month",
+        "title": "5-month rainfall anomaly",
+        "server_layer_name": "r5q_dekad"
+      },
+      {
+        "id": "rainfall_agg_7month",
+        "title": "7-month rainfall aggregate (mm)",
+        "server_layer_name": "r7h_dekad"
+      },
+      {
+        "id": "rain_anomaly_7month",
+        "title": "7-month rainfall anomaly",
+        "server_layer_name": "r7q_dekad"
+      },
+      {
+        "id": "rainfall_agg_8month",
+        "title": "8-month rainfall aggregate (mm)",
+        "server_layer_name": "r8h_dekad"
+      },
+      {
+        "id": "rain_anomaly_8month",
+        "title": "8-month rainfall anomaly",
+        "server_layer_name": "r8q_dekad"
+      },
+      {
+        "id": "spi_2m",
+        "title": "SPI - 2-month",
+        "server_layer_name": "r2s_dekad"
+      },
+      {
+        "id": "lst_nighttime",
+        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_day_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "monthly_water_anomaly",
+        "title": "Monthly Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_dekad"
+      },
+      {
         "id": "2m_water_anomaly",
         "title": "2-Month Water Anomaly Index (WAI)",
         "server_layer_name": "wai_seasonal_2month"
@@ -549,245 +784,245 @@
         "id": "6m_water_anomaly",
         "title": "6-Month Water Anomaly Index (WAI)",
         "server_layer_name": "wai_seasonal_6month"
-      },
-      {
-        "id": "daily_rainfall_forecast",
-        "title": "Rolling daily rainfall forecast",
-        "server_layer_name": "rfh_daily_forecast"
-      },
-      {
-        "id": "days_dry",
-        "title": "Days since last rain",
-        "server_layer_name": "dlc_dekad"
-      },
-      {
-        "id": "days_extreme_rain",
-        "title": "Number of days with extreme rainfall in the last 30 days",
-        "server_layer_name": "xne_dekad"
-      },
-      {
-        "id": "days_heavy_rain",
-        "title": "Number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xnh_dekad"
-      },
-      {
-        "id": "days_intense_rain",
-        "title": "Number of days with intense rainfall in the last 30 days",
-        "server_layer_name": "xni_dekad"
-      },
-      {
-        "id": "dekad_rainfall_anomaly_forecast",
-        "title": "10-day rainfall forecast anomaly",
-        "server_layer_name": "rfq_dekad"
-      },
-      {
-        "id": "dekad_rainfall_forecast",
-        "title": "10-day rainfall forecast",
-        "server_layer_name": "rfh_dekad_forecast"
-      },
-      {
-        "id": "lst_amplitude",
-        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
-        "server_layer_name": "myd11a2_taa_dekad"
-      },
-      {
-        "id": "lst_anomaly",
-        "title": "Daytime Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_day_anomaly",
-        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_daytime",
-        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "lst_nighttime",
-        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "monthly_water_anomaly",
-        "title": "Monthly Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_dekad"
-      },
-      {
-        "id": "ndvi_dekad",
-        "title": "10-day NDVI (MODIS)",
-        "server_layer_name": "mxd13a2_vim_dekad"
-      },
-      {
-        "id": "ndvi_dekad_anomaly",
-        "title": "10-day NDVI anomaly (MODIS)",
-        "server_layer_name": "mxd13a2_viq_dekad"
-      },
-      {
-        "id": "rain_anomaly_1month",
-        "title": "Monthly rainfall anomaly",
-        "server_layer_name": "r1q_dekad"
-      },
-      {
-        "id": "rain_anomaly_1year",
-        "title": "1-year rainfall anomaly",
-        "server_layer_name": "ryq_dekad"
-      },
-      {
-        "id": "rain_anomaly_2month",
-        "title": "2-month rainfall anomaly",
-        "server_layer_name": "r2q_dekad"
-      },
-      {
-        "id": "rain_anomaly_3month",
-        "title": "3-month rainfall anomaly",
-        "server_layer_name": "r3q_dekad"
-      },
-      {
-        "id": "rain_anomaly_4month",
-        "title": "4-month rainfall anomaly",
-        "server_layer_name": "r4q_dekad"
-      },
-      {
-        "id": "rain_anomaly_5month",
-        "title": "5-month rainfall anomaly",
-        "server_layer_name": "r5q_dekad"
-      },
-      {
-        "id": "rain_anomaly_6month",
-        "title": "6-month rainfall anomaly",
-        "server_layer_name": "r6q_dekad"
-      },
-      {
-        "id": "rain_anomaly_7month",
-        "title": "7-month rainfall anomaly",
-        "server_layer_name": "r7q_dekad"
-      },
-      {
-        "id": "rain_anomaly_8month",
-        "title": "8-month rainfall anomaly",
-        "server_layer_name": "r8q_dekad"
-      },
-      {
-        "id": "rain_anomaly_9month",
-        "title": "9-month rainfall anomaly",
-        "server_layer_name": "r9q_dekad"
-      },
-      {
-        "id": "rain_anomaly_dekad",
-        "title": "10-day rainfall anomaly",
-        "server_layer_name": "rfq_dekad"
-      },
-      {
-        "id": "rainfall_agg_1month",
-        "title": "1-month rainfall aggregate",
-        "server_layer_name": "r1h_dekad"
-      },
-      {
-        "id": "rainfall_agg_1year",
-        "title": "1-year rainfall aggregate (mm)",
-        "server_layer_name": "ryh_dekad"
-      },
-      {
-        "id": "rainfall_agg_2month",
-        "title": "2-month rainfall aggregate (mm)",
-        "server_layer_name": "r2h_dekad"
-      },
-      {
-        "id": "rainfall_agg_3month",
-        "title": "3-month rainfall aggregate (mm)",
-        "server_layer_name": "r3h_dekad"
-      },
-      {
-        "id": "rainfall_agg_4month",
-        "title": "4-month rainfall aggregate (mm)",
-        "server_layer_name": "r4h_dekad"
-      },
-      {
-        "id": "rainfall_agg_5month",
-        "title": "5-month rainfall aggregate (mm)",
-        "server_layer_name": "r5h_dekad"
-      },
-      {
-        "id": "rainfall_agg_6month",
-        "title": "6-month rainfall aggregate (mm)",
-        "server_layer_name": "r6h_dekad"
-      },
-      {
-        "id": "rainfall_agg_7month",
-        "title": "7-month rainfall aggregate (mm)",
-        "server_layer_name": "r7h_dekad"
-      },
-      {
-        "id": "rainfall_agg_8month",
-        "title": "8-month rainfall aggregate (mm)",
-        "server_layer_name": "r8h_dekad"
-      },
-      {
-        "id": "rainfall_agg_9month",
-        "title": "9-month rainfall aggregate (mm)",
-        "server_layer_name": "r9h_dekad"
-      },
-      {
-        "id": "rainfall_dekad",
-        "title": "10-day rainfall estimate (mm)",
-        "server_layer_name": "rfh_dekad"
-      },
-      {
-        "id": "spi_1m",
-        "title": "SPI - 1-month",
-        "server_layer_name": "r1s_dekad"
-      },
-      {
-        "id": "spi_1y",
-        "title": "SPI - 1-year",
-        "server_layer_name": "rys_dekad"
-      },
-      {
-        "id": "spi_2m",
-        "title": "SPI - 2-month",
-        "server_layer_name": "r2s_dekad"
-      },
-      {
-        "id": "spi_3m",
-        "title": "SPI - 3-month",
-        "server_layer_name": "r3s_dekad"
-      },
-      {
-        "id": "spi_6m",
-        "title": "SPI - 6-month",
-        "server_layer_name": "r6s_dekad"
-      },
-      {
-        "id": "spi_9m",
-        "title": "SPI - 9-month",
-        "server_layer_name": "r9s_dekad"
-      },
-      {
-        "id": "streak_dry_days",
-        "title": "Longest number of consecutive dry days",
-        "server_layer_name": "dlx_dekad"
-      },
-      {
-        "id": "streak_extreme_rain",
-        "title": "Longest consecutive extreme rainfall days",
-        "server_layer_name": "xle_dekad"
-      },
-      {
-        "id": "streak_heavy_rain",
-        "title": "Longest consecutive number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xlh_dekad"
-      },
-      {
-        "id": "streak_intense_rain",
-        "title": "Longest consecutive intense rainfall days",
-        "server_layer_name": "xli_dekad"
       }
     ],
     "cameroon": [
       {
+        "id": "spi_1m",
+        "title": "SPI - 1-month",
+        "server_layer_name": "r1s_dekad"
+      },
+      {
+        "id": "spi_3m",
+        "title": "SPI - 3-month",
+        "server_layer_name": "r3s_dekad"
+      },
+      {
+        "id": "spi_6m",
+        "title": "SPI - 6-month",
+        "server_layer_name": "r6s_dekad"
+      },
+      {
+        "id": "spi_9m",
+        "title": "SPI - 9-month",
+        "server_layer_name": "r9s_dekad"
+      },
+      {
+        "id": "spi_1y",
+        "title": "SPI - 1-year",
+        "server_layer_name": "rys_dekad"
+      },
+      {
+        "id": "rainfall_dekad",
+        "title": "10-day rainfall estimate (mm)",
+        "server_layer_name": "rfh_dekad"
+      },
+      {
+        "id": "rain_anomaly_dekad",
+        "title": "10-day rainfall anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rain_anomaly_1month",
+        "title": "Monthly rainfall anomaly",
+        "server_layer_name": "r1q_dekad"
+      },
+      {
+        "id": "rain_anomaly_3month",
+        "title": "3-month rainfall anomaly",
+        "server_layer_name": "r3q_dekad"
+      },
+      {
+        "id": "rain_anomaly_6month",
+        "title": "6-month rainfall anomaly",
+        "server_layer_name": "r6q_dekad"
+      },
+      {
+        "id": "rain_anomaly_9month",
+        "title": "9-month rainfall anomaly",
+        "server_layer_name": "r9q_dekad"
+      },
+      {
+        "id": "rain_anomaly_1year",
+        "title": "1-year rainfall anomaly",
+        "server_layer_name": "ryq_dekad"
+      },
+      {
+        "id": "rainfall_agg_1month",
+        "title": "1-month rainfall aggregate (mm)",
+        "server_layer_name": "r1h_dekad"
+      },
+      {
+        "id": "rainfall_agg_3month",
+        "title": "3-month rainfall aggregate (mm)",
+        "server_layer_name": "r3h_dekad"
+      },
+      {
+        "id": "rainfall_agg_6month",
+        "title": "6-month rainfall aggregate (mm)",
+        "server_layer_name": "r6h_dekad"
+      },
+      {
+        "id": "rainfall_agg_9month",
+        "title": "9-month rainfall aggregate (mm)",
+        "server_layer_name": "r9h_dekad"
+      },
+      {
+        "id": "rainfall_agg_1year",
+        "title": "1-year rainfall aggregate (mm)",
+        "server_layer_name": "ryh_dekad"
+      },
+      {
+        "id": "days_dry",
+        "title": "Days since last rain",
+        "server_layer_name": "dlc_dekad"
+      },
+      {
+        "id": "streak_dry_days",
+        "title": "Longest number of consecutive dry days",
+        "server_layer_name": "dlx_dekad"
+      },
+      {
+        "id": "days_heavy_rain",
+        "title": "Number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xnh_dekad"
+      },
+      {
+        "id": "days_intense_rain",
+        "title": "Number of days with intense rainfall in the last 30 days",
+        "server_layer_name": "xni_dekad"
+      },
+      {
+        "id": "days_extreme_rain",
+        "title": "Number of days with extreme rainfall in the last 30 days",
+        "server_layer_name": "xne_dekad"
+      },
+      {
+        "id": "streak_heavy_rain",
+        "title": "Longest consecutive number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xlh_dekad"
+      },
+      {
+        "id": "streak_intense_rain",
+        "title": "Longest consecutive intense rainfall days",
+        "server_layer_name": "xli_dekad"
+      },
+      {
+        "id": "streak_extreme_rain",
+        "title": "Longest consecutive extreme rainfall days",
+        "server_layer_name": "xle_dekad"
+      },
+      {
+        "id": "ndvi_dekad",
+        "title": "10-day NDVI (MODIS)",
+        "server_layer_name": "mxd13a2_vim_dekad"
+      },
+      {
+        "id": "ndvi_dekad_anomaly",
+        "title": "10-day NDVI anomaly (MODIS)",
+        "server_layer_name": "mxd13a2_viq_dekad"
+      },
+      {
+        "id": "lst_amplitude",
+        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
+        "server_layer_name": "myd11a2_taa_dekad"
+      },
+      {
+        "id": "lst_daytime",
+        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "daily_rainfall_forecast",
+        "title": "Rolling daily rainfall forecast",
+        "server_layer_name": "rfh_daily_forecast"
+      },
+      {
+        "id": "dekad_rainfall_forecast",
+        "title": "10-day rainfall forecast",
+        "server_layer_name": "rfh_dekad_forecast"
+      },
+      {
+        "id": "dekad_rainfall_anomaly_forecast",
+        "title": "10-day rainfall forecast anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rainfall_agg_2month",
+        "title": "2-month rainfall aggregate (mm)",
+        "server_layer_name": "r2h_dekad"
+      },
+      {
+        "id": "rain_anomaly_2month",
+        "title": "2-month rainfall anomaly",
+        "server_layer_name": "r2q_dekad"
+      },
+      {
+        "id": "rainfall_agg_4month",
+        "title": "4-month rainfall aggregate (mm)",
+        "server_layer_name": "r4h_dekad"
+      },
+      {
+        "id": "rain_anomaly_4month",
+        "title": "4-month rainfall anomaly",
+        "server_layer_name": "r4q_dekad"
+      },
+      {
+        "id": "rainfall_agg_5month",
+        "title": "5-month rainfall aggregate (mm)",
+        "server_layer_name": "r5h_dekad"
+      },
+      {
+        "id": "rain_anomaly_5month",
+        "title": "5-month rainfall anomaly",
+        "server_layer_name": "r5q_dekad"
+      },
+      {
+        "id": "rainfall_agg_7month",
+        "title": "7-month rainfall aggregate (mm)",
+        "server_layer_name": "r7h_dekad"
+      },
+      {
+        "id": "rain_anomaly_7month",
+        "title": "7-month rainfall anomaly",
+        "server_layer_name": "r7q_dekad"
+      },
+      {
+        "id": "rainfall_agg_8month",
+        "title": "8-month rainfall aggregate (mm)",
+        "server_layer_name": "r8h_dekad"
+      },
+      {
+        "id": "rain_anomaly_8month",
+        "title": "8-month rainfall anomaly",
+        "server_layer_name": "r8q_dekad"
+      },
+      {
+        "id": "spi_2m",
+        "title": "SPI - 2-month",
+        "server_layer_name": "r2s_dekad"
+      },
+      {
+        "id": "lst_nighttime",
+        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_day_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "monthly_water_anomaly",
+        "title": "Monthly Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_dekad"
+      },
+      {
         "id": "2m_water_anomaly",
         "title": "2-Month Water Anomaly Index (WAI)",
         "server_layer_name": "wai_seasonal_2month"
@@ -811,245 +1046,245 @@
         "id": "6m_water_anomaly",
         "title": "6-Month Water Anomaly Index (WAI)",
         "server_layer_name": "wai_seasonal_6month"
-      },
-      {
-        "id": "daily_rainfall_forecast",
-        "title": "Rolling daily rainfall forecast",
-        "server_layer_name": "rfh_daily_forecast"
-      },
-      {
-        "id": "days_dry",
-        "title": "Days since last rain",
-        "server_layer_name": "dlc_dekad"
-      },
-      {
-        "id": "days_extreme_rain",
-        "title": "Number of days with extreme rainfall in the last 30 days",
-        "server_layer_name": "xne_dekad"
-      },
-      {
-        "id": "days_heavy_rain",
-        "title": "Number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xnh_dekad"
-      },
-      {
-        "id": "days_intense_rain",
-        "title": "Number of days with intense rainfall in the last 30 days",
-        "server_layer_name": "xni_dekad"
-      },
-      {
-        "id": "dekad_rainfall_anomaly_forecast",
-        "title": "10-day rainfall forecast anomaly",
-        "server_layer_name": "rfq_dekad"
-      },
-      {
-        "id": "dekad_rainfall_forecast",
-        "title": "10-day rainfall forecast",
-        "server_layer_name": "rfh_dekad_forecast"
-      },
-      {
-        "id": "lst_amplitude",
-        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
-        "server_layer_name": "myd11a2_taa_dekad"
-      },
-      {
-        "id": "lst_anomaly",
-        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_day_anomaly",
-        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_daytime",
-        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "lst_nighttime",
-        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "monthly_water_anomaly",
-        "title": "Monthly Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_dekad"
-      },
-      {
-        "id": "ndvi_dekad",
-        "title": "10-day NDVI (MODIS)",
-        "server_layer_name": "mxd13a2_vim_dekad"
-      },
-      {
-        "id": "ndvi_dekad_anomaly",
-        "title": "10-day NDVI anomaly (MODIS)",
-        "server_layer_name": "mxd13a2_viq_dekad"
-      },
-      {
-        "id": "rain_anomaly_1month",
-        "title": "Monthly rainfall anomaly",
-        "server_layer_name": "r1q_dekad"
-      },
-      {
-        "id": "rain_anomaly_1year",
-        "title": "1-year rainfall anomaly",
-        "server_layer_name": "ryq_dekad"
-      },
-      {
-        "id": "rain_anomaly_2month",
-        "title": "2-month rainfall anomaly",
-        "server_layer_name": "r2q_dekad"
-      },
-      {
-        "id": "rain_anomaly_3month",
-        "title": "3-month rainfall anomaly",
-        "server_layer_name": "r3q_dekad"
-      },
-      {
-        "id": "rain_anomaly_4month",
-        "title": "4-month rainfall anomaly",
-        "server_layer_name": "r4q_dekad"
-      },
-      {
-        "id": "rain_anomaly_5month",
-        "title": "5-month rainfall anomaly",
-        "server_layer_name": "r5q_dekad"
-      },
-      {
-        "id": "rain_anomaly_6month",
-        "title": "6-month rainfall anomaly",
-        "server_layer_name": "r6q_dekad"
-      },
-      {
-        "id": "rain_anomaly_7month",
-        "title": "7-month rainfall anomaly",
-        "server_layer_name": "r7q_dekad"
-      },
-      {
-        "id": "rain_anomaly_8month",
-        "title": "8-month rainfall anomaly",
-        "server_layer_name": "r8q_dekad"
-      },
-      {
-        "id": "rain_anomaly_9month",
-        "title": "9-month rainfall anomaly",
-        "server_layer_name": "r9q_dekad"
-      },
-      {
-        "id": "rain_anomaly_dekad",
-        "title": "10-day rainfall anomaly",
-        "server_layer_name": "rfq_dekad"
-      },
-      {
-        "id": "rainfall_agg_1month",
-        "title": "1-month rainfall aggregate (mm)",
-        "server_layer_name": "r1h_dekad"
-      },
-      {
-        "id": "rainfall_agg_1year",
-        "title": "1-year rainfall aggregate (mm)",
-        "server_layer_name": "ryh_dekad"
-      },
-      {
-        "id": "rainfall_agg_2month",
-        "title": "2-month rainfall aggregate (mm)",
-        "server_layer_name": "r2h_dekad"
-      },
-      {
-        "id": "rainfall_agg_3month",
-        "title": "3-month rainfall aggregate (mm)",
-        "server_layer_name": "r3h_dekad"
-      },
-      {
-        "id": "rainfall_agg_4month",
-        "title": "4-month rainfall aggregate (mm)",
-        "server_layer_name": "r4h_dekad"
-      },
-      {
-        "id": "rainfall_agg_5month",
-        "title": "5-month rainfall aggregate (mm)",
-        "server_layer_name": "r5h_dekad"
-      },
-      {
-        "id": "rainfall_agg_6month",
-        "title": "6-month rainfall aggregate (mm)",
-        "server_layer_name": "r6h_dekad"
-      },
-      {
-        "id": "rainfall_agg_7month",
-        "title": "7-month rainfall aggregate (mm)",
-        "server_layer_name": "r7h_dekad"
-      },
-      {
-        "id": "rainfall_agg_8month",
-        "title": "8-month rainfall aggregate (mm)",
-        "server_layer_name": "r8h_dekad"
-      },
-      {
-        "id": "rainfall_agg_9month",
-        "title": "9-month rainfall aggregate (mm)",
-        "server_layer_name": "r9h_dekad"
-      },
-      {
-        "id": "rainfall_dekad",
-        "title": "10-day rainfall estimate (mm)",
-        "server_layer_name": "rfh_dekad"
-      },
-      {
-        "id": "spi_1m",
-        "title": "SPI - 1-month",
-        "server_layer_name": "r1s_dekad"
-      },
-      {
-        "id": "spi_1y",
-        "title": "SPI - 1-year",
-        "server_layer_name": "rys_dekad"
-      },
-      {
-        "id": "spi_2m",
-        "title": "SPI - 2-month",
-        "server_layer_name": "r2s_dekad"
-      },
-      {
-        "id": "spi_3m",
-        "title": "SPI - 3-month",
-        "server_layer_name": "r3s_dekad"
-      },
-      {
-        "id": "spi_6m",
-        "title": "SPI - 6-month",
-        "server_layer_name": "r6s_dekad"
-      },
-      {
-        "id": "spi_9m",
-        "title": "SPI - 9-month",
-        "server_layer_name": "r9s_dekad"
-      },
-      {
-        "id": "streak_dry_days",
-        "title": "Longest number of consecutive dry days",
-        "server_layer_name": "dlx_dekad"
-      },
-      {
-        "id": "streak_extreme_rain",
-        "title": "Longest consecutive extreme rainfall days",
-        "server_layer_name": "xle_dekad"
-      },
-      {
-        "id": "streak_heavy_rain",
-        "title": "Longest consecutive number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xlh_dekad"
-      },
-      {
-        "id": "streak_intense_rain",
-        "title": "Longest consecutive intense rainfall days",
-        "server_layer_name": "xli_dekad"
       }
     ],
     "colombia": [
       {
+        "id": "rainfall_dekad",
+        "title": "10-day rainfall estimate (mm)",
+        "server_layer_name": "rfh_dekad"
+      },
+      {
+        "id": "rainfall_agg_1month",
+        "title": "1-month rainfall aggregate",
+        "server_layer_name": "r1h_dekad"
+      },
+      {
+        "id": "rainfall_agg_3month",
+        "title": "3-month rainfall aggregate (mm)",
+        "server_layer_name": "r3h_dekad"
+      },
+      {
+        "id": "rain_anomaly_dekad",
+        "title": "10-day rainfall anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rain_anomaly_1month",
+        "title": "Monthly rainfall anomaly",
+        "server_layer_name": "r1q_dekad"
+      },
+      {
+        "id": "rain_anomaly_3month",
+        "title": "3-month rainfall anomaly",
+        "server_layer_name": "r3q_dekad"
+      },
+      {
+        "id": "ndvi_dekad",
+        "title": "10-day NDVI (MODIS)",
+        "server_layer_name": "mxd13a2_vim_dekad"
+      },
+      {
+        "id": "ndvi_dekad_anomaly",
+        "title": "10-day NDVI anomaly (MODIS)",
+        "server_layer_name": "mxd13a2_viq_dekad"
+      },
+      {
+        "id": "daily_rainfall_forecast",
+        "title": "Rolling daily rainfall forecast",
+        "server_layer_name": "rfh_daily_forecast"
+      },
+      {
+        "id": "dekad_rainfall_forecast",
+        "title": "10-day rainfall forecast",
+        "server_layer_name": "rfh_dekad_forecast"
+      },
+      {
+        "id": "dekad_rainfall_anomaly_forecast",
+        "title": "10-day rainfall forecast anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rainfall_agg_2month",
+        "title": "2-month rainfall aggregate (mm)",
+        "server_layer_name": "r2h_dekad"
+      },
+      {
+        "id": "rain_anomaly_2month",
+        "title": "2-month rainfall anomaly",
+        "server_layer_name": "r2q_dekad"
+      },
+      {
+        "id": "rainfall_agg_4month",
+        "title": "4-month rainfall aggregate (mm)",
+        "server_layer_name": "r4h_dekad"
+      },
+      {
+        "id": "rain_anomaly_4month",
+        "title": "4-month rainfall anomaly",
+        "server_layer_name": "r4q_dekad"
+      },
+      {
+        "id": "rainfall_agg_5month",
+        "title": "5-month rainfall aggregate (mm)",
+        "server_layer_name": "r5h_dekad"
+      },
+      {
+        "id": "rain_anomaly_5month",
+        "title": "5-month rainfall anomaly",
+        "server_layer_name": "r5q_dekad"
+      },
+      {
+        "id": "rainfall_agg_6month",
+        "title": "6-month rainfall aggregate (mm)",
+        "server_layer_name": "r6h_dekad"
+      },
+      {
+        "id": "rain_anomaly_6month",
+        "title": "6-month rainfall anomaly",
+        "server_layer_name": "r6q_dekad"
+      },
+      {
+        "id": "rainfall_agg_7month",
+        "title": "7-month rainfall aggregate (mm)",
+        "server_layer_name": "r7h_dekad"
+      },
+      {
+        "id": "rain_anomaly_7month",
+        "title": "7-month rainfall anomaly",
+        "server_layer_name": "r7q_dekad"
+      },
+      {
+        "id": "rainfall_agg_8month",
+        "title": "8-month rainfall aggregate (mm)",
+        "server_layer_name": "r8h_dekad"
+      },
+      {
+        "id": "rain_anomaly_8month",
+        "title": "8-month rainfall anomaly",
+        "server_layer_name": "r8q_dekad"
+      },
+      {
+        "id": "rainfall_agg_9month",
+        "title": "9-month rainfall aggregate (mm)",
+        "server_layer_name": "r9h_dekad"
+      },
+      {
+        "id": "rain_anomaly_9month",
+        "title": "9-month rainfall anomaly",
+        "server_layer_name": "r9q_dekad"
+      },
+      {
+        "id": "rainfall_agg_1year",
+        "title": "1-year rainfall aggregate (mm)",
+        "server_layer_name": "ryh_dekad"
+      },
+      {
+        "id": "rain_anomaly_1year",
+        "title": "1-year rainfall anomaly",
+        "server_layer_name": "ryq_dekad"
+      },
+      {
+        "id": "spi_1m",
+        "title": "SPI - 1-month",
+        "server_layer_name": "r1s_dekad"
+      },
+      {
+        "id": "spi_2m",
+        "title": "SPI - 2-month",
+        "server_layer_name": "r2s_dekad"
+      },
+      {
+        "id": "spi_3m",
+        "title": "SPI - 3-month",
+        "server_layer_name": "r3s_dekad"
+      },
+      {
+        "id": "spi_6m",
+        "title": "SPI - 6-month",
+        "server_layer_name": "r6s_dekad"
+      },
+      {
+        "id": "spi_9m",
+        "title": "SPI - 9-month",
+        "server_layer_name": "r9s_dekad"
+      },
+      {
+        "id": "spi_1y",
+        "title": "SPI - 1-year",
+        "server_layer_name": "rys_dekad"
+      },
+      {
+        "id": "days_dry",
+        "title": "Days since last rain",
+        "server_layer_name": "dlc_dekad"
+      },
+      {
+        "id": "streak_dry_days",
+        "title": "Longest dry spell",
+        "server_layer_name": "dlx_dekad"
+      },
+      {
+        "id": "days_heavy_rain",
+        "title": "Number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xnh_dekad"
+      },
+      {
+        "id": "days_intense_rain",
+        "title": "Number of days with intense rainfall in the last 30 days",
+        "server_layer_name": "xni_dekad"
+      },
+      {
+        "id": "days_extreme_rain",
+        "title": "Number of days with extreme rainfall in the last 30 days",
+        "server_layer_name": "xne_dekad"
+      },
+      {
+        "id": "streak_heavy_rain",
+        "title": "Longest consecutive heavy rainfall days",
+        "server_layer_name": "xlh_dekad"
+      },
+      {
+        "id": "streak_intense_rain",
+        "title": "Longest consecutive intense rainfall days",
+        "server_layer_name": "xli_dekad"
+      },
+      {
+        "id": "streak_extreme_rain",
+        "title": "Longest consecutive extreme rainfall days",
+        "server_layer_name": "xle_dekad"
+      },
+      {
+        "id": "lst_amplitude",
+        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
+        "server_layer_name": "myd11a2_taa_dekad"
+      },
+      {
+        "id": "lst_daytime",
+        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_nighttime",
+        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_day_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "monthly_water_anomaly",
+        "title": "Monthly Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_dekad"
+      },
+      {
         "id": "2m_water_anomaly",
         "title": "2-Month Water Anomaly Index (WAI)",
         "server_layer_name": "wai_seasonal_2month"
@@ -1073,245 +1308,245 @@
         "id": "6m_water_anomaly",
         "title": "6-Month Water Anomaly Index (WAI)",
         "server_layer_name": "wai_seasonal_6month"
-      },
-      {
-        "id": "daily_rainfall_forecast",
-        "title": "Rolling daily rainfall forecast",
-        "server_layer_name": "rfh_daily_forecast"
-      },
-      {
-        "id": "days_dry",
-        "title": "Days since last rain",
-        "server_layer_name": "dlc_dekad"
-      },
-      {
-        "id": "days_extreme_rain",
-        "title": "Number of days with extreme rainfall in the last 30 days",
-        "server_layer_name": "xne_dekad"
-      },
-      {
-        "id": "days_heavy_rain",
-        "title": "Number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xnh_dekad"
-      },
-      {
-        "id": "days_intense_rain",
-        "title": "Number of days with intense rainfall in the last 30 days",
-        "server_layer_name": "xni_dekad"
-      },
-      {
-        "id": "dekad_rainfall_anomaly_forecast",
-        "title": "10-day rainfall forecast anomaly",
-        "server_layer_name": "rfq_dekad"
-      },
-      {
-        "id": "dekad_rainfall_forecast",
-        "title": "10-day rainfall forecast",
-        "server_layer_name": "rfh_dekad_forecast"
-      },
-      {
-        "id": "lst_amplitude",
-        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
-        "server_layer_name": "myd11a2_taa_dekad"
-      },
-      {
-        "id": "lst_anomaly",
-        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_day_anomaly",
-        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_daytime",
-        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "lst_nighttime",
-        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "monthly_water_anomaly",
-        "title": "Monthly Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_dekad"
-      },
-      {
-        "id": "ndvi_dekad",
-        "title": "10-day NDVI (MODIS)",
-        "server_layer_name": "mxd13a2_vim_dekad"
-      },
-      {
-        "id": "ndvi_dekad_anomaly",
-        "title": "10-day NDVI anomaly (MODIS)",
-        "server_layer_name": "mxd13a2_viq_dekad"
-      },
-      {
-        "id": "rain_anomaly_1month",
-        "title": "Monthly rainfall anomaly",
-        "server_layer_name": "r1q_dekad"
-      },
-      {
-        "id": "rain_anomaly_1year",
-        "title": "1-year rainfall anomaly",
-        "server_layer_name": "ryq_dekad"
-      },
-      {
-        "id": "rain_anomaly_2month",
-        "title": "2-month rainfall anomaly",
-        "server_layer_name": "r2q_dekad"
-      },
-      {
-        "id": "rain_anomaly_3month",
-        "title": "3-month rainfall anomaly",
-        "server_layer_name": "r3q_dekad"
-      },
-      {
-        "id": "rain_anomaly_4month",
-        "title": "4-month rainfall anomaly",
-        "server_layer_name": "r4q_dekad"
-      },
-      {
-        "id": "rain_anomaly_5month",
-        "title": "5-month rainfall anomaly",
-        "server_layer_name": "r5q_dekad"
-      },
-      {
-        "id": "rain_anomaly_6month",
-        "title": "6-month rainfall anomaly",
-        "server_layer_name": "r6q_dekad"
-      },
-      {
-        "id": "rain_anomaly_7month",
-        "title": "7-month rainfall anomaly",
-        "server_layer_name": "r7q_dekad"
-      },
-      {
-        "id": "rain_anomaly_8month",
-        "title": "8-month rainfall anomaly",
-        "server_layer_name": "r8q_dekad"
-      },
-      {
-        "id": "rain_anomaly_9month",
-        "title": "9-month rainfall anomaly",
-        "server_layer_name": "r9q_dekad"
-      },
-      {
-        "id": "rain_anomaly_dekad",
-        "title": "10-day rainfall anomaly",
-        "server_layer_name": "rfq_dekad"
-      },
-      {
-        "id": "rainfall_agg_1month",
-        "title": "1-month rainfall aggregate",
-        "server_layer_name": "r1h_dekad"
-      },
-      {
-        "id": "rainfall_agg_1year",
-        "title": "1-year rainfall aggregate (mm)",
-        "server_layer_name": "ryh_dekad"
-      },
-      {
-        "id": "rainfall_agg_2month",
-        "title": "2-month rainfall aggregate (mm)",
-        "server_layer_name": "r2h_dekad"
-      },
-      {
-        "id": "rainfall_agg_3month",
-        "title": "3-month rainfall aggregate (mm)",
-        "server_layer_name": "r3h_dekad"
-      },
-      {
-        "id": "rainfall_agg_4month",
-        "title": "4-month rainfall aggregate (mm)",
-        "server_layer_name": "r4h_dekad"
-      },
-      {
-        "id": "rainfall_agg_5month",
-        "title": "5-month rainfall aggregate (mm)",
-        "server_layer_name": "r5h_dekad"
-      },
-      {
-        "id": "rainfall_agg_6month",
-        "title": "6-month rainfall aggregate (mm)",
-        "server_layer_name": "r6h_dekad"
-      },
-      {
-        "id": "rainfall_agg_7month",
-        "title": "7-month rainfall aggregate (mm)",
-        "server_layer_name": "r7h_dekad"
-      },
-      {
-        "id": "rainfall_agg_8month",
-        "title": "8-month rainfall aggregate (mm)",
-        "server_layer_name": "r8h_dekad"
-      },
-      {
-        "id": "rainfall_agg_9month",
-        "title": "9-month rainfall aggregate (mm)",
-        "server_layer_name": "r9h_dekad"
-      },
-      {
-        "id": "rainfall_dekad",
-        "title": "10-day rainfall estimate (mm)",
-        "server_layer_name": "rfh_dekad"
-      },
-      {
-        "id": "spi_1m",
-        "title": "SPI - 1-month",
-        "server_layer_name": "r1s_dekad"
-      },
-      {
-        "id": "spi_1y",
-        "title": "SPI - 1-year",
-        "server_layer_name": "rys_dekad"
-      },
-      {
-        "id": "spi_2m",
-        "title": "SPI - 2-month",
-        "server_layer_name": "r2s_dekad"
-      },
-      {
-        "id": "spi_3m",
-        "title": "SPI - 3-month",
-        "server_layer_name": "r3s_dekad"
-      },
-      {
-        "id": "spi_6m",
-        "title": "SPI - 6-month",
-        "server_layer_name": "r6s_dekad"
-      },
-      {
-        "id": "spi_9m",
-        "title": "SPI - 9-month",
-        "server_layer_name": "r9s_dekad"
-      },
-      {
-        "id": "streak_dry_days",
-        "title": "Longest dry spell",
-        "server_layer_name": "dlx_dekad"
-      },
-      {
-        "id": "streak_extreme_rain",
-        "title": "Longest consecutive extreme rainfall days",
-        "server_layer_name": "xle_dekad"
-      },
-      {
-        "id": "streak_heavy_rain",
-        "title": "Longest consecutive heavy rainfall days",
-        "server_layer_name": "xlh_dekad"
-      },
-      {
-        "id": "streak_intense_rain",
-        "title": "Longest consecutive intense rainfall days",
-        "server_layer_name": "xli_dekad"
       }
     ],
     "cuba": [
       {
+        "id": "spi_1m",
+        "title": "SPI - 1-month",
+        "server_layer_name": "r1s_dekad"
+      },
+      {
+        "id": "spi_3m",
+        "title": "SPI - 3-month",
+        "server_layer_name": "r3s_dekad"
+      },
+      {
+        "id": "spi_6m",
+        "title": "SPI - 6-month",
+        "server_layer_name": "r6s_dekad"
+      },
+      {
+        "id": "spi_9m",
+        "title": "SPI - 9-month",
+        "server_layer_name": "r9s_dekad"
+      },
+      {
+        "id": "spi_1y",
+        "title": "SPI - 1-year",
+        "server_layer_name": "rys_dekad"
+      },
+      {
+        "id": "rain_anomaly_dekad",
+        "title": "10-day rainfall anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rain_anomaly_1month",
+        "title": "Monthly rainfall anomaly",
+        "server_layer_name": "r1q_dekad"
+      },
+      {
+        "id": "rain_anomaly_3month",
+        "title": "3-month rainfall anomaly",
+        "server_layer_name": "r3q_dekad"
+      },
+      {
+        "id": "rain_anomaly_6month",
+        "title": "6-month rainfall anomaly",
+        "server_layer_name": "r6q_dekad"
+      },
+      {
+        "id": "rain_anomaly_9month",
+        "title": "9-month rainfall anomaly",
+        "server_layer_name": "r9q_dekad"
+      },
+      {
+        "id": "rain_anomaly_1year",
+        "title": "1-year rainfall anomaly",
+        "server_layer_name": "ryq_dekad"
+      },
+      {
+        "id": "rainfall_dekad",
+        "title": "10-day rainfall estimate (mm)",
+        "server_layer_name": "rfh_dekad"
+      },
+      {
+        "id": "rainfall_agg_1month",
+        "title": "1-month rainfall aggregate (mm)",
+        "server_layer_name": "r1h_dekad"
+      },
+      {
+        "id": "rainfall_agg_3month",
+        "title": "3-month rainfall aggregate (mm)",
+        "server_layer_name": "r3h_dekad"
+      },
+      {
+        "id": "rainfall_agg_6month",
+        "title": "6-month rainfall aggregate (mm)",
+        "server_layer_name": "r6h_dekad"
+      },
+      {
+        "id": "rainfall_agg_9month",
+        "title": "9-month rainfall aggregate (mm)",
+        "server_layer_name": "r9h_dekad"
+      },
+      {
+        "id": "rainfall_agg_1year",
+        "title": "1-year rainfall aggregate (mm)",
+        "server_layer_name": "ryh_dekad"
+      },
+      {
+        "id": "days_dry",
+        "title": "Days since last rain",
+        "server_layer_name": "dlc_dekad"
+      },
+      {
+        "id": "streak_dry_days",
+        "title": "Longest number of consecutive dry days",
+        "server_layer_name": "dlx_dekad"
+      },
+      {
+        "id": "days_heavy_rain",
+        "title": "Number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xnh_dekad"
+      },
+      {
+        "id": "days_intense_rain",
+        "title": "Number of days with intense rainfall in the last 30 days",
+        "server_layer_name": "xni_dekad"
+      },
+      {
+        "id": "days_extreme_rain",
+        "title": "Number of days with extreme rainfall in the last 30 days",
+        "server_layer_name": "xne_dekad"
+      },
+      {
+        "id": "streak_heavy_rain",
+        "title": "Longest consecutive number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xlh_dekad"
+      },
+      {
+        "id": "streak_intense_rain",
+        "title": "Longest consecutive intense rainfall days",
+        "server_layer_name": "xli_dekad"
+      },
+      {
+        "id": "streak_extreme_rain",
+        "title": "Longest consecutive extreme rainfall days",
+        "server_layer_name": "xle_dekad"
+      },
+      {
+        "id": "ndvi_dekad",
+        "title": "10-day NDVI (MODIS)",
+        "server_layer_name": "mxd13a2_vim_dekad"
+      },
+      {
+        "id": "ndvi_dekad_anomaly",
+        "title": "10-day NDVI anomaly (MODIS)",
+        "server_layer_name": "mxd13a2_viq_dekad"
+      },
+      {
+        "id": "lst_amplitude",
+        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
+        "server_layer_name": "myd11a2_taa_dekad"
+      },
+      {
+        "id": "lst_daytime",
+        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_nighttime",
+        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_anomaly",
+        "title": "Daytime Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "daily_rainfall_forecast",
+        "title": "Rolling daily rainfall forecast",
+        "server_layer_name": "rfh_daily_forecast"
+      },
+      {
+        "id": "dekad_rainfall_forecast",
+        "title": "10-day rainfall forecast",
+        "server_layer_name": "rfh_dekad_forecast"
+      },
+      {
+        "id": "dekad_rainfall_anomaly_forecast",
+        "title": "10-day rainfall forecast anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rainfall_agg_2month",
+        "title": "2-month rainfall aggregate (mm)",
+        "server_layer_name": "r2h_dekad"
+      },
+      {
+        "id": "rain_anomaly_2month",
+        "title": "2-month rainfall anomaly",
+        "server_layer_name": "r2q_dekad"
+      },
+      {
+        "id": "rainfall_agg_4month",
+        "title": "4-month rainfall aggregate (mm)",
+        "server_layer_name": "r4h_dekad"
+      },
+      {
+        "id": "rain_anomaly_4month",
+        "title": "4-month rainfall anomaly",
+        "server_layer_name": "r4q_dekad"
+      },
+      {
+        "id": "rainfall_agg_5month",
+        "title": "5-month rainfall aggregate (mm)",
+        "server_layer_name": "r5h_dekad"
+      },
+      {
+        "id": "rain_anomaly_5month",
+        "title": "5-month rainfall anomaly",
+        "server_layer_name": "r5q_dekad"
+      },
+      {
+        "id": "rainfall_agg_7month",
+        "title": "7-month rainfall aggregate (mm)",
+        "server_layer_name": "r7h_dekad"
+      },
+      {
+        "id": "rain_anomaly_7month",
+        "title": "7-month rainfall anomaly",
+        "server_layer_name": "r7q_dekad"
+      },
+      {
+        "id": "rainfall_agg_8month",
+        "title": "8-month rainfall aggregate (mm)",
+        "server_layer_name": "r8h_dekad"
+      },
+      {
+        "id": "rain_anomaly_8month",
+        "title": "8-month rainfall anomaly",
+        "server_layer_name": "r8q_dekad"
+      },
+      {
+        "id": "spi_2m",
+        "title": "SPI - 2-month",
+        "server_layer_name": "r2s_dekad"
+      },
+      {
+        "id": "lst_day_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "monthly_water_anomaly",
+        "title": "Monthly Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_dekad"
+      },
+      {
         "id": "2m_water_anomaly",
         "title": "2-Month Water Anomaly Index (WAI)",
         "server_layer_name": "wai_seasonal_2month"
@@ -1335,468 +1570,13 @@
         "id": "6m_water_anomaly",
         "title": "6-Month Water Anomaly Index (WAI)",
         "server_layer_name": "wai_seasonal_6month"
-      },
-      {
-        "id": "daily_rainfall_forecast",
-        "title": "Rolling daily rainfall forecast",
-        "server_layer_name": "rfh_daily_forecast"
-      },
-      {
-        "id": "days_dry",
-        "title": "Days since last rain",
-        "server_layer_name": "dlc_dekad"
-      },
-      {
-        "id": "days_extreme_rain",
-        "title": "Number of days with extreme rainfall in the last 30 days",
-        "server_layer_name": "xne_dekad"
-      },
-      {
-        "id": "days_heavy_rain",
-        "title": "Number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xnh_dekad"
-      },
-      {
-        "id": "days_intense_rain",
-        "title": "Number of days with intense rainfall in the last 30 days",
-        "server_layer_name": "xni_dekad"
-      },
-      {
-        "id": "dekad_rainfall_anomaly_forecast",
-        "title": "10-day rainfall forecast anomaly",
-        "server_layer_name": "rfq_dekad"
-      },
-      {
-        "id": "dekad_rainfall_forecast",
-        "title": "10-day rainfall forecast",
-        "server_layer_name": "rfh_dekad_forecast"
-      },
-      {
-        "id": "lst_amplitude",
-        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
-        "server_layer_name": "myd11a2_taa_dekad"
-      },
-      {
-        "id": "lst_anomaly",
-        "title": "Daytime Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_day_anomaly",
-        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_daytime",
-        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "lst_nighttime",
-        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "monthly_water_anomaly",
-        "title": "Monthly Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_dekad"
-      },
-      {
-        "id": "ndvi_dekad",
-        "title": "10-day NDVI (MODIS)",
-        "server_layer_name": "mxd13a2_vim_dekad"
-      },
-      {
-        "id": "ndvi_dekad_anomaly",
-        "title": "10-day NDVI anomaly (MODIS)",
-        "server_layer_name": "mxd13a2_viq_dekad"
-      },
-      {
-        "id": "rain_anomaly_1month",
-        "title": "Monthly rainfall anomaly",
-        "server_layer_name": "r1q_dekad"
-      },
-      {
-        "id": "rain_anomaly_1year",
-        "title": "1-year rainfall anomaly",
-        "server_layer_name": "ryq_dekad"
-      },
-      {
-        "id": "rain_anomaly_2month",
-        "title": "2-month rainfall anomaly",
-        "server_layer_name": "r2q_dekad"
-      },
-      {
-        "id": "rain_anomaly_3month",
-        "title": "3-month rainfall anomaly",
-        "server_layer_name": "r3q_dekad"
-      },
-      {
-        "id": "rain_anomaly_4month",
-        "title": "4-month rainfall anomaly",
-        "server_layer_name": "r4q_dekad"
-      },
-      {
-        "id": "rain_anomaly_5month",
-        "title": "5-month rainfall anomaly",
-        "server_layer_name": "r5q_dekad"
-      },
-      {
-        "id": "rain_anomaly_6month",
-        "title": "6-month rainfall anomaly",
-        "server_layer_name": "r6q_dekad"
-      },
-      {
-        "id": "rain_anomaly_7month",
-        "title": "7-month rainfall anomaly",
-        "server_layer_name": "r7q_dekad"
-      },
-      {
-        "id": "rain_anomaly_8month",
-        "title": "8-month rainfall anomaly",
-        "server_layer_name": "r8q_dekad"
-      },
-      {
-        "id": "rain_anomaly_9month",
-        "title": "9-month rainfall anomaly",
-        "server_layer_name": "r9q_dekad"
-      },
-      {
-        "id": "rain_anomaly_dekad",
-        "title": "10-day rainfall anomaly",
-        "server_layer_name": "rfq_dekad"
-      },
-      {
-        "id": "rainfall_agg_1month",
-        "title": "1-month rainfall aggregate (mm)",
-        "server_layer_name": "r1h_dekad"
-      },
-      {
-        "id": "rainfall_agg_1year",
-        "title": "1-year rainfall aggregate (mm)",
-        "server_layer_name": "ryh_dekad"
-      },
-      {
-        "id": "rainfall_agg_2month",
-        "title": "2-month rainfall aggregate (mm)",
-        "server_layer_name": "r2h_dekad"
-      },
-      {
-        "id": "rainfall_agg_3month",
-        "title": "3-month rainfall aggregate (mm)",
-        "server_layer_name": "r3h_dekad"
-      },
-      {
-        "id": "rainfall_agg_4month",
-        "title": "4-month rainfall aggregate (mm)",
-        "server_layer_name": "r4h_dekad"
-      },
-      {
-        "id": "rainfall_agg_5month",
-        "title": "5-month rainfall aggregate (mm)",
-        "server_layer_name": "r5h_dekad"
-      },
-      {
-        "id": "rainfall_agg_6month",
-        "title": "6-month rainfall aggregate (mm)",
-        "server_layer_name": "r6h_dekad"
-      },
-      {
-        "id": "rainfall_agg_7month",
-        "title": "7-month rainfall aggregate (mm)",
-        "server_layer_name": "r7h_dekad"
-      },
-      {
-        "id": "rainfall_agg_8month",
-        "title": "8-month rainfall aggregate (mm)",
-        "server_layer_name": "r8h_dekad"
-      },
-      {
-        "id": "rainfall_agg_9month",
-        "title": "9-month rainfall aggregate (mm)",
-        "server_layer_name": "r9h_dekad"
-      },
-      {
-        "id": "rainfall_dekad",
-        "title": "10-day rainfall estimate (mm)",
-        "server_layer_name": "rfh_dekad"
-      },
-      {
-        "id": "spi_1m",
-        "title": "SPI - 1-month",
-        "server_layer_name": "r1s_dekad"
-      },
-      {
-        "id": "spi_1y",
-        "title": "SPI - 1-year",
-        "server_layer_name": "rys_dekad"
-      },
-      {
-        "id": "spi_2m",
-        "title": "SPI - 2-month",
-        "server_layer_name": "r2s_dekad"
-      },
-      {
-        "id": "spi_3m",
-        "title": "SPI - 3-month",
-        "server_layer_name": "r3s_dekad"
-      },
-      {
-        "id": "spi_6m",
-        "title": "SPI - 6-month",
-        "server_layer_name": "r6s_dekad"
-      },
-      {
-        "id": "spi_9m",
-        "title": "SPI - 9-month",
-        "server_layer_name": "r9s_dekad"
-      },
-      {
-        "id": "streak_dry_days",
-        "title": "Longest number of consecutive dry days",
-        "server_layer_name": "dlx_dekad"
-      },
-      {
-        "id": "streak_extreme_rain",
-        "title": "Longest consecutive extreme rainfall days",
-        "server_layer_name": "xle_dekad"
-      },
-      {
-        "id": "streak_heavy_rain",
-        "title": "Longest consecutive number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xlh_dekad"
-      },
-      {
-        "id": "streak_intense_rain",
-        "title": "Longest consecutive intense rainfall days",
-        "server_layer_name": "xli_dekad"
       }
     ],
     "ecuador": [
       {
-        "id": "2m_water_anomaly",
-        "title": "2-Month Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_seasonal_2month"
-      },
-      {
-        "id": "3m_water_anomaly",
-        "title": "3-Month Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_seasonal_3month"
-      },
-      {
-        "id": "4m_water_anomaly",
-        "title": "4-Month Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_seasonal_4month"
-      },
-      {
-        "id": "5m_water_anomaly",
-        "title": "5-Month Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_seasonal_5month"
-      },
-      {
-        "id": "6m_water_anomaly",
-        "title": "6-Month Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_seasonal_6month"
-      },
-      {
-        "id": "daily_rainfall_forecast",
-        "title": "Rolling daily rainfall forecast",
-        "server_layer_name": "rfh_daily_forecast"
-      },
-      {
-        "id": "days_dry",
-        "title": "Days since last rain",
-        "server_layer_name": "dlc_dekad"
-      },
-      {
-        "id": "days_extreme_rain",
-        "title": "Number of days with extreme rainfall in the last 30 days",
-        "server_layer_name": "xne_dekad"
-      },
-      {
-        "id": "days_heavy_rain",
-        "title": "Number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xnh_dekad"
-      },
-      {
-        "id": "days_intense_rain",
-        "title": "Number of days with intense rainfall in the last 30 days",
-        "server_layer_name": "xni_dekad"
-      },
-      {
-        "id": "dekad_rainfall_anomaly_forecast",
-        "title": "10-day rainfall forecast anomaly",
-        "server_layer_name": "rfq_dekad"
-      },
-      {
-        "id": "dekad_rainfall_forecast",
-        "title": "10-day rainfall forecast",
-        "server_layer_name": "rfh_dekad_forecast"
-      },
-      {
-        "id": "lst_amplitude",
-        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
-        "server_layer_name": "myd11a2_taa_dekad"
-      },
-      {
-        "id": "lst_anomaly",
-        "title": "Daytime Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_day_anomaly",
-        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_daytime",
-        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "lst_nighttime",
-        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "monthly_water_anomaly",
-        "title": "Monthly Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_dekad"
-      },
-      {
-        "id": "ndvi_dekad",
-        "title": "10-day NDVI (MODIS)",
-        "server_layer_name": "mxd13a2_vim_dekad"
-      },
-      {
-        "id": "ndvi_dekad_anomaly",
-        "title": "10-day NDVI anomaly (MODIS)",
-        "server_layer_name": "mxd13a2_viq_dekad"
-      },
-      {
-        "id": "rain_anomaly_1month",
-        "title": "Monthly rainfall anomaly",
-        "server_layer_name": "r1q_dekad"
-      },
-      {
-        "id": "rain_anomaly_1year",
-        "title": "1-year rainfall anomaly",
-        "server_layer_name": "ryq_dekad"
-      },
-      {
-        "id": "rain_anomaly_2month",
-        "title": "2-month rainfall anomaly",
-        "server_layer_name": "r2q_dekad"
-      },
-      {
-        "id": "rain_anomaly_3month",
-        "title": "3-month rainfall anomaly",
-        "server_layer_name": "r3q_dekad"
-      },
-      {
-        "id": "rain_anomaly_4month",
-        "title": "4-month rainfall anomaly",
-        "server_layer_name": "r4q_dekad"
-      },
-      {
-        "id": "rain_anomaly_5month",
-        "title": "5-month rainfall anomaly",
-        "server_layer_name": "r5q_dekad"
-      },
-      {
-        "id": "rain_anomaly_6month",
-        "title": "6-month rainfall anomaly",
-        "server_layer_name": "r6q_dekad"
-      },
-      {
-        "id": "rain_anomaly_7month",
-        "title": "7-month rainfall anomaly",
-        "server_layer_name": "r7q_dekad"
-      },
-      {
-        "id": "rain_anomaly_8month",
-        "title": "8-month rainfall anomaly",
-        "server_layer_name": "r8q_dekad"
-      },
-      {
-        "id": "rain_anomaly_9month",
-        "title": "9-month rainfall anomaly",
-        "server_layer_name": "r9q_dekad"
-      },
-      {
-        "id": "rain_anomaly_dekad",
-        "title": "10-day rainfall anomaly",
-        "server_layer_name": "rfq_dekad"
-      },
-      {
-        "id": "rainfall_agg_1month",
-        "title": "1-month rainfall aggregate (mm)",
-        "server_layer_name": "r1h_dekad"
-      },
-      {
-        "id": "rainfall_agg_1year",
-        "title": "1-year rainfall aggregate (mm)",
-        "server_layer_name": "ryh_dekad"
-      },
-      {
-        "id": "rainfall_agg_2month",
-        "title": "2-month rainfall aggregate (mm)",
-        "server_layer_name": "r2h_dekad"
-      },
-      {
-        "id": "rainfall_agg_3month",
-        "title": "3-month rainfall aggregate (mm)",
-        "server_layer_name": "r3h_dekad"
-      },
-      {
-        "id": "rainfall_agg_4month",
-        "title": "4-month rainfall aggregate (mm)",
-        "server_layer_name": "r4h_dekad"
-      },
-      {
-        "id": "rainfall_agg_5month",
-        "title": "5-month rainfall aggregate (mm)",
-        "server_layer_name": "r5h_dekad"
-      },
-      {
-        "id": "rainfall_agg_6month",
-        "title": "6-month rainfall aggregate (mm)",
-        "server_layer_name": "r6h_dekad"
-      },
-      {
-        "id": "rainfall_agg_7month",
-        "title": "7-month rainfall aggregate (mm)",
-        "server_layer_name": "r7h_dekad"
-      },
-      {
-        "id": "rainfall_agg_8month",
-        "title": "8-month rainfall aggregate (mm)",
-        "server_layer_name": "r8h_dekad"
-      },
-      {
-        "id": "rainfall_agg_9month",
-        "title": "9-month rainfall aggregate (mm)",
-        "server_layer_name": "r9h_dekad"
-      },
-      {
-        "id": "rainfall_dekad",
-        "title": "10-day rainfall estimate (mm)",
-        "server_layer_name": "rfh_dekad"
-      },
-      {
         "id": "spi_1m",
         "title": "SPI - 1-month",
         "server_layer_name": "r1s_dekad"
-      },
-      {
-        "id": "spi_1y",
-        "title": "SPI - 1-year",
-        "server_layer_name": "rys_dekad"
-      },
-      {
-        "id": "spi_2m",
-        "title": "SPI - 2-month",
-        "server_layer_name": "r2s_dekad"
       },
       {
         "id": "spi_3m",
@@ -1814,14 +1594,94 @@
         "server_layer_name": "r9s_dekad"
       },
       {
+        "id": "spi_1y",
+        "title": "SPI - 1-year",
+        "server_layer_name": "rys_dekad"
+      },
+      {
+        "id": "rain_anomaly_dekad",
+        "title": "10-day rainfall anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rain_anomaly_1month",
+        "title": "Monthly rainfall anomaly",
+        "server_layer_name": "r1q_dekad"
+      },
+      {
+        "id": "rain_anomaly_3month",
+        "title": "3-month rainfall anomaly",
+        "server_layer_name": "r3q_dekad"
+      },
+      {
+        "id": "rain_anomaly_6month",
+        "title": "6-month rainfall anomaly",
+        "server_layer_name": "r6q_dekad"
+      },
+      {
+        "id": "rain_anomaly_9month",
+        "title": "9-month rainfall anomaly",
+        "server_layer_name": "r9q_dekad"
+      },
+      {
+        "id": "rain_anomaly_1year",
+        "title": "1-year rainfall anomaly",
+        "server_layer_name": "ryq_dekad"
+      },
+      {
+        "id": "rainfall_dekad",
+        "title": "10-day rainfall estimate (mm)",
+        "server_layer_name": "rfh_dekad"
+      },
+      {
+        "id": "rainfall_agg_1month",
+        "title": "1-month rainfall aggregate (mm)",
+        "server_layer_name": "r1h_dekad"
+      },
+      {
+        "id": "rainfall_agg_3month",
+        "title": "3-month rainfall aggregate (mm)",
+        "server_layer_name": "r3h_dekad"
+      },
+      {
+        "id": "rainfall_agg_6month",
+        "title": "6-month rainfall aggregate (mm)",
+        "server_layer_name": "r6h_dekad"
+      },
+      {
+        "id": "rainfall_agg_9month",
+        "title": "9-month rainfall aggregate (mm)",
+        "server_layer_name": "r9h_dekad"
+      },
+      {
+        "id": "rainfall_agg_1year",
+        "title": "1-year rainfall aggregate (mm)",
+        "server_layer_name": "ryh_dekad"
+      },
+      {
+        "id": "days_dry",
+        "title": "Days since last rain",
+        "server_layer_name": "dlc_dekad"
+      },
+      {
         "id": "streak_dry_days",
         "title": "Longest number of consecutive dry days",
         "server_layer_name": "dlx_dekad"
       },
       {
-        "id": "streak_extreme_rain",
-        "title": "Longest consecutive extreme rainfall days",
-        "server_layer_name": "xle_dekad"
+        "id": "days_heavy_rain",
+        "title": "Number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xnh_dekad"
+      },
+      {
+        "id": "days_intense_rain",
+        "title": "Number of days with intense rainfall in the last 30 days",
+        "server_layer_name": "xni_dekad"
+      },
+      {
+        "id": "days_extreme_rain",
+        "title": "Number of days with extreme rainfall in the last 30 days",
+        "server_layer_name": "xne_dekad"
       },
       {
         "id": "streak_heavy_rain",
@@ -1832,9 +1692,122 @@
         "id": "streak_intense_rain",
         "title": "Longest consecutive intense rainfall days",
         "server_layer_name": "xli_dekad"
-      }
-    ],
-    "global": [
+      },
+      {
+        "id": "streak_extreme_rain",
+        "title": "Longest consecutive extreme rainfall days",
+        "server_layer_name": "xle_dekad"
+      },
+      {
+        "id": "ndvi_dekad",
+        "title": "10-day NDVI (MODIS)",
+        "server_layer_name": "mxd13a2_vim_dekad"
+      },
+      {
+        "id": "ndvi_dekad_anomaly",
+        "title": "10-day NDVI anomaly (MODIS)",
+        "server_layer_name": "mxd13a2_viq_dekad"
+      },
+      {
+        "id": "lst_amplitude",
+        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
+        "server_layer_name": "myd11a2_taa_dekad"
+      },
+      {
+        "id": "lst_daytime",
+        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_nighttime",
+        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_anomaly",
+        "title": "Daytime Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "daily_rainfall_forecast",
+        "title": "Rolling daily rainfall forecast",
+        "server_layer_name": "rfh_daily_forecast"
+      },
+      {
+        "id": "dekad_rainfall_forecast",
+        "title": "10-day rainfall forecast",
+        "server_layer_name": "rfh_dekad_forecast"
+      },
+      {
+        "id": "dekad_rainfall_anomaly_forecast",
+        "title": "10-day rainfall forecast anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rainfall_agg_2month",
+        "title": "2-month rainfall aggregate (mm)",
+        "server_layer_name": "r2h_dekad"
+      },
+      {
+        "id": "rain_anomaly_2month",
+        "title": "2-month rainfall anomaly",
+        "server_layer_name": "r2q_dekad"
+      },
+      {
+        "id": "rainfall_agg_4month",
+        "title": "4-month rainfall aggregate (mm)",
+        "server_layer_name": "r4h_dekad"
+      },
+      {
+        "id": "rain_anomaly_4month",
+        "title": "4-month rainfall anomaly",
+        "server_layer_name": "r4q_dekad"
+      },
+      {
+        "id": "rainfall_agg_5month",
+        "title": "5-month rainfall aggregate (mm)",
+        "server_layer_name": "r5h_dekad"
+      },
+      {
+        "id": "rain_anomaly_5month",
+        "title": "5-month rainfall anomaly",
+        "server_layer_name": "r5q_dekad"
+      },
+      {
+        "id": "rainfall_agg_7month",
+        "title": "7-month rainfall aggregate (mm)",
+        "server_layer_name": "r7h_dekad"
+      },
+      {
+        "id": "rain_anomaly_7month",
+        "title": "7-month rainfall anomaly",
+        "server_layer_name": "r7q_dekad"
+      },
+      {
+        "id": "rainfall_agg_8month",
+        "title": "8-month rainfall aggregate (mm)",
+        "server_layer_name": "r8h_dekad"
+      },
+      {
+        "id": "rain_anomaly_8month",
+        "title": "8-month rainfall anomaly",
+        "server_layer_name": "r8q_dekad"
+      },
+      {
+        "id": "spi_2m",
+        "title": "SPI - 2-month",
+        "server_layer_name": "r2s_dekad"
+      },
+      {
+        "id": "lst_day_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "monthly_water_anomaly",
+        "title": "Monthly Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_dekad"
+      },
       {
         "id": "2m_water_anomaly",
         "title": "2-Month Water Anomaly Index (WAI)",
@@ -1859,36 +1832,13 @@
         "id": "6m_water_anomaly",
         "title": "6-Month Water Anomaly Index (WAI)",
         "server_layer_name": "wai_seasonal_6month"
-      },
+      }
+    ],
+    "global": [
       {
         "id": "daily_rainfall_forecast",
         "title": "Rolling daily rainfall forecast",
         "server_layer_name": "rfh_daily_forecast"
-      },
-      {
-        "id": "days_dry",
-        "title": "Days since last rain",
-        "server_layer_name": "dlc_dekad"
-      },
-      {
-        "id": "days_extreme_rain",
-        "title": "Number of days with extreme rainfall in the last 30 days",
-        "server_layer_name": "xne_dekad"
-      },
-      {
-        "id": "days_heavy_rain",
-        "title": "Number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xnh_dekad"
-      },
-      {
-        "id": "days_intense_rain",
-        "title": "Number of days with intense rainfall in the last 30 days",
-        "server_layer_name": "xni_dekad"
-      },
-      {
-        "id": "dekad_rainfall_anomaly_forecast",
-        "title": "10-day rainfall forecast anomaly",
-        "server_layer_name": "rfq_dekad"
       },
       {
         "id": "dekad_rainfall_forecast",
@@ -1896,44 +1846,14 @@
         "server_layer_name": "rfh_dekad_forecast"
       },
       {
-        "id": "lst_amplitude",
-        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
-        "server_layer_name": "myd11a2_taa_dekad"
+        "id": "dekad_rainfall_anomaly_forecast",
+        "title": "10-day rainfall forecast anomaly",
+        "server_layer_name": "rfq_dekad"
       },
       {
-        "id": "lst_anomaly",
-        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_day_anomaly",
-        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_daytime",
-        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "lst_nighttime",
-        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "monthly_water_anomaly",
-        "title": "Monthly Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_dekad"
-      },
-      {
-        "id": "ndvi_dekad",
-        "title": "10-day NDVI (MODIS)",
-        "server_layer_name": "mxd13a2_vim_dekad"
-      },
-      {
-        "id": "ndvi_dekad_anomaly",
-        "title": "10-day NDVI anomaly (MODIS)",
-        "server_layer_name": "mxd13a2_viq_dekad"
+        "id": "rain_anomaly_dekad",
+        "title": "10-day rainfall anomaly",
+        "server_layer_name": "rfq_dekad"
       },
       {
         "id": "rain_anomaly_1month",
@@ -1941,29 +1861,9 @@
         "server_layer_name": "r1q_dekad"
       },
       {
-        "id": "rain_anomaly_1year",
-        "title": "1-year rainfall anomaly",
-        "server_layer_name": "ryq_dekad"
-      },
-      {
-        "id": "rain_anomaly_2month",
-        "title": "2-month rainfall anomaly",
-        "server_layer_name": "r2q_dekad"
-      },
-      {
         "id": "rain_anomaly_3month",
         "title": "3-month rainfall anomaly",
         "server_layer_name": "r3q_dekad"
-      },
-      {
-        "id": "rain_anomaly_4month",
-        "title": "4-month rainfall anomaly",
-        "server_layer_name": "r4q_dekad"
-      },
-      {
-        "id": "rain_anomaly_5month",
-        "title": "5-month rainfall anomaly",
-        "server_layer_name": "r5q_dekad"
       },
       {
         "id": "rain_anomaly_6month",
@@ -1971,24 +1871,19 @@
         "server_layer_name": "r6q_dekad"
       },
       {
-        "id": "rain_anomaly_7month",
-        "title": "7-month rainfall anomaly",
-        "server_layer_name": "r7q_dekad"
-      },
-      {
-        "id": "rain_anomaly_8month",
-        "title": "8-month rainfall anomaly",
-        "server_layer_name": "r8q_dekad"
-      },
-      {
         "id": "rain_anomaly_9month",
         "title": "9-month rainfall anomaly",
         "server_layer_name": "r9q_dekad"
       },
       {
-        "id": "rain_anomaly_dekad",
-        "title": "10-day rainfall anomaly",
-        "server_layer_name": "rfq_dekad"
+        "id": "rain_anomaly_1year",
+        "title": "1-year rainfall anomaly",
+        "server_layer_name": "ryq_dekad"
+      },
+      {
+        "id": "rainfall_dekad",
+        "title": "10-day rainfall estimate (mm)",
+        "server_layer_name": "rfh_dekad"
       },
       {
         "id": "rainfall_agg_1month",
@@ -1996,29 +1891,9 @@
         "server_layer_name": "r1h_dekad"
       },
       {
-        "id": "rainfall_agg_1year",
-        "title": "1-year rainfall aggregate (mm)",
-        "server_layer_name": "ryh_dekad"
-      },
-      {
-        "id": "rainfall_agg_2month",
-        "title": "2-month rainfall aggregate (mm)",
-        "server_layer_name": "r2h_dekad"
-      },
-      {
         "id": "rainfall_agg_3month",
         "title": "3-month rainfall aggregate (mm)",
         "server_layer_name": "r3h_dekad"
-      },
-      {
-        "id": "rainfall_agg_4month",
-        "title": "4-month rainfall aggregate (mm)",
-        "server_layer_name": "r4h_dekad"
-      },
-      {
-        "id": "rainfall_agg_5month",
-        "title": "5-month rainfall aggregate (mm)",
-        "server_layer_name": "r5h_dekad"
       },
       {
         "id": "rainfall_agg_6month",
@@ -2026,39 +1901,19 @@
         "server_layer_name": "r6h_dekad"
       },
       {
-        "id": "rainfall_agg_7month",
-        "title": "7-month rainfall aggregate (mm)",
-        "server_layer_name": "r7h_dekad"
-      },
-      {
-        "id": "rainfall_agg_8month",
-        "title": "8-month rainfall aggregate (mm)",
-        "server_layer_name": "r8h_dekad"
-      },
-      {
         "id": "rainfall_agg_9month",
         "title": "9-month rainfall aggregate (mm)",
         "server_layer_name": "r9h_dekad"
       },
       {
-        "id": "rainfall_dekad",
-        "title": "10-day rainfall estimate (mm)",
-        "server_layer_name": "rfh_dekad"
+        "id": "rainfall_agg_1year",
+        "title": "1-year rainfall aggregate (mm)",
+        "server_layer_name": "ryh_dekad"
       },
       {
         "id": "spi_1m",
         "title": "SPI - 1-month",
         "server_layer_name": "r1s_dekad"
-      },
-      {
-        "id": "spi_1y",
-        "title": "SPI - 1-year",
-        "server_layer_name": "rys_dekad"
-      },
-      {
-        "id": "spi_2m",
-        "title": "SPI - 2-month",
-        "server_layer_name": "r2s_dekad"
       },
       {
         "id": "spi_3m",
@@ -2076,14 +1931,34 @@
         "server_layer_name": "r9s_dekad"
       },
       {
+        "id": "spi_1y",
+        "title": "SPI - 1-year",
+        "server_layer_name": "rys_dekad"
+      },
+      {
+        "id": "days_dry",
+        "title": "Days since last rain",
+        "server_layer_name": "dlc_dekad"
+      },
+      {
         "id": "streak_dry_days",
         "title": "Longest dry spell",
         "server_layer_name": "dlx_dekad"
       },
       {
-        "id": "streak_extreme_rain",
-        "title": "Longest consecutive extreme rainfall days",
-        "server_layer_name": "xle_dekad"
+        "id": "days_heavy_rain",
+        "title": "Number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xnh_dekad"
+      },
+      {
+        "id": "days_intense_rain",
+        "title": "Number of days with intense rainfall in the last 30 days",
+        "server_layer_name": "xni_dekad"
+      },
+      {
+        "id": "days_extreme_rain",
+        "title": "Number of days with extreme rainfall in the last 30 days",
+        "server_layer_name": "xne_dekad"
       },
       {
         "id": "streak_heavy_rain",
@@ -2094,9 +1969,107 @@
         "id": "streak_intense_rain",
         "title": "Longest consecutive intense rainfall days",
         "server_layer_name": "xli_dekad"
-      }
-    ],
-    "haiti": [
+      },
+      {
+        "id": "streak_extreme_rain",
+        "title": "Longest consecutive extreme rainfall days",
+        "server_layer_name": "xle_dekad"
+      },
+      {
+        "id": "lst_daytime",
+        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_nighttime",
+        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_amplitude",
+        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
+        "server_layer_name": "myd11a2_taa_dekad"
+      },
+      {
+        "id": "ndvi_dekad",
+        "title": "10-day NDVI (MODIS)",
+        "server_layer_name": "mxd13a2_vim_dekad"
+      },
+      {
+        "id": "ndvi_dekad_anomaly",
+        "title": "10-day NDVI anomaly (MODIS)",
+        "server_layer_name": "mxd13a2_viq_dekad"
+      },
+      {
+        "id": "rainfall_agg_2month",
+        "title": "2-month rainfall aggregate (mm)",
+        "server_layer_name": "r2h_dekad"
+      },
+      {
+        "id": "rain_anomaly_2month",
+        "title": "2-month rainfall anomaly",
+        "server_layer_name": "r2q_dekad"
+      },
+      {
+        "id": "rainfall_agg_4month",
+        "title": "4-month rainfall aggregate (mm)",
+        "server_layer_name": "r4h_dekad"
+      },
+      {
+        "id": "rain_anomaly_4month",
+        "title": "4-month rainfall anomaly",
+        "server_layer_name": "r4q_dekad"
+      },
+      {
+        "id": "rainfall_agg_5month",
+        "title": "5-month rainfall aggregate (mm)",
+        "server_layer_name": "r5h_dekad"
+      },
+      {
+        "id": "rain_anomaly_5month",
+        "title": "5-month rainfall anomaly",
+        "server_layer_name": "r5q_dekad"
+      },
+      {
+        "id": "rainfall_agg_7month",
+        "title": "7-month rainfall aggregate (mm)",
+        "server_layer_name": "r7h_dekad"
+      },
+      {
+        "id": "rain_anomaly_7month",
+        "title": "7-month rainfall anomaly",
+        "server_layer_name": "r7q_dekad"
+      },
+      {
+        "id": "rainfall_agg_8month",
+        "title": "8-month rainfall aggregate (mm)",
+        "server_layer_name": "r8h_dekad"
+      },
+      {
+        "id": "rain_anomaly_8month",
+        "title": "8-month rainfall anomaly",
+        "server_layer_name": "r8q_dekad"
+      },
+      {
+        "id": "spi_2m",
+        "title": "SPI - 2-month",
+        "server_layer_name": "r2s_dekad"
+      },
+      {
+        "id": "lst_day_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "monthly_water_anomaly",
+        "title": "Monthly Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_dekad"
+      },
       {
         "id": "2m_water_anomaly",
         "title": "2-Month Water Anomaly Index (WAI)",
@@ -2121,206 +2094,13 @@
         "id": "6m_water_anomaly",
         "title": "6-Month Water Anomaly Index (WAI)",
         "server_layer_name": "wai_seasonal_6month"
-      },
-      {
-        "id": "daily_rainfall_forecast",
-        "title": "Rolling daily rainfall forecast",
-        "server_layer_name": "rfh_daily_forecast"
-      },
-      {
-        "id": "days_dry",
-        "title": "Days since last rain",
-        "server_layer_name": "dlc_dekad"
-      },
-      {
-        "id": "days_extreme_rain",
-        "title": "Number of days with extreme rainfall in the last 30 days",
-        "server_layer_name": "xne_dekad"
-      },
-      {
-        "id": "days_heavy_rain",
-        "title": "Number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xnh_dekad"
-      },
-      {
-        "id": "days_intense_rain",
-        "title": "Number of days with intense rainfall in the last 30 days",
-        "server_layer_name": "xni_dekad"
-      },
-      {
-        "id": "dekad_rainfall_anomaly_forecast",
-        "title": "10-day rainfall forecast anomaly",
-        "server_layer_name": "rfq_dekad"
-      },
-      {
-        "id": "dekad_rainfall_forecast",
-        "title": "10-day rainfall forecast",
-        "server_layer_name": "rfh_dekad_forecast"
-      },
-      {
-        "id": "lst_amplitude",
-        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
-        "server_layer_name": "myd11a2_taa_dekad"
-      },
-      {
-        "id": "lst_anomaly",
-        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_day_anomaly",
-        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_daytime",
-        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "lst_nighttime",
-        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "monthly_water_anomaly",
-        "title": "Monthly Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_dekad"
-      },
-      {
-        "id": "ndvi_dekad",
-        "title": "10-day NDVI (MODIS)",
-        "server_layer_name": "mxd13a2_vim_dekad"
-      },
-      {
-        "id": "ndvi_dekad_anomaly",
-        "title": "10-day NDVI anomaly (MODIS)",
-        "server_layer_name": "mxd13a2_viq_dekad"
-      },
-      {
-        "id": "rain_anomaly_1month",
-        "title": "Monthly rainfall anomaly",
-        "server_layer_name": "r1q_dekad"
-      },
-      {
-        "id": "rain_anomaly_1year",
-        "title": "1-year rainfall anomaly",
-        "server_layer_name": "ryq_dekad"
-      },
-      {
-        "id": "rain_anomaly_2month",
-        "title": "2-month rainfall anomaly",
-        "server_layer_name": "r2q_dekad"
-      },
-      {
-        "id": "rain_anomaly_3month",
-        "title": "3-month rainfall anomaly",
-        "server_layer_name": "r3q_dekad"
-      },
-      {
-        "id": "rain_anomaly_4month",
-        "title": "4-month rainfall anomaly",
-        "server_layer_name": "r4q_dekad"
-      },
-      {
-        "id": "rain_anomaly_5month",
-        "title": "5-month rainfall anomaly",
-        "server_layer_name": "r5q_dekad"
-      },
-      {
-        "id": "rain_anomaly_6month",
-        "title": "6-month rainfall anomaly",
-        "server_layer_name": "r6q_dekad"
-      },
-      {
-        "id": "rain_anomaly_7month",
-        "title": "7-month rainfall anomaly",
-        "server_layer_name": "r7q_dekad"
-      },
-      {
-        "id": "rain_anomaly_8month",
-        "title": "8-month rainfall anomaly",
-        "server_layer_name": "r8q_dekad"
-      },
-      {
-        "id": "rain_anomaly_9month",
-        "title": "9-month rainfall anomaly",
-        "server_layer_name": "r9q_dekad"
-      },
-      {
-        "id": "rain_anomaly_dekad",
-        "title": "10-day rainfall anomaly",
-        "server_layer_name": "rfq_dekad"
-      },
-      {
-        "id": "rainfall_agg_1month",
-        "title": "1-month rainfall aggregate (mm)",
-        "server_layer_name": "r1h_dekad"
-      },
-      {
-        "id": "rainfall_agg_1year",
-        "title": "1-year rainfall aggregate (mm)",
-        "server_layer_name": "ryh_dekad"
-      },
-      {
-        "id": "rainfall_agg_2month",
-        "title": "2-month rainfall aggregate (mm)",
-        "server_layer_name": "r2h_dekad"
-      },
-      {
-        "id": "rainfall_agg_3month",
-        "title": "3-month rainfall aggregate (mm)",
-        "server_layer_name": "r3h_dekad"
-      },
-      {
-        "id": "rainfall_agg_4month",
-        "title": "4-month rainfall aggregate (mm)",
-        "server_layer_name": "r4h_dekad"
-      },
-      {
-        "id": "rainfall_agg_5month",
-        "title": "5-month rainfall aggregate (mm)",
-        "server_layer_name": "r5h_dekad"
-      },
-      {
-        "id": "rainfall_agg_6month",
-        "title": "6-month rainfall aggregate (mm)",
-        "server_layer_name": "r6h_dekad"
-      },
-      {
-        "id": "rainfall_agg_7month",
-        "title": "7-month rainfall aggregate (mm)",
-        "server_layer_name": "r7h_dekad"
-      },
-      {
-        "id": "rainfall_agg_8month",
-        "title": "8-month rainfall aggregate (mm)",
-        "server_layer_name": "r8h_dekad"
-      },
-      {
-        "id": "rainfall_agg_9month",
-        "title": "9-month rainfall aggregate (mm)",
-        "server_layer_name": "r9h_dekad"
-      },
-      {
-        "id": "rainfall_dekad",
-        "title": "10-day rainfall estimate (mm)",
-        "server_layer_name": "rfh_dekad"
-      },
+      }
+    ],
+    "haiti": [
       {
         "id": "spi_1m",
         "title": "SPI - 1-month",
         "server_layer_name": "r1s_dekad"
-      },
-      {
-        "id": "spi_1y",
-        "title": "SPI - 1-year",
-        "server_layer_name": "rys_dekad"
-      },
-      {
-        "id": "spi_2m",
-        "title": "SPI - 2-month",
-        "server_layer_name": "r2s_dekad"
       },
       {
         "id": "spi_3m",
@@ -2338,14 +2118,124 @@
         "server_layer_name": "r9s_dekad"
       },
       {
+        "id": "spi_1y",
+        "title": "SPI - 1-year",
+        "server_layer_name": "rys_dekad"
+      },
+      {
+        "id": "rainfall_dekad",
+        "title": "10-day rainfall estimate (mm)",
+        "server_layer_name": "rfh_dekad"
+      },
+      {
+        "id": "rain_anomaly_dekad",
+        "title": "10-day rainfall anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rainfall_agg_1month",
+        "title": "1-month rainfall aggregate (mm)",
+        "server_layer_name": "r1h_dekad"
+      },
+      {
+        "id": "rain_anomaly_1month",
+        "title": "Monthly rainfall anomaly",
+        "server_layer_name": "r1q_dekad"
+      },
+      {
+        "id": "rainfall_agg_3month",
+        "title": "3-month rainfall aggregate (mm)",
+        "server_layer_name": "r3h_dekad"
+      },
+      {
+        "id": "rain_anomaly_3month",
+        "title": "3-month rainfall anomaly",
+        "server_layer_name": "r3q_dekad"
+      },
+      {
+        "id": "rain_anomaly_6month",
+        "title": "6-month rainfall anomaly",
+        "server_layer_name": "r6q_dekad"
+      },
+      {
+        "id": "rain_anomaly_9month",
+        "title": "9-month rainfall anomaly",
+        "server_layer_name": "r9q_dekad"
+      },
+      {
+        "id": "rain_anomaly_1year",
+        "title": "1-year rainfall anomaly",
+        "server_layer_name": "ryq_dekad"
+      },
+      {
+        "id": "rainfall_agg_2month",
+        "title": "2-month rainfall aggregate (mm)",
+        "server_layer_name": "r2h_dekad"
+      },
+      {
+        "id": "rain_anomaly_2month",
+        "title": "2-month rainfall anomaly",
+        "server_layer_name": "r2q_dekad"
+      },
+      {
+        "id": "rainfall_agg_4month",
+        "title": "4-month rainfall aggregate (mm)",
+        "server_layer_name": "r4h_dekad"
+      },
+      {
+        "id": "rain_anomaly_4month",
+        "title": "4-month rainfall anomaly",
+        "server_layer_name": "r4q_dekad"
+      },
+      {
+        "id": "rainfall_agg_5month",
+        "title": "5-month rainfall aggregate (mm)",
+        "server_layer_name": "r5h_dekad"
+      },
+      {
+        "id": "rain_anomaly_5month",
+        "title": "5-month rainfall anomaly",
+        "server_layer_name": "r5q_dekad"
+      },
+      {
+        "id": "rainfall_agg_6month",
+        "title": "6-month rainfall aggregate (mm)",
+        "server_layer_name": "r6h_dekad"
+      },
+      {
+        "id": "rainfall_agg_9month",
+        "title": "9-month rainfall aggregate (mm)",
+        "server_layer_name": "r9h_dekad"
+      },
+      {
+        "id": "rainfall_agg_1year",
+        "title": "1-year rainfall aggregate (mm)",
+        "server_layer_name": "ryh_dekad"
+      },
+      {
+        "id": "days_dry",
+        "title": "Days since last rain",
+        "server_layer_name": "dlc_dekad"
+      },
+      {
         "id": "streak_dry_days",
         "title": "Longest number of consecutive dry days",
         "server_layer_name": "dlx_dekad"
       },
       {
-        "id": "streak_extreme_rain",
-        "title": "Longest consecutive extreme rainfall days",
-        "server_layer_name": "xle_dekad"
+        "id": "days_heavy_rain",
+        "title": "Number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xnh_dekad"
+      },
+      {
+        "id": "days_intense_rain",
+        "title": "Number of days with intense rainfall in the last 30 days",
+        "server_layer_name": "xni_dekad"
+      },
+      {
+        "id": "days_extreme_rain",
+        "title": "Number of days with extreme rainfall in the last 30 days",
+        "server_layer_name": "xne_dekad"
       },
       {
         "id": "streak_heavy_rain",
@@ -2356,9 +2246,92 @@
         "id": "streak_intense_rain",
         "title": "Longest consecutive intense rainfall days",
         "server_layer_name": "xli_dekad"
-      }
-    ],
-    "indonesia": [
+      },
+      {
+        "id": "streak_extreme_rain",
+        "title": "Longest consecutive extreme rainfall days",
+        "server_layer_name": "xle_dekad"
+      },
+      {
+        "id": "ndvi_dekad",
+        "title": "10-day NDVI (MODIS)",
+        "server_layer_name": "mxd13a2_vim_dekad"
+      },
+      {
+        "id": "ndvi_dekad_anomaly",
+        "title": "10-day NDVI anomaly (MODIS)",
+        "server_layer_name": "mxd13a2_viq_dekad"
+      },
+      {
+        "id": "lst_amplitude",
+        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
+        "server_layer_name": "myd11a2_taa_dekad"
+      },
+      {
+        "id": "lst_daytime",
+        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "daily_rainfall_forecast",
+        "title": "Rolling daily rainfall forecast",
+        "server_layer_name": "rfh_daily_forecast"
+      },
+      {
+        "id": "dekad_rainfall_forecast",
+        "title": "10-day rainfall forecast",
+        "server_layer_name": "rfh_dekad_forecast"
+      },
+      {
+        "id": "dekad_rainfall_anomaly_forecast",
+        "title": "10-day rainfall forecast anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rainfall_agg_7month",
+        "title": "7-month rainfall aggregate (mm)",
+        "server_layer_name": "r7h_dekad"
+      },
+      {
+        "id": "rain_anomaly_7month",
+        "title": "7-month rainfall anomaly",
+        "server_layer_name": "r7q_dekad"
+      },
+      {
+        "id": "rainfall_agg_8month",
+        "title": "8-month rainfall aggregate (mm)",
+        "server_layer_name": "r8h_dekad"
+      },
+      {
+        "id": "rain_anomaly_8month",
+        "title": "8-month rainfall anomaly",
+        "server_layer_name": "r8q_dekad"
+      },
+      {
+        "id": "spi_2m",
+        "title": "SPI - 2-month",
+        "server_layer_name": "r2s_dekad"
+      },
+      {
+        "id": "lst_nighttime",
+        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_day_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "monthly_water_anomaly",
+        "title": "Monthly Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_dekad"
+      },
       {
         "id": "2m_water_anomaly",
         "title": "2-Month Water Anomaly Index (WAI)",
@@ -2383,81 +2356,13 @@
         "id": "6m_water_anomaly",
         "title": "6-Month Water Anomaly Index (WAI)",
         "server_layer_name": "wai_seasonal_6month"
-      },
+      }
+    ],
+    "indonesia": [
       {
-        "id": "daily_rainfall_forecast",
-        "title": "Rolling daily rainfall forecast",
-        "server_layer_name": "rfh_daily_forecast"
-      },
-      {
-        "id": "days_dry",
-        "title": "Days since last rain",
-        "server_layer_name": "dlc_dekad"
-      },
-      {
-        "id": "days_extreme_rain",
-        "title": "Number of days with extreme rainfall in the last 30 days",
-        "server_layer_name": "xne_dekad"
-      },
-      {
-        "id": "days_heavy_rain",
-        "title": "Number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xnh_dekad"
-      },
-      {
-        "id": "days_intense_rain",
-        "title": "Number of days with intense rainfall in the last 30 days",
-        "server_layer_name": "xni_dekad"
-      },
-      {
-        "id": "dekad_rainfall_anomaly_forecast",
-        "title": "10-day rainfall forecast anomaly",
+        "id": "rain_anomaly_dekad",
+        "title": "CHIRPS 10-day rainfall anomaly",
         "server_layer_name": "rfq_dekad"
-      },
-      {
-        "id": "dekad_rainfall_forecast",
-        "title": "10-day rainfall forecast",
-        "server_layer_name": "rfh_dekad_forecast"
-      },
-      {
-        "id": "lst_amplitude",
-        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
-        "server_layer_name": "myd11a2_taa_dekad"
-      },
-      {
-        "id": "lst_anomaly",
-        "title": "Daytime Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_day_anomaly",
-        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_daytime",
-        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "lst_nighttime",
-        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "monthly_water_anomaly",
-        "title": "Monthly Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_dekad"
-      },
-      {
-        "id": "ndvi_dekad",
-        "title": "10-day NDVI (MODIS)",
-        "server_layer_name": "mxd13a2_vim_dekad"
-      },
-      {
-        "id": "ndvi_dekad_anomaly",
-        "title": "10-day NDVI anomaly (MODIS)",
-        "server_layer_name": "mxd13a2_viq_dekad"
       },
       {
         "id": "rain_anomaly_1month",
@@ -2465,29 +2370,9 @@
         "server_layer_name": "r1q_dekad"
       },
       {
-        "id": "rain_anomaly_1year",
-        "title": "CHIRPS 1-year rainfall anomaly",
-        "server_layer_name": "ryq_dekad"
-      },
-      {
-        "id": "rain_anomaly_2month",
-        "title": "2-month rainfall anomaly",
-        "server_layer_name": "r2q_dekad"
-      },
-      {
         "id": "rain_anomaly_3month",
         "title": "CHIRPS 3-month rainfall anomaly",
         "server_layer_name": "r3q_dekad"
-      },
-      {
-        "id": "rain_anomaly_4month",
-        "title": "4-month rainfall anomaly",
-        "server_layer_name": "r4q_dekad"
-      },
-      {
-        "id": "rain_anomaly_5month",
-        "title": "5-month rainfall anomaly",
-        "server_layer_name": "r5q_dekad"
       },
       {
         "id": "rain_anomaly_6month",
@@ -2495,74 +2380,14 @@
         "server_layer_name": "r6q_dekad"
       },
       {
-        "id": "rain_anomaly_7month",
-        "title": "7-month rainfall anomaly",
-        "server_layer_name": "r7q_dekad"
-      },
-      {
-        "id": "rain_anomaly_8month",
-        "title": "8-month rainfall anomaly",
-        "server_layer_name": "r8q_dekad"
-      },
-      {
         "id": "rain_anomaly_9month",
         "title": "CHIRPS 9-month rainfall anomaly",
         "server_layer_name": "r9q_dekad"
       },
       {
-        "id": "rain_anomaly_dekad",
-        "title": "CHIRPS 10-day rainfall anomaly",
-        "server_layer_name": "rfq_dekad"
-      },
-      {
-        "id": "rainfall_agg_1month",
-        "title": "CHIRPS 1-month rainfall aggregate",
-        "server_layer_name": "r1h_dekad"
-      },
-      {
-        "id": "rainfall_agg_1year",
-        "title": "CHIRPS 1-year rainfall aggregate (mm)",
-        "server_layer_name": "ryh_dekad"
-      },
-      {
-        "id": "rainfall_agg_2month",
-        "title": "2-month rainfall aggregate (mm)",
-        "server_layer_name": "r2h_dekad"
-      },
-      {
-        "id": "rainfall_agg_3month",
-        "title": "CHIRPS 3-month rainfall aggregate (mm)",
-        "server_layer_name": "r3h_dekad"
-      },
-      {
-        "id": "rainfall_agg_4month",
-        "title": "4-month rainfall aggregate (mm)",
-        "server_layer_name": "r4h_dekad"
-      },
-      {
-        "id": "rainfall_agg_5month",
-        "title": "5-month rainfall aggregate (mm)",
-        "server_layer_name": "r5h_dekad"
-      },
-      {
-        "id": "rainfall_agg_6month",
-        "title": "CHIRPS 6-month rainfall aggregate (mm)",
-        "server_layer_name": "r6h_dekad"
-      },
-      {
-        "id": "rainfall_agg_7month",
-        "title": "7-month rainfall aggregate (mm)",
-        "server_layer_name": "r7h_dekad"
-      },
-      {
-        "id": "rainfall_agg_8month",
-        "title": "8-month rainfall aggregate (mm)",
-        "server_layer_name": "r8h_dekad"
-      },
-      {
-        "id": "rainfall_agg_9month",
-        "title": "CHIRPS 9-month rainfall aggregate (mm)",
-        "server_layer_name": "r9h_dekad"
+        "id": "rain_anomaly_1year",
+        "title": "CHIRPS 1-year rainfall anomaly",
+        "server_layer_name": "ryq_dekad"
       },
       {
         "id": "rainfall_dekad",
@@ -2570,19 +2395,34 @@
         "server_layer_name": "rfh_dekad"
       },
       {
+        "id": "rainfall_agg_1month",
+        "title": "CHIRPS 1-month rainfall aggregate",
+        "server_layer_name": "r1h_dekad"
+      },
+      {
+        "id": "rainfall_agg_3month",
+        "title": "CHIRPS 3-month rainfall aggregate (mm)",
+        "server_layer_name": "r3h_dekad"
+      },
+      {
+        "id": "rainfall_agg_6month",
+        "title": "CHIRPS 6-month rainfall aggregate (mm)",
+        "server_layer_name": "r6h_dekad"
+      },
+      {
+        "id": "rainfall_agg_9month",
+        "title": "CHIRPS 9-month rainfall aggregate (mm)",
+        "server_layer_name": "r9h_dekad"
+      },
+      {
+        "id": "rainfall_agg_1year",
+        "title": "CHIRPS 1-year rainfall aggregate (mm)",
+        "server_layer_name": "ryh_dekad"
+      },
+      {
         "id": "spi_1m",
         "title": "SPI - 1-month",
         "server_layer_name": "r1s_dekad"
-      },
-      {
-        "id": "spi_1y",
-        "title": "SPI - 1-year",
-        "server_layer_name": "rys_dekad"
-      },
-      {
-        "id": "spi_2m",
-        "title": "SPI - 2-month",
-        "server_layer_name": "r2s_dekad"
       },
       {
         "id": "spi_3m",
@@ -2600,14 +2440,34 @@
         "server_layer_name": "r9s_dekad"
       },
       {
+        "id": "spi_1y",
+        "title": "SPI - 1-year",
+        "server_layer_name": "rys_dekad"
+      },
+      {
+        "id": "days_dry",
+        "title": "Days since last rain",
+        "server_layer_name": "dlc_dekad"
+      },
+      {
         "id": "streak_dry_days",
         "title": "Longest dry spell",
         "server_layer_name": "dlx_dekad"
       },
       {
-        "id": "streak_extreme_rain",
-        "title": "Longest consecutive extreme rainfall days",
-        "server_layer_name": "xle_dekad"
+        "id": "days_heavy_rain",
+        "title": "Number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xnh_dekad"
+      },
+      {
+        "id": "days_intense_rain",
+        "title": "Number of days with intense rainfall in the last 30 days",
+        "server_layer_name": "xni_dekad"
+      },
+      {
+        "id": "days_extreme_rain",
+        "title": "Number of days with extreme rainfall in the last 30 days",
+        "server_layer_name": "xne_dekad"
       },
       {
         "id": "streak_heavy_rain",
@@ -2618,10 +2478,385 @@
         "id": "streak_intense_rain",
         "title": "Longest consecutive intense rainfall days",
         "server_layer_name": "xli_dekad"
+      },
+      {
+        "id": "streak_extreme_rain",
+        "title": "Longest consecutive extreme rainfall days",
+        "server_layer_name": "xle_dekad"
+      },
+      {
+        "id": "ndvi_dekad",
+        "title": "10-day NDVI (MODIS)",
+        "server_layer_name": "mxd13a2_vim_dekad"
+      },
+      {
+        "id": "ndvi_dekad_anomaly",
+        "title": "10-day NDVI anomaly (MODIS)",
+        "server_layer_name": "mxd13a2_viq_dekad"
+      },
+      {
+        "id": "lst_amplitude",
+        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
+        "server_layer_name": "myd11a2_taa_dekad"
+      },
+      {
+        "id": "lst_daytime",
+        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_nighttime",
+        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_anomaly",
+        "title": "Daytime Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "daily_rainfall_forecast",
+        "title": "Rolling daily rainfall forecast",
+        "server_layer_name": "rfh_daily_forecast"
+      },
+      {
+        "id": "dekad_rainfall_forecast",
+        "title": "10-day rainfall forecast",
+        "server_layer_name": "rfh_dekad_forecast"
+      },
+      {
+        "id": "dekad_rainfall_anomaly_forecast",
+        "title": "10-day rainfall forecast anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rainfall_agg_2month",
+        "title": "2-month rainfall aggregate (mm)",
+        "server_layer_name": "r2h_dekad"
+      },
+      {
+        "id": "rain_anomaly_2month",
+        "title": "2-month rainfall anomaly",
+        "server_layer_name": "r2q_dekad"
+      },
+      {
+        "id": "rainfall_agg_4month",
+        "title": "4-month rainfall aggregate (mm)",
+        "server_layer_name": "r4h_dekad"
+      },
+      {
+        "id": "rain_anomaly_4month",
+        "title": "4-month rainfall anomaly",
+        "server_layer_name": "r4q_dekad"
+      },
+      {
+        "id": "rainfall_agg_5month",
+        "title": "5-month rainfall aggregate (mm)",
+        "server_layer_name": "r5h_dekad"
+      },
+      {
+        "id": "rain_anomaly_5month",
+        "title": "5-month rainfall anomaly",
+        "server_layer_name": "r5q_dekad"
+      },
+      {
+        "id": "rainfall_agg_7month",
+        "title": "7-month rainfall aggregate (mm)",
+        "server_layer_name": "r7h_dekad"
+      },
+      {
+        "id": "rain_anomaly_7month",
+        "title": "7-month rainfall anomaly",
+        "server_layer_name": "r7q_dekad"
+      },
+      {
+        "id": "rainfall_agg_8month",
+        "title": "8-month rainfall aggregate (mm)",
+        "server_layer_name": "r8h_dekad"
+      },
+      {
+        "id": "rain_anomaly_8month",
+        "title": "8-month rainfall anomaly",
+        "server_layer_name": "r8q_dekad"
+      },
+      {
+        "id": "spi_2m",
+        "title": "SPI - 2-month",
+        "server_layer_name": "r2s_dekad"
+      },
+      {
+        "id": "lst_day_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "monthly_water_anomaly",
+        "title": "Monthly Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_dekad"
+      },
+      {
+        "id": "2m_water_anomaly",
+        "title": "2-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_2month"
+      },
+      {
+        "id": "3m_water_anomaly",
+        "title": "3-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_3month"
+      },
+      {
+        "id": "4m_water_anomaly",
+        "title": "4-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_4month"
+      },
+      {
+        "id": "5m_water_anomaly",
+        "title": "5-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_5month"
+      },
+      {
+        "id": "6m_water_anomaly",
+        "title": "6-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_6month"
       }
     ],
     "jordan": [
       {
+        "id": "rainfall_dekad",
+        "title": "10-day rainfall estimate (mm)",
+        "server_layer_name": "rfh_dekad"
+      },
+      {
+        "id": "rain_anomaly_dekad",
+        "title": "10-day rainfall anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rainfall_agg_1month",
+        "title": "1-month rainfall aggregate",
+        "server_layer_name": "r1h_dekad"
+      },
+      {
+        "id": "rain_anomaly_1month",
+        "title": "Monthly rainfall anomaly",
+        "server_layer_name": "r1q_dekad"
+      },
+      {
+        "id": "rainfall_agg_3month",
+        "title": "3-month rainfall aggregate (mm)",
+        "server_layer_name": "r3h_dekad"
+      },
+      {
+        "id": "rain_anomaly_3month",
+        "title": "3-month rainfall anomaly",
+        "server_layer_name": "r3q_dekad"
+      },
+      {
+        "id": "ndvi_dekad",
+        "title": "10-day NDVI (MODIS)",
+        "server_layer_name": "mxd13a2_vim_dekad"
+      },
+      {
+        "id": "ndvi_dekad_anomaly",
+        "title": "10-day NDVI anomaly (MODIS)",
+        "server_layer_name": "mxd13a2_viq_dekad"
+      },
+      {
+        "id": "daily_rainfall_forecast",
+        "title": "Rolling daily rainfall forecast",
+        "server_layer_name": "rfh_daily_forecast"
+      },
+      {
+        "id": "dekad_rainfall_forecast",
+        "title": "10-day rainfall forecast",
+        "server_layer_name": "rfh_dekad_forecast"
+      },
+      {
+        "id": "dekad_rainfall_anomaly_forecast",
+        "title": "10-day rainfall forecast anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rainfall_agg_2month",
+        "title": "2-month rainfall aggregate (mm)",
+        "server_layer_name": "r2h_dekad"
+      },
+      {
+        "id": "rain_anomaly_2month",
+        "title": "2-month rainfall anomaly",
+        "server_layer_name": "r2q_dekad"
+      },
+      {
+        "id": "rainfall_agg_4month",
+        "title": "4-month rainfall aggregate (mm)",
+        "server_layer_name": "r4h_dekad"
+      },
+      {
+        "id": "rain_anomaly_4month",
+        "title": "4-month rainfall anomaly",
+        "server_layer_name": "r4q_dekad"
+      },
+      {
+        "id": "rainfall_agg_5month",
+        "title": "5-month rainfall aggregate (mm)",
+        "server_layer_name": "r5h_dekad"
+      },
+      {
+        "id": "rain_anomaly_5month",
+        "title": "5-month rainfall anomaly",
+        "server_layer_name": "r5q_dekad"
+      },
+      {
+        "id": "rainfall_agg_6month",
+        "title": "6-month rainfall aggregate (mm)",
+        "server_layer_name": "r6h_dekad"
+      },
+      {
+        "id": "rain_anomaly_6month",
+        "title": "6-month rainfall anomaly",
+        "server_layer_name": "r6q_dekad"
+      },
+      {
+        "id": "rainfall_agg_7month",
+        "title": "7-month rainfall aggregate (mm)",
+        "server_layer_name": "r7h_dekad"
+      },
+      {
+        "id": "rain_anomaly_7month",
+        "title": "7-month rainfall anomaly",
+        "server_layer_name": "r7q_dekad"
+      },
+      {
+        "id": "rainfall_agg_8month",
+        "title": "8-month rainfall aggregate (mm)",
+        "server_layer_name": "r8h_dekad"
+      },
+      {
+        "id": "rain_anomaly_8month",
+        "title": "8-month rainfall anomaly",
+        "server_layer_name": "r8q_dekad"
+      },
+      {
+        "id": "rainfall_agg_9month",
+        "title": "9-month rainfall aggregate (mm)",
+        "server_layer_name": "r9h_dekad"
+      },
+      {
+        "id": "rain_anomaly_9month",
+        "title": "9-month rainfall anomaly",
+        "server_layer_name": "r9q_dekad"
+      },
+      {
+        "id": "rainfall_agg_1year",
+        "title": "1-year rainfall aggregate (mm)",
+        "server_layer_name": "ryh_dekad"
+      },
+      {
+        "id": "rain_anomaly_1year",
+        "title": "1-year rainfall anomaly",
+        "server_layer_name": "ryq_dekad"
+      },
+      {
+        "id": "spi_1m",
+        "title": "SPI - 1-month",
+        "server_layer_name": "r1s_dekad"
+      },
+      {
+        "id": "spi_2m",
+        "title": "SPI - 2-month",
+        "server_layer_name": "r2s_dekad"
+      },
+      {
+        "id": "spi_3m",
+        "title": "SPI - 3-month",
+        "server_layer_name": "r3s_dekad"
+      },
+      {
+        "id": "spi_6m",
+        "title": "SPI - 6-month",
+        "server_layer_name": "r6s_dekad"
+      },
+      {
+        "id": "spi_9m",
+        "title": "SPI - 9-month",
+        "server_layer_name": "r9s_dekad"
+      },
+      {
+        "id": "spi_1y",
+        "title": "SPI - 1-year",
+        "server_layer_name": "rys_dekad"
+      },
+      {
+        "id": "days_dry",
+        "title": "Days since last rain",
+        "server_layer_name": "dlc_dekad"
+      },
+      {
+        "id": "streak_dry_days",
+        "title": "Longest dry spell",
+        "server_layer_name": "dlx_dekad"
+      },
+      {
+        "id": "days_heavy_rain",
+        "title": "Number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xnh_dekad"
+      },
+      {
+        "id": "days_intense_rain",
+        "title": "Number of days with intense rainfall in the last 30 days",
+        "server_layer_name": "xni_dekad"
+      },
+      {
+        "id": "days_extreme_rain",
+        "title": "Number of days with extreme rainfall in the last 30 days",
+        "server_layer_name": "xne_dekad"
+      },
+      {
+        "id": "streak_heavy_rain",
+        "title": "Longest consecutive heavy rainfall days",
+        "server_layer_name": "xlh_dekad"
+      },
+      {
+        "id": "streak_intense_rain",
+        "title": "Longest consecutive intense rainfall days",
+        "server_layer_name": "xli_dekad"
+      },
+      {
+        "id": "streak_extreme_rain",
+        "title": "Longest consecutive extreme rainfall days",
+        "server_layer_name": "xle_dekad"
+      },
+      {
+        "id": "lst_amplitude",
+        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
+        "server_layer_name": "myd11a2_taa_dekad"
+      },
+      {
+        "id": "lst_daytime",
+        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_nighttime",
+        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_day_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "monthly_water_anomaly",
+        "title": "Monthly Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_dekad"
+      },
+      {
         "id": "2m_water_anomaly",
         "title": "2-Month Water Anomaly Index (WAI)",
         "server_layer_name": "wai_seasonal_2month"
@@ -2645,245 +2880,245 @@
         "id": "6m_water_anomaly",
         "title": "6-Month Water Anomaly Index (WAI)",
         "server_layer_name": "wai_seasonal_6month"
-      },
-      {
-        "id": "daily_rainfall_forecast",
-        "title": "Rolling daily rainfall forecast",
-        "server_layer_name": "rfh_daily_forecast"
-      },
-      {
-        "id": "days_dry",
-        "title": "Days since last rain",
-        "server_layer_name": "dlc_dekad"
-      },
-      {
-        "id": "days_extreme_rain",
-        "title": "Number of days with extreme rainfall in the last 30 days",
-        "server_layer_name": "xne_dekad"
-      },
-      {
-        "id": "days_heavy_rain",
-        "title": "Number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xnh_dekad"
-      },
-      {
-        "id": "days_intense_rain",
-        "title": "Number of days with intense rainfall in the last 30 days",
-        "server_layer_name": "xni_dekad"
-      },
-      {
-        "id": "dekad_rainfall_anomaly_forecast",
-        "title": "10-day rainfall forecast anomaly",
-        "server_layer_name": "rfq_dekad"
-      },
-      {
-        "id": "dekad_rainfall_forecast",
-        "title": "10-day rainfall forecast",
-        "server_layer_name": "rfh_dekad_forecast"
-      },
-      {
-        "id": "lst_amplitude",
-        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
-        "server_layer_name": "myd11a2_taa_dekad"
-      },
-      {
-        "id": "lst_anomaly",
-        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_day_anomaly",
-        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_daytime",
-        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "lst_nighttime",
-        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "monthly_water_anomaly",
-        "title": "Monthly Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_dekad"
-      },
-      {
-        "id": "ndvi_dekad",
-        "title": "10-day NDVI (MODIS)",
-        "server_layer_name": "mxd13a2_vim_dekad"
-      },
-      {
-        "id": "ndvi_dekad_anomaly",
-        "title": "10-day NDVI anomaly (MODIS)",
-        "server_layer_name": "mxd13a2_viq_dekad"
-      },
-      {
-        "id": "rain_anomaly_1month",
-        "title": "Monthly rainfall anomaly",
-        "server_layer_name": "r1q_dekad"
-      },
-      {
-        "id": "rain_anomaly_1year",
-        "title": "1-year rainfall anomaly",
-        "server_layer_name": "ryq_dekad"
-      },
-      {
-        "id": "rain_anomaly_2month",
-        "title": "2-month rainfall anomaly",
-        "server_layer_name": "r2q_dekad"
-      },
-      {
-        "id": "rain_anomaly_3month",
-        "title": "3-month rainfall anomaly",
-        "server_layer_name": "r3q_dekad"
-      },
-      {
-        "id": "rain_anomaly_4month",
-        "title": "4-month rainfall anomaly",
-        "server_layer_name": "r4q_dekad"
-      },
-      {
-        "id": "rain_anomaly_5month",
-        "title": "5-month rainfall anomaly",
-        "server_layer_name": "r5q_dekad"
-      },
-      {
-        "id": "rain_anomaly_6month",
-        "title": "6-month rainfall anomaly",
-        "server_layer_name": "r6q_dekad"
-      },
-      {
-        "id": "rain_anomaly_7month",
-        "title": "7-month rainfall anomaly",
-        "server_layer_name": "r7q_dekad"
-      },
-      {
-        "id": "rain_anomaly_8month",
-        "title": "8-month rainfall anomaly",
-        "server_layer_name": "r8q_dekad"
-      },
-      {
-        "id": "rain_anomaly_9month",
-        "title": "9-month rainfall anomaly",
-        "server_layer_name": "r9q_dekad"
-      },
-      {
-        "id": "rain_anomaly_dekad",
-        "title": "10-day rainfall anomaly",
-        "server_layer_name": "rfq_dekad"
-      },
-      {
-        "id": "rainfall_agg_1month",
-        "title": "1-month rainfall aggregate",
-        "server_layer_name": "r1h_dekad"
-      },
-      {
-        "id": "rainfall_agg_1year",
-        "title": "1-year rainfall aggregate (mm)",
-        "server_layer_name": "ryh_dekad"
-      },
-      {
-        "id": "rainfall_agg_2month",
-        "title": "2-month rainfall aggregate (mm)",
-        "server_layer_name": "r2h_dekad"
-      },
-      {
-        "id": "rainfall_agg_3month",
-        "title": "3-month rainfall aggregate (mm)",
-        "server_layer_name": "r3h_dekad"
-      },
-      {
-        "id": "rainfall_agg_4month",
-        "title": "4-month rainfall aggregate (mm)",
-        "server_layer_name": "r4h_dekad"
-      },
-      {
-        "id": "rainfall_agg_5month",
-        "title": "5-month rainfall aggregate (mm)",
-        "server_layer_name": "r5h_dekad"
-      },
-      {
-        "id": "rainfall_agg_6month",
-        "title": "6-month rainfall aggregate (mm)",
-        "server_layer_name": "r6h_dekad"
-      },
-      {
-        "id": "rainfall_agg_7month",
-        "title": "7-month rainfall aggregate (mm)",
-        "server_layer_name": "r7h_dekad"
-      },
-      {
-        "id": "rainfall_agg_8month",
-        "title": "8-month rainfall aggregate (mm)",
-        "server_layer_name": "r8h_dekad"
-      },
-      {
-        "id": "rainfall_agg_9month",
-        "title": "9-month rainfall aggregate (mm)",
-        "server_layer_name": "r9h_dekad"
-      },
-      {
-        "id": "rainfall_dekad",
-        "title": "10-day rainfall estimate (mm)",
-        "server_layer_name": "rfh_dekad"
-      },
-      {
-        "id": "spi_1m",
-        "title": "SPI - 1-month",
-        "server_layer_name": "r1s_dekad"
-      },
-      {
-        "id": "spi_1y",
-        "title": "SPI - 1-year",
-        "server_layer_name": "rys_dekad"
-      },
-      {
-        "id": "spi_2m",
-        "title": "SPI - 2-month",
-        "server_layer_name": "r2s_dekad"
-      },
-      {
-        "id": "spi_3m",
-        "title": "SPI - 3-month",
-        "server_layer_name": "r3s_dekad"
-      },
-      {
-        "id": "spi_6m",
-        "title": "SPI - 6-month",
-        "server_layer_name": "r6s_dekad"
-      },
-      {
-        "id": "spi_9m",
-        "title": "SPI - 9-month",
-        "server_layer_name": "r9s_dekad"
-      },
-      {
-        "id": "streak_dry_days",
-        "title": "Longest dry spell",
-        "server_layer_name": "dlx_dekad"
-      },
-      {
-        "id": "streak_extreme_rain",
-        "title": "Longest consecutive extreme rainfall days",
-        "server_layer_name": "xle_dekad"
-      },
-      {
-        "id": "streak_heavy_rain",
-        "title": "Longest consecutive heavy rainfall days",
-        "server_layer_name": "xlh_dekad"
-      },
-      {
-        "id": "streak_intense_rain",
-        "title": "Longest consecutive intense rainfall days",
-        "server_layer_name": "xli_dekad"
       }
     ],
     "kyrgyzstan": [
       {
+        "id": "rainfall_dekad",
+        "title": "10-day rainfall estimate (mm)",
+        "server_layer_name": "rfh_dekad"
+      },
+      {
+        "id": "rain_anomaly_dekad",
+        "title": "10-day rainfall anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rainfall_agg_1month",
+        "title": "1-month rainfall aggregate",
+        "server_layer_name": "r1h_dekad"
+      },
+      {
+        "id": "rain_anomaly_1month",
+        "title": "Monthly rainfall anomaly",
+        "server_layer_name": "r1q_dekad"
+      },
+      {
+        "id": "rainfall_agg_3month",
+        "title": "3-month rainfall aggregate (mm)",
+        "server_layer_name": "r3h_dekad"
+      },
+      {
+        "id": "rain_anomaly_3month",
+        "title": "3-month rainfall anomaly",
+        "server_layer_name": "r3q_dekad"
+      },
+      {
+        "id": "ndvi_dekad",
+        "title": "10-day NDVI (MODIS)",
+        "server_layer_name": "mxd13a2_vim_dekad"
+      },
+      {
+        "id": "ndvi_dekad_anomaly",
+        "title": "10-day NDVI anomaly (MODIS)",
+        "server_layer_name": "mxd13a2_viq_dekad"
+      },
+      {
+        "id": "dekad_rainfall_anomaly_forecast",
+        "title": "10-day rainfall forecast anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "daily_rainfall_forecast",
+        "title": "Rolling daily rainfall forecast",
+        "server_layer_name": "rfh_daily_forecast"
+      },
+      {
+        "id": "dekad_rainfall_forecast",
+        "title": "10-day rainfall forecast",
+        "server_layer_name": "rfh_dekad_forecast"
+      },
+      {
+        "id": "rainfall_agg_2month",
+        "title": "2-month rainfall aggregate (mm)",
+        "server_layer_name": "r2h_dekad"
+      },
+      {
+        "id": "rain_anomaly_2month",
+        "title": "2-month rainfall anomaly",
+        "server_layer_name": "r2q_dekad"
+      },
+      {
+        "id": "rainfall_agg_4month",
+        "title": "4-month rainfall aggregate (mm)",
+        "server_layer_name": "r4h_dekad"
+      },
+      {
+        "id": "rain_anomaly_4month",
+        "title": "4-month rainfall anomaly",
+        "server_layer_name": "r4q_dekad"
+      },
+      {
+        "id": "rainfall_agg_5month",
+        "title": "5-month rainfall aggregate (mm)",
+        "server_layer_name": "r5h_dekad"
+      },
+      {
+        "id": "rain_anomaly_5month",
+        "title": "5-month rainfall anomaly",
+        "server_layer_name": "r5q_dekad"
+      },
+      {
+        "id": "rainfall_agg_6month",
+        "title": "6-month rainfall aggregate (mm)",
+        "server_layer_name": "r6h_dekad"
+      },
+      {
+        "id": "rain_anomaly_6month",
+        "title": "6-month rainfall anomaly",
+        "server_layer_name": "r6q_dekad"
+      },
+      {
+        "id": "rainfall_agg_7month",
+        "title": "7-month rainfall aggregate (mm)",
+        "server_layer_name": "r7h_dekad"
+      },
+      {
+        "id": "rain_anomaly_7month",
+        "title": "7-month rainfall anomaly",
+        "server_layer_name": "r7q_dekad"
+      },
+      {
+        "id": "rainfall_agg_8month",
+        "title": "8-month rainfall aggregate (mm)",
+        "server_layer_name": "r8h_dekad"
+      },
+      {
+        "id": "rain_anomaly_8month",
+        "title": "8-month rainfall anomaly",
+        "server_layer_name": "r8q_dekad"
+      },
+      {
+        "id": "rainfall_agg_9month",
+        "title": "9-month rainfall aggregate (mm)",
+        "server_layer_name": "r9h_dekad"
+      },
+      {
+        "id": "rain_anomaly_9month",
+        "title": "9-month rainfall anomaly",
+        "server_layer_name": "r9q_dekad"
+      },
+      {
+        "id": "rainfall_agg_1year",
+        "title": "1-year rainfall aggregate (mm)",
+        "server_layer_name": "ryh_dekad"
+      },
+      {
+        "id": "rain_anomaly_1year",
+        "title": "1-year rainfall anomaly",
+        "server_layer_name": "ryq_dekad"
+      },
+      {
+        "id": "spi_1m",
+        "title": "SPI - 1-month",
+        "server_layer_name": "r1s_dekad"
+      },
+      {
+        "id": "spi_2m",
+        "title": "SPI - 2-month",
+        "server_layer_name": "r2s_dekad"
+      },
+      {
+        "id": "spi_3m",
+        "title": "SPI - 3-month",
+        "server_layer_name": "r3s_dekad"
+      },
+      {
+        "id": "spi_6m",
+        "title": "SPI - 6-month",
+        "server_layer_name": "r6s_dekad"
+      },
+      {
+        "id": "spi_9m",
+        "title": "SPI - 9-month",
+        "server_layer_name": "r9s_dekad"
+      },
+      {
+        "id": "spi_1y",
+        "title": "SPI - 1-year",
+        "server_layer_name": "rys_dekad"
+      },
+      {
+        "id": "days_dry",
+        "title": "Days since last rain",
+        "server_layer_name": "dlc_dekad"
+      },
+      {
+        "id": "streak_dry_days",
+        "title": "Longest dry spell",
+        "server_layer_name": "dlx_dekad"
+      },
+      {
+        "id": "days_heavy_rain",
+        "title": "Number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xnh_dekad"
+      },
+      {
+        "id": "days_intense_rain",
+        "title": "Number of days with intense rainfall in the last 30 days",
+        "server_layer_name": "xni_dekad"
+      },
+      {
+        "id": "days_extreme_rain",
+        "title": "Number of days with extreme rainfall in the last 30 days",
+        "server_layer_name": "xne_dekad"
+      },
+      {
+        "id": "streak_heavy_rain",
+        "title": "Longest consecutive heavy rainfall days",
+        "server_layer_name": "xlh_dekad"
+      },
+      {
+        "id": "streak_intense_rain",
+        "title": "Longest consecutive intense rainfall days",
+        "server_layer_name": "xli_dekad"
+      },
+      {
+        "id": "streak_extreme_rain",
+        "title": "Longest consecutive extreme rainfall days",
+        "server_layer_name": "xle_dekad"
+      },
+      {
+        "id": "lst_amplitude",
+        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
+        "server_layer_name": "myd11a2_taa_dekad"
+      },
+      {
+        "id": "lst_daytime",
+        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_nighttime",
+        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_day_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "monthly_water_anomaly",
+        "title": "Monthly Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_dekad"
+      },
+      {
         "id": "2m_water_anomaly",
         "title": "2-Month Water Anomaly Index (WAI)",
         "server_layer_name": "wai_seasonal_2month"
@@ -2907,245 +3142,245 @@
         "id": "6m_water_anomaly",
         "title": "6-Month Water Anomaly Index (WAI)",
         "server_layer_name": "wai_seasonal_6month"
-      },
-      {
-        "id": "daily_rainfall_forecast",
-        "title": "Rolling daily rainfall forecast",
-        "server_layer_name": "rfh_daily_forecast"
-      },
-      {
-        "id": "days_dry",
-        "title": "Days since last rain",
-        "server_layer_name": "dlc_dekad"
-      },
-      {
-        "id": "days_extreme_rain",
-        "title": "Number of days with extreme rainfall in the last 30 days",
-        "server_layer_name": "xne_dekad"
-      },
-      {
-        "id": "days_heavy_rain",
-        "title": "Number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xnh_dekad"
-      },
-      {
-        "id": "days_intense_rain",
-        "title": "Number of days with intense rainfall in the last 30 days",
-        "server_layer_name": "xni_dekad"
-      },
-      {
-        "id": "dekad_rainfall_anomaly_forecast",
-        "title": "10-day rainfall forecast anomaly",
-        "server_layer_name": "rfq_dekad"
-      },
-      {
-        "id": "dekad_rainfall_forecast",
-        "title": "10-day rainfall forecast",
-        "server_layer_name": "rfh_dekad_forecast"
-      },
-      {
-        "id": "lst_amplitude",
-        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
-        "server_layer_name": "myd11a2_taa_dekad"
-      },
-      {
-        "id": "lst_anomaly",
-        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_day_anomaly",
-        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_daytime",
-        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "lst_nighttime",
-        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "monthly_water_anomaly",
-        "title": "Monthly Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_dekad"
-      },
-      {
-        "id": "ndvi_dekad",
-        "title": "10-day NDVI (MODIS)",
-        "server_layer_name": "mxd13a2_vim_dekad"
-      },
-      {
-        "id": "ndvi_dekad_anomaly",
-        "title": "10-day NDVI anomaly (MODIS)",
-        "server_layer_name": "mxd13a2_viq_dekad"
-      },
-      {
-        "id": "rain_anomaly_1month",
-        "title": "Monthly rainfall anomaly",
-        "server_layer_name": "r1q_dekad"
-      },
-      {
-        "id": "rain_anomaly_1year",
-        "title": "1-year rainfall anomaly",
-        "server_layer_name": "ryq_dekad"
-      },
-      {
-        "id": "rain_anomaly_2month",
-        "title": "2-month rainfall anomaly",
-        "server_layer_name": "r2q_dekad"
-      },
-      {
-        "id": "rain_anomaly_3month",
-        "title": "3-month rainfall anomaly",
-        "server_layer_name": "r3q_dekad"
-      },
-      {
-        "id": "rain_anomaly_4month",
-        "title": "4-month rainfall anomaly",
-        "server_layer_name": "r4q_dekad"
-      },
-      {
-        "id": "rain_anomaly_5month",
-        "title": "5-month rainfall anomaly",
-        "server_layer_name": "r5q_dekad"
-      },
-      {
-        "id": "rain_anomaly_6month",
-        "title": "6-month rainfall anomaly",
-        "server_layer_name": "r6q_dekad"
-      },
-      {
-        "id": "rain_anomaly_7month",
-        "title": "7-month rainfall anomaly",
-        "server_layer_name": "r7q_dekad"
-      },
-      {
-        "id": "rain_anomaly_8month",
-        "title": "8-month rainfall anomaly",
-        "server_layer_name": "r8q_dekad"
-      },
-      {
-        "id": "rain_anomaly_9month",
-        "title": "9-month rainfall anomaly",
-        "server_layer_name": "r9q_dekad"
-      },
-      {
-        "id": "rain_anomaly_dekad",
-        "title": "10-day rainfall anomaly",
-        "server_layer_name": "rfq_dekad"
-      },
-      {
-        "id": "rainfall_agg_1month",
-        "title": "1-month rainfall aggregate",
-        "server_layer_name": "r1h_dekad"
-      },
-      {
-        "id": "rainfall_agg_1year",
-        "title": "1-year rainfall aggregate (mm)",
-        "server_layer_name": "ryh_dekad"
-      },
-      {
-        "id": "rainfall_agg_2month",
-        "title": "2-month rainfall aggregate (mm)",
-        "server_layer_name": "r2h_dekad"
-      },
-      {
-        "id": "rainfall_agg_3month",
-        "title": "3-month rainfall aggregate (mm)",
-        "server_layer_name": "r3h_dekad"
-      },
-      {
-        "id": "rainfall_agg_4month",
-        "title": "4-month rainfall aggregate (mm)",
-        "server_layer_name": "r4h_dekad"
-      },
-      {
-        "id": "rainfall_agg_5month",
-        "title": "5-month rainfall aggregate (mm)",
-        "server_layer_name": "r5h_dekad"
-      },
-      {
-        "id": "rainfall_agg_6month",
-        "title": "6-month rainfall aggregate (mm)",
-        "server_layer_name": "r6h_dekad"
-      },
-      {
-        "id": "rainfall_agg_7month",
-        "title": "7-month rainfall aggregate (mm)",
-        "server_layer_name": "r7h_dekad"
-      },
-      {
-        "id": "rainfall_agg_8month",
-        "title": "8-month rainfall aggregate (mm)",
-        "server_layer_name": "r8h_dekad"
-      },
-      {
-        "id": "rainfall_agg_9month",
-        "title": "9-month rainfall aggregate (mm)",
-        "server_layer_name": "r9h_dekad"
-      },
-      {
-        "id": "rainfall_dekad",
-        "title": "10-day rainfall estimate (mm)",
-        "server_layer_name": "rfh_dekad"
-      },
-      {
-        "id": "spi_1m",
-        "title": "SPI - 1-month",
-        "server_layer_name": "r1s_dekad"
-      },
-      {
-        "id": "spi_1y",
-        "title": "SPI - 1-year",
-        "server_layer_name": "rys_dekad"
-      },
-      {
-        "id": "spi_2m",
-        "title": "SPI - 2-month",
-        "server_layer_name": "r2s_dekad"
-      },
-      {
-        "id": "spi_3m",
-        "title": "SPI - 3-month",
-        "server_layer_name": "r3s_dekad"
-      },
-      {
-        "id": "spi_6m",
-        "title": "SPI - 6-month",
-        "server_layer_name": "r6s_dekad"
-      },
-      {
-        "id": "spi_9m",
-        "title": "SPI - 9-month",
-        "server_layer_name": "r9s_dekad"
-      },
-      {
-        "id": "streak_dry_days",
-        "title": "Longest dry spell",
-        "server_layer_name": "dlx_dekad"
-      },
-      {
-        "id": "streak_extreme_rain",
-        "title": "Longest consecutive extreme rainfall days",
-        "server_layer_name": "xle_dekad"
-      },
-      {
-        "id": "streak_heavy_rain",
-        "title": "Longest consecutive heavy rainfall days",
-        "server_layer_name": "xlh_dekad"
-      },
-      {
-        "id": "streak_intense_rain",
-        "title": "Longest consecutive intense rainfall days",
-        "server_layer_name": "xli_dekad"
       }
     ],
     "malawi": [
       {
+        "id": "rainfall_dekad",
+        "title": "10-day rainfall estimate (mm)",
+        "server_layer_name": "rfh_dekad"
+      },
+      {
+        "id": "rain_anomaly_dekad",
+        "title": "10-day rainfall anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rainfall_agg_1month",
+        "title": "1-month rainfall aggregate",
+        "server_layer_name": "r1h_dekad"
+      },
+      {
+        "id": "rain_anomaly_1month",
+        "title": "Monthly rainfall anomaly",
+        "server_layer_name": "r1q_dekad"
+      },
+      {
+        "id": "rainfall_agg_3month",
+        "title": "3-month rainfall aggregate (mm)",
+        "server_layer_name": "r3h_dekad"
+      },
+      {
+        "id": "rain_anomaly_3month",
+        "title": "3-month rainfall anomaly",
+        "server_layer_name": "r3q_dekad"
+      },
+      {
+        "id": "ndvi_dekad",
+        "title": "10-day NDVI (MODIS)",
+        "server_layer_name": "mxd13a2_vim_dekad"
+      },
+      {
+        "id": "ndvi_dekad_anomaly",
+        "title": "10-day NDVI anomaly (MODIS)",
+        "server_layer_name": "mxd13a2_viq_dekad"
+      },
+      {
+        "id": "daily_rainfall_forecast",
+        "title": "Rolling daily rainfall forecast",
+        "server_layer_name": "rfh_daily_forecast"
+      },
+      {
+        "id": "dekad_rainfall_forecast",
+        "title": "10-day rainfall forecast",
+        "server_layer_name": "rfh_dekad_forecast"
+      },
+      {
+        "id": "dekad_rainfall_anomaly_forecast",
+        "title": "10-day rainfall forecast anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rainfall_agg_2month",
+        "title": "2-month rainfall aggregate (mm)",
+        "server_layer_name": "r2h_dekad"
+      },
+      {
+        "id": "rain_anomaly_2month",
+        "title": "2-month rainfall anomaly",
+        "server_layer_name": "r2q_dekad"
+      },
+      {
+        "id": "rainfall_agg_4month",
+        "title": "4-month rainfall aggregate (mm)",
+        "server_layer_name": "r4h_dekad"
+      },
+      {
+        "id": "rain_anomaly_4month",
+        "title": "4-month rainfall anomaly",
+        "server_layer_name": "r4q_dekad"
+      },
+      {
+        "id": "rainfall_agg_5month",
+        "title": "5-month rainfall aggregate (mm)",
+        "server_layer_name": "r5h_dekad"
+      },
+      {
+        "id": "rain_anomaly_5month",
+        "title": "5-month rainfall anomaly",
+        "server_layer_name": "r5q_dekad"
+      },
+      {
+        "id": "rainfall_agg_6month",
+        "title": "6-month rainfall aggregate (mm)",
+        "server_layer_name": "r6h_dekad"
+      },
+      {
+        "id": "rain_anomaly_6month",
+        "title": "6-month rainfall anomaly",
+        "server_layer_name": "r6q_dekad"
+      },
+      {
+        "id": "rainfall_agg_7month",
+        "title": "7-month rainfall aggregate (mm)",
+        "server_layer_name": "r7h_dekad"
+      },
+      {
+        "id": "rain_anomaly_7month",
+        "title": "7-month rainfall anomaly",
+        "server_layer_name": "r7q_dekad"
+      },
+      {
+        "id": "rainfall_agg_8month",
+        "title": "8-month rainfall aggregate (mm)",
+        "server_layer_name": "r8h_dekad"
+      },
+      {
+        "id": "rain_anomaly_8month",
+        "title": "8-month rainfall anomaly",
+        "server_layer_name": "r8q_dekad"
+      },
+      {
+        "id": "rainfall_agg_9month",
+        "title": "9-month rainfall aggregate (mm)",
+        "server_layer_name": "r9h_dekad"
+      },
+      {
+        "id": "rain_anomaly_9month",
+        "title": "9-month rainfall anomaly",
+        "server_layer_name": "r9q_dekad"
+      },
+      {
+        "id": "rainfall_agg_1year",
+        "title": "1-year rainfall aggregate (mm)",
+        "server_layer_name": "ryh_dekad"
+      },
+      {
+        "id": "rain_anomaly_1year",
+        "title": "1-year rainfall anomaly",
+        "server_layer_name": "ryq_dekad"
+      },
+      {
+        "id": "spi_1m",
+        "title": "SPI - 1-month",
+        "server_layer_name": "r1s_dekad"
+      },
+      {
+        "id": "spi_2m",
+        "title": "SPI - 2-month",
+        "server_layer_name": "r2s_dekad"
+      },
+      {
+        "id": "spi_3m",
+        "title": "SPI - 3-month",
+        "server_layer_name": "r3s_dekad"
+      },
+      {
+        "id": "spi_6m",
+        "title": "SPI - 6-month",
+        "server_layer_name": "r6s_dekad"
+      },
+      {
+        "id": "spi_9m",
+        "title": "SPI - 9-month",
+        "server_layer_name": "r9s_dekad"
+      },
+      {
+        "id": "spi_1y",
+        "title": "SPI - 1-year",
+        "server_layer_name": "rys_dekad"
+      },
+      {
+        "id": "days_dry",
+        "title": "Days since last rain",
+        "server_layer_name": "dlc_dekad"
+      },
+      {
+        "id": "streak_dry_days",
+        "title": "Longest dry spell",
+        "server_layer_name": "dlx_dekad"
+      },
+      {
+        "id": "days_heavy_rain",
+        "title": "Number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xnh_dekad"
+      },
+      {
+        "id": "days_intense_rain",
+        "title": "Number of days with intense rainfall in the last 30 days",
+        "server_layer_name": "xni_dekad"
+      },
+      {
+        "id": "days_extreme_rain",
+        "title": "Number of days with extreme rainfall in the last 30 days",
+        "server_layer_name": "xne_dekad"
+      },
+      {
+        "id": "streak_heavy_rain",
+        "title": "Longest consecutive heavy rainfall days",
+        "server_layer_name": "xlh_dekad"
+      },
+      {
+        "id": "streak_intense_rain",
+        "title": "Longest consecutive intense rainfall days",
+        "server_layer_name": "xli_dekad"
+      },
+      {
+        "id": "streak_extreme_rain",
+        "title": "Longest consecutive extreme rainfall days",
+        "server_layer_name": "xle_dekad"
+      },
+      {
+        "id": "lst_amplitude",
+        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
+        "server_layer_name": "myd11a2_taa_dekad"
+      },
+      {
+        "id": "lst_daytime",
+        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_nighttime",
+        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_day_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "monthly_water_anomaly",
+        "title": "Monthly Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_dekad"
+      },
+      {
         "id": "2m_water_anomaly",
         "title": "2-Month Water Anomaly Index (WAI)",
         "server_layer_name": "wai_seasonal_2month"
@@ -3169,298 +3404,13 @@
         "id": "6m_water_anomaly",
         "title": "6-Month Water Anomaly Index (WAI)",
         "server_layer_name": "wai_seasonal_6month"
-      },
-      {
-        "id": "daily_rainfall_forecast",
-        "title": "Rolling daily rainfall forecast",
-        "server_layer_name": "rfh_daily_forecast"
-      },
-      {
-        "id": "days_dry",
-        "title": "Days since last rain",
-        "server_layer_name": "dlc_dekad"
-      },
-      {
-        "id": "days_extreme_rain",
-        "title": "Number of days with extreme rainfall in the last 30 days",
-        "server_layer_name": "xne_dekad"
-      },
-      {
-        "id": "days_heavy_rain",
-        "title": "Number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xnh_dekad"
-      },
-      {
-        "id": "days_intense_rain",
-        "title": "Number of days with intense rainfall in the last 30 days",
-        "server_layer_name": "xni_dekad"
-      },
-      {
-        "id": "dekad_rainfall_anomaly_forecast",
-        "title": "10-day rainfall forecast anomaly",
-        "server_layer_name": "rfq_dekad"
-      },
-      {
-        "id": "dekad_rainfall_forecast",
-        "title": "10-day rainfall forecast",
-        "server_layer_name": "rfh_dekad_forecast"
-      },
-      {
-        "id": "lst_amplitude",
-        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
-        "server_layer_name": "myd11a2_taa_dekad"
-      },
-      {
-        "id": "lst_anomaly",
-        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_day_anomaly",
-        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_daytime",
-        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "lst_nighttime",
-        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "monthly_water_anomaly",
-        "title": "Monthly Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_dekad"
-      },
-      {
-        "id": "ndvi_dekad",
-        "title": "10-day NDVI (MODIS)",
-        "server_layer_name": "mxd13a2_vim_dekad"
-      },
-      {
-        "id": "ndvi_dekad_anomaly",
-        "title": "10-day NDVI anomaly (MODIS)",
-        "server_layer_name": "mxd13a2_viq_dekad"
-      },
-      {
-        "id": "rain_anomaly_1month",
-        "title": "Monthly rainfall anomaly",
-        "server_layer_name": "r1q_dekad"
-      },
-      {
-        "id": "rain_anomaly_1year",
-        "title": "1-year rainfall anomaly",
-        "server_layer_name": "ryq_dekad"
-      },
-      {
-        "id": "rain_anomaly_2month",
-        "title": "2-month rainfall anomaly",
-        "server_layer_name": "r2q_dekad"
-      },
-      {
-        "id": "rain_anomaly_3month",
-        "title": "3-month rainfall anomaly",
-        "server_layer_name": "r3q_dekad"
-      },
-      {
-        "id": "rain_anomaly_4month",
-        "title": "4-month rainfall anomaly",
-        "server_layer_name": "r4q_dekad"
-      },
-      {
-        "id": "rain_anomaly_5month",
-        "title": "5-month rainfall anomaly",
-        "server_layer_name": "r5q_dekad"
-      },
-      {
-        "id": "rain_anomaly_6month",
-        "title": "6-month rainfall anomaly",
-        "server_layer_name": "r6q_dekad"
-      },
-      {
-        "id": "rain_anomaly_7month",
-        "title": "7-month rainfall anomaly",
-        "server_layer_name": "r7q_dekad"
-      },
-      {
-        "id": "rain_anomaly_8month",
-        "title": "8-month rainfall anomaly",
-        "server_layer_name": "r8q_dekad"
-      },
-      {
-        "id": "rain_anomaly_9month",
-        "title": "9-month rainfall anomaly",
-        "server_layer_name": "r9q_dekad"
-      },
-      {
-        "id": "rain_anomaly_dekad",
-        "title": "10-day rainfall anomaly",
-        "server_layer_name": "rfq_dekad"
-      },
-      {
-        "id": "rainfall_agg_1month",
-        "title": "1-month rainfall aggregate",
-        "server_layer_name": "r1h_dekad"
-      },
-      {
-        "id": "rainfall_agg_1year",
-        "title": "1-year rainfall aggregate (mm)",
-        "server_layer_name": "ryh_dekad"
-      },
-      {
-        "id": "rainfall_agg_2month",
-        "title": "2-month rainfall aggregate (mm)",
-        "server_layer_name": "r2h_dekad"
-      },
-      {
-        "id": "rainfall_agg_3month",
-        "title": "3-month rainfall aggregate (mm)",
-        "server_layer_name": "r3h_dekad"
-      },
-      {
-        "id": "rainfall_agg_4month",
-        "title": "4-month rainfall aggregate (mm)",
-        "server_layer_name": "r4h_dekad"
-      },
-      {
-        "id": "rainfall_agg_5month",
-        "title": "5-month rainfall aggregate (mm)",
-        "server_layer_name": "r5h_dekad"
-      },
-      {
-        "id": "rainfall_agg_6month",
-        "title": "6-month rainfall aggregate (mm)",
-        "server_layer_name": "r6h_dekad"
-      },
-      {
-        "id": "rainfall_agg_7month",
-        "title": "7-month rainfall aggregate (mm)",
-        "server_layer_name": "r7h_dekad"
-      },
-      {
-        "id": "rainfall_agg_8month",
-        "title": "8-month rainfall aggregate (mm)",
-        "server_layer_name": "r8h_dekad"
-      },
-      {
-        "id": "rainfall_agg_9month",
-        "title": "9-month rainfall aggregate (mm)",
-        "server_layer_name": "r9h_dekad"
-      },
-      {
-        "id": "rainfall_dekad",
-        "title": "10-day rainfall estimate (mm)",
-        "server_layer_name": "rfh_dekad"
-      },
-      {
-        "id": "spi_1m",
-        "title": "SPI - 1-month",
-        "server_layer_name": "r1s_dekad"
-      },
-      {
-        "id": "spi_1y",
-        "title": "SPI - 1-year",
-        "server_layer_name": "rys_dekad"
-      },
-      {
-        "id": "spi_2m",
-        "title": "SPI - 2-month",
-        "server_layer_name": "r2s_dekad"
-      },
-      {
-        "id": "spi_3m",
-        "title": "SPI - 3-month",
-        "server_layer_name": "r3s_dekad"
-      },
-      {
-        "id": "spi_6m",
-        "title": "SPI - 6-month",
-        "server_layer_name": "r6s_dekad"
-      },
-      {
-        "id": "spi_9m",
-        "title": "SPI - 9-month",
-        "server_layer_name": "r9s_dekad"
-      },
-      {
-        "id": "streak_dry_days",
-        "title": "Longest dry spell",
-        "server_layer_name": "dlx_dekad"
-      },
-      {
-        "id": "streak_extreme_rain",
-        "title": "Longest consecutive extreme rainfall days",
-        "server_layer_name": "xle_dekad"
-      },
-      {
-        "id": "streak_heavy_rain",
-        "title": "Longest consecutive heavy rainfall days",
-        "server_layer_name": "xlh_dekad"
-      },
-      {
-        "id": "streak_intense_rain",
-        "title": "Longest consecutive intense rainfall days",
-        "server_layer_name": "xli_dekad"
       }
     ],
     "mongolia": [
       {
-        "id": "2m_water_anomaly",
-        "title": "2-Month Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_seasonal_2month"
-      },
-      {
-        "id": "3m_water_anomaly",
-        "title": "3-Month Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_seasonal_3month"
-      },
-      {
-        "id": "4m_water_anomaly",
-        "title": "4-Month Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_seasonal_4month"
-      },
-      {
-        "id": "5m_water_anomaly",
-        "title": "5-Month Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_seasonal_5month"
-      },
-      {
-        "id": "6m_water_anomaly",
-        "title": "6-Month Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_seasonal_6month"
-      },
-      {
         "id": "daily_rainfall_forecast",
         "title": "Rolling daily rainfall forecast",
         "server_layer_name": "rfh_daily_forecast"
-      },
-      {
-        "id": "days_dry",
-        "title": "Days since last rain",
-        "server_layer_name": "dlc_dekad"
-      },
-      {
-        "id": "days_extreme_rain",
-        "title": "Number of days with extreme rainfall in the last 30 days",
-        "server_layer_name": "xne_dekad"
-      },
-      {
-        "id": "days_heavy_rain",
-        "title": "Number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xnh_dekad"
-      },
-      {
-        "id": "days_intense_rain",
-        "title": "Number of days with intense rainfall in the last 30 days",
-        "server_layer_name": "xni_dekad"
-      },
-      {
-        "id": "dekad_rainfall_anomaly_forecast",
-        "title": "10-day rainfall forecast anomaly",
-        "server_layer_name": "rfq_dekad"
       },
       {
         "id": "dekad_rainfall_forecast",
@@ -3468,94 +3418,14 @@
         "server_layer_name": "rfh_dekad_forecast"
       },
       {
-        "id": "lst_amplitude",
-        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
-        "server_layer_name": "myd11a2_taa_dekad"
+        "id": "dekad_rainfall_anomaly_forecast",
+        "title": "10-day rainfall forecast anomaly",
+        "server_layer_name": "rfq_dekad"
       },
       {
-        "id": "lst_anomaly",
-        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_day_anomaly",
-        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_daytime",
-        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "lst_nighttime",
-        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "monthly_water_anomaly",
-        "title": "Monthly Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_dekad"
-      },
-      {
-        "id": "ndvi_dekad",
-        "title": "10-day NDVI (MODIS)",
-        "server_layer_name": "mxd13a2_vim_dekad"
-      },
-      {
-        "id": "ndvi_dekad_anomaly",
-        "title": "10-day NDVI anomaly (MODIS)",
-        "server_layer_name": "mxd13a2_viq_dekad"
-      },
-      {
-        "id": "rain_anomaly_1month",
-        "title": "Monthly rainfall anomaly",
-        "server_layer_name": "r1q_dekad"
-      },
-      {
-        "id": "rain_anomaly_1year",
-        "title": "1-year rainfall anomaly",
-        "server_layer_name": "ryq_dekad"
-      },
-      {
-        "id": "rain_anomaly_2month",
-        "title": "2-month rainfall anomaly",
-        "server_layer_name": "r2q_dekad"
-      },
-      {
-        "id": "rain_anomaly_3month",
-        "title": "3-month rainfall anomaly",
-        "server_layer_name": "r3q_dekad"
-      },
-      {
-        "id": "rain_anomaly_4month",
-        "title": "4-month rainfall anomaly",
-        "server_layer_name": "r4q_dekad"
-      },
-      {
-        "id": "rain_anomaly_5month",
-        "title": "5-month rainfall anomaly",
-        "server_layer_name": "r5q_dekad"
-      },
-      {
-        "id": "rain_anomaly_6month",
-        "title": "6-month rainfall anomaly",
-        "server_layer_name": "r6q_dekad"
-      },
-      {
-        "id": "rain_anomaly_7month",
-        "title": "7-month rainfall anomaly",
-        "server_layer_name": "r7q_dekad"
-      },
-      {
-        "id": "rain_anomaly_8month",
-        "title": "8-month rainfall anomaly",
-        "server_layer_name": "r8q_dekad"
-      },
-      {
-        "id": "rain_anomaly_9month",
-        "title": "9-month rainfall anomaly",
-        "server_layer_name": "r9q_dekad"
+        "id": "rainfall_dekad",
+        "title": "10-day rainfall estimate (mm)",
+        "server_layer_name": "rfh_dekad"
       },
       {
         "id": "rain_anomaly_dekad",
@@ -3568,14 +3438,9 @@
         "server_layer_name": "r1h_dekad"
       },
       {
-        "id": "rainfall_agg_1year",
-        "title": "1-year rainfall aggregate (mm)",
-        "server_layer_name": "ryh_dekad"
-      },
-      {
-        "id": "rainfall_agg_2month",
-        "title": "2-month rainfall aggregate (mm)",
-        "server_layer_name": "r2h_dekad"
+        "id": "rain_anomaly_1month",
+        "title": "Monthly rainfall anomaly",
+        "server_layer_name": "r1q_dekad"
       },
       {
         "id": "rainfall_agg_3month",
@@ -3583,9 +3448,29 @@
         "server_layer_name": "r3h_dekad"
       },
       {
+        "id": "rain_anomaly_3month",
+        "title": "3-month rainfall anomaly",
+        "server_layer_name": "r3q_dekad"
+      },
+      {
+        "id": "rainfall_agg_2month",
+        "title": "2-month rainfall aggregate (mm)",
+        "server_layer_name": "r2h_dekad"
+      },
+      {
+        "id": "rain_anomaly_2month",
+        "title": "2-month rainfall anomaly",
+        "server_layer_name": "r2q_dekad"
+      },
+      {
         "id": "rainfall_agg_4month",
         "title": "4-month rainfall aggregate (mm)",
         "server_layer_name": "r4h_dekad"
+      },
+      {
+        "id": "rain_anomaly_4month",
+        "title": "4-month rainfall anomaly",
+        "server_layer_name": "r4q_dekad"
       },
       {
         "id": "rainfall_agg_5month",
@@ -3593,9 +3478,19 @@
         "server_layer_name": "r5h_dekad"
       },
       {
+        "id": "rain_anomaly_5month",
+        "title": "5-month rainfall anomaly",
+        "server_layer_name": "r5q_dekad"
+      },
+      {
         "id": "rainfall_agg_6month",
         "title": "6-month rainfall aggregate (mm)",
         "server_layer_name": "r6h_dekad"
+      },
+      {
+        "id": "rain_anomaly_6month",
+        "title": "6-month rainfall anomaly",
+        "server_layer_name": "r6q_dekad"
       },
       {
         "id": "rainfall_agg_7month",
@@ -3603,9 +3498,19 @@
         "server_layer_name": "r7h_dekad"
       },
       {
+        "id": "rain_anomaly_7month",
+        "title": "7-month rainfall anomaly",
+        "server_layer_name": "r7q_dekad"
+      },
+      {
         "id": "rainfall_agg_8month",
         "title": "8-month rainfall aggregate (mm)",
         "server_layer_name": "r8h_dekad"
+      },
+      {
+        "id": "rain_anomaly_8month",
+        "title": "8-month rainfall anomaly",
+        "server_layer_name": "r8q_dekad"
       },
       {
         "id": "rainfall_agg_9month",
@@ -3613,19 +3518,24 @@
         "server_layer_name": "r9h_dekad"
       },
       {
-        "id": "rainfall_dekad",
-        "title": "10-day rainfall estimate (mm)",
-        "server_layer_name": "rfh_dekad"
+        "id": "rain_anomaly_9month",
+        "title": "9-month rainfall anomaly",
+        "server_layer_name": "r9q_dekad"
+      },
+      {
+        "id": "rainfall_agg_1year",
+        "title": "1-year rainfall aggregate (mm)",
+        "server_layer_name": "ryh_dekad"
+      },
+      {
+        "id": "rain_anomaly_1year",
+        "title": "1-year rainfall anomaly",
+        "server_layer_name": "ryq_dekad"
       },
       {
         "id": "spi_1m",
         "title": "SPI - 1-month",
         "server_layer_name": "r1s_dekad"
-      },
-      {
-        "id": "spi_1y",
-        "title": "SPI - 1-year",
-        "server_layer_name": "rys_dekad"
       },
       {
         "id": "spi_2m",
@@ -3648,14 +3558,34 @@
         "server_layer_name": "r9s_dekad"
       },
       {
+        "id": "spi_1y",
+        "title": "SPI - 1-year",
+        "server_layer_name": "rys_dekad"
+      },
+      {
+        "id": "days_dry",
+        "title": "Days since last rain",
+        "server_layer_name": "dlc_dekad"
+      },
+      {
         "id": "streak_dry_days",
         "title": "Longest dry spell",
         "server_layer_name": "dlx_dekad"
       },
       {
-        "id": "streak_extreme_rain",
-        "title": "Longest consecutive extreme rainfall days",
-        "server_layer_name": "xle_dekad"
+        "id": "days_heavy_rain",
+        "title": "Number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xnh_dekad"
+      },
+      {
+        "id": "days_intense_rain",
+        "title": "Number of days with intense rainfall in the last 30 days",
+        "server_layer_name": "xni_dekad"
+      },
+      {
+        "id": "days_extreme_rain",
+        "title": "Number of days with extreme rainfall in the last 30 days",
+        "server_layer_name": "xne_dekad"
       },
       {
         "id": "streak_heavy_rain",
@@ -3666,9 +3596,52 @@
         "id": "streak_intense_rain",
         "title": "Longest consecutive intense rainfall days",
         "server_layer_name": "xli_dekad"
-      }
-    ],
-    "mozambique": [
+      },
+      {
+        "id": "streak_extreme_rain",
+        "title": "Longest consecutive extreme rainfall days",
+        "server_layer_name": "xle_dekad"
+      },
+      {
+        "id": "ndvi_dekad",
+        "title": "10-day NDVI (MODIS)",
+        "server_layer_name": "mxd13a2_vim_dekad"
+      },
+      {
+        "id": "ndvi_dekad_anomaly",
+        "title": "10-day NDVI anomaly (MODIS)",
+        "server_layer_name": "mxd13a2_viq_dekad"
+      },
+      {
+        "id": "lst_amplitude",
+        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
+        "server_layer_name": "myd11a2_taa_dekad"
+      },
+      {
+        "id": "lst_daytime",
+        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_nighttime",
+        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_day_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "monthly_water_anomaly",
+        "title": "Monthly Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_dekad"
+      },
       {
         "id": "2m_water_anomaly",
         "title": "2-Month Water Anomaly Index (WAI)",
@@ -3693,192 +3666,9 @@
         "id": "6m_water_anomaly",
         "title": "6-Month Water Anomaly Index (WAI)",
         "server_layer_name": "wai_seasonal_6month"
-      },
-      {
-        "id": "daily_rainfall_forecast",
-        "title": "Rolling daily rainfall forecast",
-        "server_layer_name": "rfh_daily_forecast"
-      },
-      {
-        "id": "days_dry",
-        "title": "Days since last rain",
-        "server_layer_name": "dlc_dekad"
-      },
-      {
-        "id": "days_extreme_rain",
-        "title": "Number of days with extreme rainfall in the last 30 days",
-        "server_layer_name": "xne_dekad"
-      },
-      {
-        "id": "days_heavy_rain",
-        "title": "Number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xnh_dekad"
-      },
-      {
-        "id": "days_intense_rain",
-        "title": "Number of days with intense rainfall in the last 30 days",
-        "server_layer_name": "xni_dekad"
-      },
-      {
-        "id": "dekad_rainfall_anomaly_forecast",
-        "title": "10-day rainfall forecast anomaly",
-        "server_layer_name": "rfq_dekad"
-      },
-      {
-        "id": "dekad_rainfall_forecast",
-        "title": "10-day rainfall forecast",
-        "server_layer_name": "rfh_dekad_forecast"
-      },
-      {
-        "id": "lst_amplitude",
-        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
-        "server_layer_name": "myd11a2_taa_dekad"
-      },
-      {
-        "id": "lst_anomaly",
-        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_day_anomaly",
-        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_day_anomaly_blended",
-        "title": "INAM mean maximum air temperature anomaly (10-day)",
-        "server_layer_name": "myd11a2_blended_txd_moz_dekad"
-      },
-      {
-        "id": "lst_daytime",
-        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "lst_daytime_blended",
-        "title": "INAM mean maximum air temperature (10-day)",
-        "server_layer_name": "myd11a2_blended_txb_moz_dekad"
-      },
-      {
-        "id": "lst_nighttime",
-        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "monthly_water_anomaly",
-        "title": "Monthly Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_dekad"
-      },
-      {
-        "id": "ndvi_dekad",
-        "title": "10-day NDVI (MODIS)",
-        "server_layer_name": "mxd13a2_vim_dekad"
-      },
-      {
-        "id": "ndvi_dekad_anomaly",
-        "title": "10-day NDVI anomaly (MODIS)",
-        "server_layer_name": "mxd13a2_viq_dekad"
-      },
-      {
-        "id": "precip_blended_1m",
-        "title": "Blended rainfall aggregate (1-month)",
-        "server_layer_name": "rfb_blended_moz_dekad"
-      },
-      {
-        "id": "precip_blended_1y",
-        "title": "Blended rainfall aggregate (1-year)",
-        "server_layer_name": "rfb_blended_moz_dekad"
-      },
-      {
-        "id": "precip_blended_2m",
-        "title": "Blended rainfall aggregate (2-month)",
-        "server_layer_name": "rfb_blended_moz_dekad"
-      },
-      {
-        "id": "precip_blended_3m",
-        "title": "Blended rainfall aggregate (3-month)",
-        "server_layer_name": "rfb_blended_moz_dekad"
-      },
-      {
-        "id": "precip_blended_4m",
-        "title": "Blended rainfall aggregate (4-month)",
-        "server_layer_name": "rfb_blended_moz_dekad"
-      },
-      {
-        "id": "precip_blended_5m",
-        "title": "Blended rainfall aggregate (5-month)",
-        "server_layer_name": "rfb_blended_moz_dekad"
-      },
-      {
-        "id": "precip_blended_6m",
-        "title": "Blended rainfall aggregate (6-month)",
-        "server_layer_name": "rfb_blended_moz_dekad"
-      },
-      {
-        "id": "precip_blended_7m",
-        "title": "Blended rainfall aggregate (7-month)",
-        "server_layer_name": "rfb_blended_moz_dekad"
-      },
-      {
-        "id": "precip_blended_8m",
-        "title": "Blended rainfall aggregate (8-month)",
-        "server_layer_name": "rfb_blended_moz_dekad"
-      },
-      {
-        "id": "precip_blended_9m",
-        "title": "Blended rainfall aggregate (9-month)",
-        "server_layer_name": "rfb_blended_moz_dekad"
-      },
-      {
-        "id": "precip_blended_anomaly_1m",
-        "title": "Blended rainfall anomaly (1-month)",
-        "server_layer_name": "rfq_blended_moz_dekad"
-      },
-      {
-        "id": "precip_blended_anomaly_1y",
-        "title": "Blended rainfall anomaly (1-year)",
-        "server_layer_name": "rfq_blended_moz_dekad"
-      },
-      {
-        "id": "precip_blended_anomaly_2m",
-        "title": "Blended rainfall anomaly (2-month)",
-        "server_layer_name": "rfq_blended_moz_dekad"
-      },
-      {
-        "id": "precip_blended_anomaly_3m",
-        "title": "Blended rainfall anomaly (3-month)",
-        "server_layer_name": "rfq_blended_moz_dekad"
-      },
-      {
-        "id": "precip_blended_anomaly_4m",
-        "title": "Blended rainfall anomaly (4-month)",
-        "server_layer_name": "rfq_blended_moz_dekad"
-      },
-      {
-        "id": "precip_blended_anomaly_5m",
-        "title": "Blended rainfall anomaly (5-month)",
-        "server_layer_name": "rfq_blended_moz_dekad"
-      },
-      {
-        "id": "precip_blended_anomaly_6m",
-        "title": "Blended rainfall anomaly (6-month)",
-        "server_layer_name": "rfq_blended_moz_dekad"
-      },
-      {
-        "id": "precip_blended_anomaly_7m",
-        "title": "Blended rainfall anomaly (7-month)",
-        "server_layer_name": "rfq_blended_moz_dekad"
-      },
-      {
-        "id": "precip_blended_anomaly_8m",
-        "title": "Blended rainfall anomaly (8-month)",
-        "server_layer_name": "rfq_blended_moz_dekad"
-      },
-      {
-        "id": "precip_blended_anomaly_9m",
-        "title": "Blended rainfall anomaly (9-month)",
-        "server_layer_name": "rfq_blended_moz_dekad"
-      },
+      }
+    ],
+    "mozambique": [
       {
         "id": "precip_blended_dekad",
         "title": "Blended rainfall aggregate (10-day)",
@@ -3890,54 +3680,109 @@
         "server_layer_name": "rfq_blended_moz_dekad"
       },
       {
-        "id": "rain_anomaly_1month",
-        "title": "CHIRPS 1-month rainfall anomaly",
-        "server_layer_name": "r1q_dekad"
+        "id": "precip_blended_1m",
+        "title": "Blended rainfall aggregate (1-month)",
+        "server_layer_name": "rfb_blended_moz_dekad"
       },
       {
-        "id": "rain_anomaly_1year",
-        "title": "CHIRPS 1-year rainfall anomaly",
-        "server_layer_name": "ryq_dekad"
+        "id": "precip_blended_anomaly_1m",
+        "title": "Blended rainfall anomaly (1-month)",
+        "server_layer_name": "rfq_blended_moz_dekad"
       },
       {
-        "id": "rain_anomaly_2month",
-        "title": "2-month rainfall anomaly",
-        "server_layer_name": "r2q_dekad"
+        "id": "precip_blended_2m",
+        "title": "Blended rainfall aggregate (2-month)",
+        "server_layer_name": "rfb_blended_moz_dekad"
       },
       {
-        "id": "rain_anomaly_3month",
-        "title": "CHIRPS 3-month rainfall anomaly",
-        "server_layer_name": "r3q_dekad"
+        "id": "precip_blended_anomaly_2m",
+        "title": "Blended rainfall anomaly (2-month)",
+        "server_layer_name": "rfq_blended_moz_dekad"
       },
       {
-        "id": "rain_anomaly_4month",
-        "title": "4-month rainfall anomaly",
-        "server_layer_name": "r4q_dekad"
+        "id": "precip_blended_3m",
+        "title": "Blended rainfall aggregate (3-month)",
+        "server_layer_name": "rfb_blended_moz_dekad"
       },
       {
-        "id": "rain_anomaly_5month",
-        "title": "5-month rainfall anomaly",
-        "server_layer_name": "r5q_dekad"
+        "id": "precip_blended_anomaly_3m",
+        "title": "Blended rainfall anomaly (3-month)",
+        "server_layer_name": "rfq_blended_moz_dekad"
       },
       {
-        "id": "rain_anomaly_6month",
-        "title": "CHIRPS 6-month rainfall anomaly",
-        "server_layer_name": "r6q_dekad"
+        "id": "precip_blended_4m",
+        "title": "Blended rainfall aggregate (4-month)",
+        "server_layer_name": "rfb_blended_moz_dekad"
       },
       {
-        "id": "rain_anomaly_7month",
-        "title": "7-month rainfall anomaly",
-        "server_layer_name": "r7q_dekad"
+        "id": "precip_blended_anomaly_4m",
+        "title": "Blended rainfall anomaly (4-month)",
+        "server_layer_name": "rfq_blended_moz_dekad"
       },
       {
-        "id": "rain_anomaly_8month",
-        "title": "8-month rainfall anomaly",
-        "server_layer_name": "r8q_dekad"
+        "id": "precip_blended_5m",
+        "title": "Blended rainfall aggregate (5-month)",
+        "server_layer_name": "rfb_blended_moz_dekad"
       },
       {
-        "id": "rain_anomaly_9month",
-        "title": "CHIRPS 9-month rainfall anomaly",
-        "server_layer_name": "r9q_dekad"
+        "id": "precip_blended_anomaly_5m",
+        "title": "Blended rainfall anomaly (5-month)",
+        "server_layer_name": "rfq_blended_moz_dekad"
+      },
+      {
+        "id": "precip_blended_6m",
+        "title": "Blended rainfall aggregate (6-month)",
+        "server_layer_name": "rfb_blended_moz_dekad"
+      },
+      {
+        "id": "precip_blended_anomaly_6m",
+        "title": "Blended rainfall anomaly (6-month)",
+        "server_layer_name": "rfq_blended_moz_dekad"
+      },
+      {
+        "id": "precip_blended_7m",
+        "title": "Blended rainfall aggregate (7-month)",
+        "server_layer_name": "rfb_blended_moz_dekad"
+      },
+      {
+        "id": "precip_blended_anomaly_7m",
+        "title": "Blended rainfall anomaly (7-month)",
+        "server_layer_name": "rfq_blended_moz_dekad"
+      },
+      {
+        "id": "precip_blended_8m",
+        "title": "Blended rainfall aggregate (8-month)",
+        "server_layer_name": "rfb_blended_moz_dekad"
+      },
+      {
+        "id": "precip_blended_anomaly_8m",
+        "title": "Blended rainfall anomaly (8-month)",
+        "server_layer_name": "rfq_blended_moz_dekad"
+      },
+      {
+        "id": "precip_blended_9m",
+        "title": "Blended rainfall aggregate (9-month)",
+        "server_layer_name": "rfb_blended_moz_dekad"
+      },
+      {
+        "id": "precip_blended_anomaly_9m",
+        "title": "Blended rainfall anomaly (9-month)",
+        "server_layer_name": "rfq_blended_moz_dekad"
+      },
+      {
+        "id": "precip_blended_1y",
+        "title": "Blended rainfall aggregate (1-year)",
+        "server_layer_name": "rfb_blended_moz_dekad"
+      },
+      {
+        "id": "precip_blended_anomaly_1y",
+        "title": "Blended rainfall anomaly (1-year)",
+        "server_layer_name": "rfq_blended_moz_dekad"
+      },
+      {
+        "id": "rainfall_dekad",
+        "title": "CHIRPS 10-day rainfall estimate (mm)",
+        "server_layer_name": "rfh_dekad"
       },
       {
         "id": "rain_anomaly_dekad",
@@ -3950,14 +3795,9 @@
         "server_layer_name": "r1h_dekad"
       },
       {
-        "id": "rainfall_agg_1year",
-        "title": "CHIRPS 1-year rainfall aggregate (mm)",
-        "server_layer_name": "ryh_dekad"
-      },
-      {
-        "id": "rainfall_agg_2month",
-        "title": "2-month rainfall aggregate (mm)",
-        "server_layer_name": "r2h_dekad"
+        "id": "rain_anomaly_1month",
+        "title": "CHIRPS 1-month rainfall anomaly",
+        "server_layer_name": "r1q_dekad"
       },
       {
         "id": "rainfall_agg_3month",
@@ -3965,14 +3805,9 @@
         "server_layer_name": "r3h_dekad"
       },
       {
-        "id": "rainfall_agg_4month",
-        "title": "4-month rainfall aggregate (mm)",
-        "server_layer_name": "r4h_dekad"
-      },
-      {
-        "id": "rainfall_agg_5month",
-        "title": "5-month rainfall aggregate (mm)",
-        "server_layer_name": "r5h_dekad"
+        "id": "rain_anomaly_3month",
+        "title": "CHIRPS 3-month rainfall anomaly",
+        "server_layer_name": "r3q_dekad"
       },
       {
         "id": "rainfall_agg_6month",
@@ -3980,14 +3815,9 @@
         "server_layer_name": "r6h_dekad"
       },
       {
-        "id": "rainfall_agg_7month",
-        "title": "7-month rainfall aggregate (mm)",
-        "server_layer_name": "r7h_dekad"
-      },
-      {
-        "id": "rainfall_agg_8month",
-        "title": "8-month rainfall aggregate (mm)",
-        "server_layer_name": "r8h_dekad"
+        "id": "rain_anomaly_6month",
+        "title": "CHIRPS 6-month rainfall anomaly",
+        "server_layer_name": "r6q_dekad"
       },
       {
         "id": "rainfall_agg_9month",
@@ -3995,48 +3825,43 @@
         "server_layer_name": "r9h_dekad"
       },
       {
-        "id": "rainfall_dekad",
-        "title": "CHIRPS 10-day rainfall estimate (mm)",
-        "server_layer_name": "rfh_dekad"
+        "id": "rain_anomaly_9month",
+        "title": "CHIRPS 9-month rainfall anomaly",
+        "server_layer_name": "r9q_dekad"
       },
       {
-        "id": "spi_1m",
-        "title": "SPI - 1-month",
-        "server_layer_name": "r1s_dekad"
+        "id": "rainfall_agg_1year",
+        "title": "CHIRPS 1-year rainfall aggregate (mm)",
+        "server_layer_name": "ryh_dekad"
       },
       {
-        "id": "spi_1y",
-        "title": "SPI - 1-year",
-        "server_layer_name": "rys_dekad"
+        "id": "rain_anomaly_1year",
+        "title": "CHIRPS 1-year rainfall anomaly",
+        "server_layer_name": "ryq_dekad"
       },
       {
-        "id": "spi_2m",
-        "title": "SPI - 2-month",
-        "server_layer_name": "r2s_dekad"
+        "id": "ndvi_dekad",
+        "title": "10-day NDVI (MODIS)",
+        "server_layer_name": "mxd13a2_vim_dekad"
       },
       {
-        "id": "spi_3m",
-        "title": "SPI - 3-month",
-        "server_layer_name": "r3s_dekad"
+        "id": "ndvi_dekad_anomaly",
+        "title": "10-day NDVI anomaly (MODIS)",
+        "server_layer_name": "mxd13a2_viq_dekad"
       },
       {
-        "id": "spi_6m",
-        "title": "SPI - 6-month",
-        "server_layer_name": "r6s_dekad"
+        "id": "lst_daytime_blended",
+        "title": "INAM mean maximum air temperature (10-day)",
+        "server_layer_name": "myd11a2_blended_txb_moz_dekad"
       },
       {
-        "id": "spi_9m",
-        "title": "SPI - 9-month",
-        "server_layer_name": "r9s_dekad"
+        "id": "lst_day_anomaly_blended",
+        "title": "INAM mean maximum air temperature anomaly (10-day)",
+        "server_layer_name": "myd11a2_blended_txd_moz_dekad"
       },
       {
         "id": "spi_blended_1m",
         "title": "INAM SPI - 1-month",
-        "server_layer_name": "rxs_blended_moz_dekad"
-      },
-      {
-        "id": "spi_blended_1y",
-        "title": "INAM SPI - 1-year",
         "server_layer_name": "rxs_blended_moz_dekad"
       },
       {
@@ -4045,23 +3870,8 @@
         "server_layer_name": "rxs_blended_moz_dekad"
       },
       {
-        "id": "spi_blended_2y",
-        "title": "INAM SPI - 2-year",
-        "server_layer_name": "rxs_blended_moz_dekad"
-      },
-      {
         "id": "spi_blended_3m",
         "title": "INAM SPI - 3-month",
-        "server_layer_name": "rxs_blended_moz_dekad"
-      },
-      {
-        "id": "spi_blended_3y",
-        "title": "INAM SPI - 3-year",
-        "server_layer_name": "rxs_blended_moz_dekad"
-      },
-      {
-        "id": "spi_blended_5y",
-        "title": "INAM SPI - 5-year",
         "server_layer_name": "rxs_blended_moz_dekad"
       },
       {
@@ -4075,51 +3885,24 @@
         "server_layer_name": "rxs_blended_moz_dekad"
       },
       {
-        "id": "streak_dry_days",
-        "title": "Longest dry spell",
-        "server_layer_name": "dlx_dekad"
+        "id": "spi_blended_1y",
+        "title": "INAM SPI - 1-year",
+        "server_layer_name": "rxs_blended_moz_dekad"
       },
       {
-        "id": "streak_extreme_rain",
-        "title": "Longest consecutive extreme rainfall days",
-        "server_layer_name": "xle_dekad"
+        "id": "spi_blended_2y",
+        "title": "INAM SPI - 2-year",
+        "server_layer_name": "rxs_blended_moz_dekad"
       },
       {
-        "id": "streak_heavy_rain",
-        "title": "Longest consecutive heavy rainfall days",
-        "server_layer_name": "xlh_dekad"
+        "id": "spi_blended_3y",
+        "title": "INAM SPI - 3-year",
+        "server_layer_name": "rxs_blended_moz_dekad"
       },
       {
-        "id": "streak_intense_rain",
-        "title": "Longest consecutive intense rainfall days",
-        "server_layer_name": "xli_dekad"
-      }
-    ],
-    "myanmar": [
-      {
-        "id": "2m_water_anomaly",
-        "title": "2-Month Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_seasonal_2month"
-      },
-      {
-        "id": "3m_water_anomaly",
-        "title": "3-Month Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_seasonal_3month"
-      },
-      {
-        "id": "4m_water_anomaly",
-        "title": "4-Month Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_seasonal_4month"
-      },
-      {
-        "id": "5m_water_anomaly",
-        "title": "5-Month Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_seasonal_5month"
-      },
-      {
-        "id": "6m_water_anomaly",
-        "title": "6-Month Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_seasonal_6month"
+        "id": "spi_blended_5y",
+        "title": "INAM SPI - 5-year",
+        "server_layer_name": "rxs_blended_moz_dekad"
       },
       {
         "id": "daily_rainfall_forecast",
@@ -4127,24 +3910,9 @@
         "server_layer_name": "rfh_daily_forecast"
       },
       {
-        "id": "days_dry",
-        "title": "Days since last rain",
-        "server_layer_name": "dlc_dekad"
-      },
-      {
-        "id": "days_extreme_rain",
-        "title": "Number of days with extreme rainfall in the last 30 days",
-        "server_layer_name": "xne_dekad"
-      },
-      {
-        "id": "days_heavy_rain",
-        "title": "Number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xnh_dekad"
-      },
-      {
-        "id": "days_intense_rain",
-        "title": "Number of days with intense rainfall in the last 30 days",
-        "server_layer_name": "xni_dekad"
+        "id": "dekad_rainfall_forecast",
+        "title": "10-day rainfall forecast",
+        "server_layer_name": "rfh_dekad_forecast"
       },
       {
         "id": "dekad_rainfall_anomaly_forecast",
@@ -4152,59 +3920,9 @@
         "server_layer_name": "rfq_dekad"
       },
       {
-        "id": "dekad_rainfall_forecast",
-        "title": "10-day rainfall forecast",
-        "server_layer_name": "rfh_dekad_forecast"
-      },
-      {
-        "id": "lst_amplitude",
-        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
-        "server_layer_name": "myd11a2_taa_dekad"
-      },
-      {
-        "id": "lst_anomaly",
-        "title": "Daytime Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_day_anomaly",
-        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_daytime",
-        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "lst_nighttime",
-        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "monthly_water_anomaly",
-        "title": "Monthly Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_dekad"
-      },
-      {
-        "id": "ndvi_dekad",
-        "title": "10-day NDVI (MODIS)",
-        "server_layer_name": "mxd13a2_vim_dekad"
-      },
-      {
-        "id": "ndvi_dekad_anomaly",
-        "title": "10-day NDVI anomaly (MODIS)",
-        "server_layer_name": "mxd13a2_viq_dekad"
-      },
-      {
-        "id": "rain_anomaly_1month",
-        "title": "Monthly rainfall anomaly",
-        "server_layer_name": "r1q_dekad"
-      },
-      {
-        "id": "rain_anomaly_1year",
-        "title": "1-year rainfall anomaly",
-        "server_layer_name": "ryq_dekad"
+        "id": "rainfall_agg_2month",
+        "title": "2-month rainfall aggregate (mm)",
+        "server_layer_name": "r2h_dekad"
       },
       {
         "id": "rain_anomaly_2month",
@@ -4212,9 +3930,9 @@
         "server_layer_name": "r2q_dekad"
       },
       {
-        "id": "rain_anomaly_3month",
-        "title": "3-month rainfall anomaly",
-        "server_layer_name": "r3q_dekad"
+        "id": "rainfall_agg_4month",
+        "title": "4-month rainfall aggregate (mm)",
+        "server_layer_name": "r4h_dekad"
       },
       {
         "id": "rain_anomaly_4month",
@@ -4222,69 +3940,14 @@
         "server_layer_name": "r4q_dekad"
       },
       {
-        "id": "rain_anomaly_5month",
-        "title": "5-month rainfall anomaly",
-        "server_layer_name": "r5q_dekad"
-      },
-      {
-        "id": "rain_anomaly_6month",
-        "title": "6-month rainfall anomaly",
-        "server_layer_name": "r6q_dekad"
-      },
-      {
-        "id": "rain_anomaly_7month",
-        "title": "7-month rainfall anomaly",
-        "server_layer_name": "r7q_dekad"
-      },
-      {
-        "id": "rain_anomaly_8month",
-        "title": "8-month rainfall anomaly",
-        "server_layer_name": "r8q_dekad"
-      },
-      {
-        "id": "rain_anomaly_9month",
-        "title": "9-month rainfall anomaly",
-        "server_layer_name": "r9q_dekad"
-      },
-      {
-        "id": "rain_anomaly_dekad",
-        "title": "10-day rainfall anomaly",
-        "server_layer_name": "rfq_dekad"
-      },
-      {
-        "id": "rainfall_agg_1month",
-        "title": "1-month rainfall aggregate",
-        "server_layer_name": "r1h_dekad"
-      },
-      {
-        "id": "rainfall_agg_1year",
-        "title": "1-year rainfall aggregate (mm)",
-        "server_layer_name": "ryh_dekad"
-      },
-      {
-        "id": "rainfall_agg_2month",
-        "title": "2-month rainfall aggregate (mm)",
-        "server_layer_name": "r2h_dekad"
-      },
-      {
-        "id": "rainfall_agg_3month",
-        "title": "3-month rainfall aggregate (mm)",
-        "server_layer_name": "r3h_dekad"
-      },
-      {
-        "id": "rainfall_agg_4month",
-        "title": "4-month rainfall aggregate (mm)",
-        "server_layer_name": "r4h_dekad"
-      },
-      {
         "id": "rainfall_agg_5month",
         "title": "5-month rainfall aggregate (mm)",
         "server_layer_name": "r5h_dekad"
       },
       {
-        "id": "rainfall_agg_6month",
-        "title": "6-month rainfall aggregate (mm)",
-        "server_layer_name": "r6h_dekad"
+        "id": "rain_anomaly_5month",
+        "title": "5-month rainfall anomaly",
+        "server_layer_name": "r5q_dekad"
       },
       {
         "id": "rainfall_agg_7month",
@@ -4292,29 +3955,24 @@
         "server_layer_name": "r7h_dekad"
       },
       {
+        "id": "rain_anomaly_7month",
+        "title": "7-month rainfall anomaly",
+        "server_layer_name": "r7q_dekad"
+      },
+      {
         "id": "rainfall_agg_8month",
         "title": "8-month rainfall aggregate (mm)",
         "server_layer_name": "r8h_dekad"
       },
       {
-        "id": "rainfall_agg_9month",
-        "title": "9-month rainfall aggregate (mm)",
-        "server_layer_name": "r9h_dekad"
-      },
-      {
-        "id": "rainfall_dekad",
-        "title": "10-day rainfall estimate (mm)",
-        "server_layer_name": "rfh_dekad"
+        "id": "rain_anomaly_8month",
+        "title": "8-month rainfall anomaly",
+        "server_layer_name": "r8q_dekad"
       },
       {
         "id": "spi_1m",
         "title": "SPI - 1-month",
         "server_layer_name": "r1s_dekad"
-      },
-      {
-        "id": "spi_1y",
-        "title": "SPI - 1-year",
-        "server_layer_name": "rys_dekad"
       },
       {
         "id": "spi_2m",
@@ -4337,9 +3995,44 @@
         "server_layer_name": "r9s_dekad"
       },
       {
+        "id": "spi_1y",
+        "title": "SPI - 1-year",
+        "server_layer_name": "rys_dekad"
+      },
+      {
+        "id": "days_dry",
+        "title": "Days since last rain",
+        "server_layer_name": "dlc_dekad"
+      },
+      {
         "id": "streak_dry_days",
-        "title": "Longest number of consecutive dry days",
+        "title": "Longest dry spell",
         "server_layer_name": "dlx_dekad"
+      },
+      {
+        "id": "days_heavy_rain",
+        "title": "Number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xnh_dekad"
+      },
+      {
+        "id": "days_intense_rain",
+        "title": "Number of days with intense rainfall in the last 30 days",
+        "server_layer_name": "xni_dekad"
+      },
+      {
+        "id": "days_extreme_rain",
+        "title": "Number of days with extreme rainfall in the last 30 days",
+        "server_layer_name": "xne_dekad"
+      },
+      {
+        "id": "streak_heavy_rain",
+        "title": "Longest consecutive heavy rainfall days",
+        "server_layer_name": "xlh_dekad"
+      },
+      {
+        "id": "streak_intense_rain",
+        "title": "Longest consecutive intense rainfall days",
+        "server_layer_name": "xli_dekad"
       },
       {
         "id": "streak_extreme_rain",
@@ -4347,17 +4040,35 @@
         "server_layer_name": "xle_dekad"
       },
       {
-        "id": "streak_heavy_rain",
-        "title": "Longest consecutive number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xlh_dekad"
+        "id": "lst_amplitude",
+        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
+        "server_layer_name": "myd11a2_taa_dekad"
       },
       {
-        "id": "streak_intense_rain",
-        "title": "Longest consecutive intense rainfall days",
-        "server_layer_name": "xli_dekad"
-      }
-    ],
-    "namibia": [
+        "id": "lst_daytime",
+        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_nighttime",
+        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_day_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "monthly_water_anomaly",
+        "title": "Monthly Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_dekad"
+      },
       {
         "id": "2m_water_anomaly",
         "title": "2-Month Water Anomaly Index (WAI)",
@@ -4382,11 +4093,93 @@
         "id": "6m_water_anomaly",
         "title": "6-Month Water Anomaly Index (WAI)",
         "server_layer_name": "wai_seasonal_6month"
+      }
+    ],
+    "myanmar": [
+      {
+        "id": "rainfall_dekad",
+        "title": "10-day rainfall estimate (mm)",
+        "server_layer_name": "rfh_dekad"
       },
       {
-        "id": "daily_rainfall_forecast",
-        "title": "Rolling daily rainfall forecast",
-        "server_layer_name": "rfh_daily_forecast"
+        "id": "rain_anomaly_dekad",
+        "title": "10-day rainfall anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rainfall_agg_1month",
+        "title": "1-month rainfall aggregate",
+        "server_layer_name": "r1h_dekad"
+      },
+      {
+        "id": "rain_anomaly_1month",
+        "title": "Monthly rainfall anomaly",
+        "server_layer_name": "r1q_dekad"
+      },
+      {
+        "id": "rainfall_agg_3month",
+        "title": "3-month rainfall aggregate (mm)",
+        "server_layer_name": "r3h_dekad"
+      },
+      {
+        "id": "rain_anomaly_3month",
+        "title": "3-month rainfall anomaly",
+        "server_layer_name": "r3q_dekad"
+      },
+      {
+        "id": "rainfall_agg_6month",
+        "title": "6-month rainfall aggregate (mm)",
+        "server_layer_name": "r6h_dekad"
+      },
+      {
+        "id": "rain_anomaly_6month",
+        "title": "6-month rainfall anomaly",
+        "server_layer_name": "r6q_dekad"
+      },
+      {
+        "id": "rainfall_agg_9month",
+        "title": "9-month rainfall aggregate (mm)",
+        "server_layer_name": "r9h_dekad"
+      },
+      {
+        "id": "rain_anomaly_9month",
+        "title": "9-month rainfall anomaly",
+        "server_layer_name": "r9q_dekad"
+      },
+      {
+        "id": "rainfall_agg_1year",
+        "title": "1-year rainfall aggregate (mm)",
+        "server_layer_name": "ryh_dekad"
+      },
+      {
+        "id": "rain_anomaly_1year",
+        "title": "1-year rainfall anomaly",
+        "server_layer_name": "ryq_dekad"
+      },
+      {
+        "id": "spi_1m",
+        "title": "SPI - 1-month",
+        "server_layer_name": "r1s_dekad"
+      },
+      {
+        "id": "spi_3m",
+        "title": "SPI - 3-month",
+        "server_layer_name": "r3s_dekad"
+      },
+      {
+        "id": "spi_6m",
+        "title": "SPI - 6-month",
+        "server_layer_name": "r6s_dekad"
+      },
+      {
+        "id": "spi_9m",
+        "title": "SPI - 9-month",
+        "server_layer_name": "r9s_dekad"
+      },
+      {
+        "id": "spi_1y",
+        "title": "SPI - 1-year",
+        "server_layer_name": "rys_dekad"
       },
       {
         "id": "days_dry",
@@ -4394,9 +4187,9 @@
         "server_layer_name": "dlc_dekad"
       },
       {
-        "id": "days_extreme_rain",
-        "title": "Number of days with extreme rainfall in the last 30 days",
-        "server_layer_name": "xne_dekad"
+        "id": "streak_dry_days",
+        "title": "Longest number of consecutive dry days",
+        "server_layer_name": "dlx_dekad"
       },
       {
         "id": "days_heavy_rain",
@@ -4409,14 +4202,34 @@
         "server_layer_name": "xni_dekad"
       },
       {
-        "id": "dekad_rainfall_anomaly_forecast",
-        "title": "10-day rainfall forecast anomaly",
-        "server_layer_name": "rfq_dekad"
+        "id": "days_extreme_rain",
+        "title": "Number of days with extreme rainfall in the last 30 days",
+        "server_layer_name": "xne_dekad"
       },
       {
-        "id": "dekad_rainfall_forecast",
-        "title": "10-day rainfall forecast",
-        "server_layer_name": "rfh_dekad_forecast"
+        "id": "streak_heavy_rain",
+        "title": "Longest consecutive number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xlh_dekad"
+      },
+      {
+        "id": "streak_intense_rain",
+        "title": "Longest consecutive intense rainfall days",
+        "server_layer_name": "xli_dekad"
+      },
+      {
+        "id": "streak_extreme_rain",
+        "title": "Longest consecutive extreme rainfall days",
+        "server_layer_name": "xle_dekad"
+      },
+      {
+        "id": "ndvi_dekad",
+        "title": "10-day NDVI (MODIS)",
+        "server_layer_name": "mxd13a2_vim_dekad"
+      },
+      {
+        "id": "ndvi_dekad_anomaly",
+        "title": "10-day NDVI anomaly (MODIS)",
+        "server_layer_name": "mxd13a2_viq_dekad"
       },
       {
         "id": "lst_amplitude",
@@ -4424,19 +4237,84 @@
         "server_layer_name": "myd11a2_taa_dekad"
       },
       {
-        "id": "lst_anomaly",
-        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_day_anomaly",
-        "title": "Daytime Land Surface Temperature - 10-day Anomaly 1km (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
         "id": "lst_daytime",
-        "title": "Daytime Land Surface Temperature - 10-day 1km (MODIS)",
+        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
         "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_anomaly",
+        "title": "Daytime Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "daily_rainfall_forecast",
+        "title": "Rolling daily rainfall forecast",
+        "server_layer_name": "rfh_daily_forecast"
+      },
+      {
+        "id": "dekad_rainfall_forecast",
+        "title": "10-day rainfall forecast",
+        "server_layer_name": "rfh_dekad_forecast"
+      },
+      {
+        "id": "dekad_rainfall_anomaly_forecast",
+        "title": "10-day rainfall forecast anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rainfall_agg_2month",
+        "title": "2-month rainfall aggregate (mm)",
+        "server_layer_name": "r2h_dekad"
+      },
+      {
+        "id": "rain_anomaly_2month",
+        "title": "2-month rainfall anomaly",
+        "server_layer_name": "r2q_dekad"
+      },
+      {
+        "id": "rainfall_agg_4month",
+        "title": "4-month rainfall aggregate (mm)",
+        "server_layer_name": "r4h_dekad"
+      },
+      {
+        "id": "rain_anomaly_4month",
+        "title": "4-month rainfall anomaly",
+        "server_layer_name": "r4q_dekad"
+      },
+      {
+        "id": "rainfall_agg_5month",
+        "title": "5-month rainfall aggregate (mm)",
+        "server_layer_name": "r5h_dekad"
+      },
+      {
+        "id": "rain_anomaly_5month",
+        "title": "5-month rainfall anomaly",
+        "server_layer_name": "r5q_dekad"
+      },
+      {
+        "id": "rainfall_agg_7month",
+        "title": "7-month rainfall aggregate (mm)",
+        "server_layer_name": "r7h_dekad"
+      },
+      {
+        "id": "rain_anomaly_7month",
+        "title": "7-month rainfall anomaly",
+        "server_layer_name": "r7q_dekad"
+      },
+      {
+        "id": "rainfall_agg_8month",
+        "title": "8-month rainfall aggregate (mm)",
+        "server_layer_name": "r8h_dekad"
+      },
+      {
+        "id": "rain_anomaly_8month",
+        "title": "8-month rainfall anomaly",
+        "server_layer_name": "r8q_dekad"
+      },
+      {
+        "id": "spi_2m",
+        "title": "SPI - 2-month",
+        "server_layer_name": "r2s_dekad"
       },
       {
         "id": "lst_nighttime",
@@ -4444,9 +4322,171 @@
         "server_layer_name": "myd11a2_txa_dekad"
       },
       {
+        "id": "lst_day_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
         "id": "monthly_water_anomaly",
         "title": "Monthly Water Anomaly Index (WAI)",
         "server_layer_name": "wai_dekad"
+      },
+      {
+        "id": "2m_water_anomaly",
+        "title": "2-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_2month"
+      },
+      {
+        "id": "3m_water_anomaly",
+        "title": "3-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_3month"
+      },
+      {
+        "id": "4m_water_anomaly",
+        "title": "4-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_4month"
+      },
+      {
+        "id": "5m_water_anomaly",
+        "title": "5-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_5month"
+      },
+      {
+        "id": "6m_water_anomaly",
+        "title": "6-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_6month"
+      }
+    ],
+    "namibia": [
+      {
+        "id": "rain_anomaly_dekad",
+        "title": "10-day rainfall anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rain_anomaly_1month",
+        "title": "1-month rainfall anomaly",
+        "server_layer_name": "r1q_dekad"
+      },
+      {
+        "id": "rain_anomaly_3month",
+        "title": "3-month rainfall anomaly",
+        "server_layer_name": "r3q_dekad"
+      },
+      {
+        "id": "rain_anomaly_6month",
+        "title": "6-month rainfall anomaly",
+        "server_layer_name": "r6q_dekad"
+      },
+      {
+        "id": "rain_anomaly_9month",
+        "title": "9-month rainfall anomaly",
+        "server_layer_name": "r9q_dekad"
+      },
+      {
+        "id": "rain_anomaly_1year",
+        "title": "1-year rainfall anomaly",
+        "server_layer_name": "ryq_dekad"
+      },
+      {
+        "id": "rainfall_dekad",
+        "title": "10-day rainfall estimate (mm)",
+        "server_layer_name": "rfh_dekad"
+      },
+      {
+        "id": "rainfall_agg_1month",
+        "title": "1-month rainfall aggregate",
+        "server_layer_name": "r1h_dekad"
+      },
+      {
+        "id": "rainfall_agg_2month",
+        "title": "2-month rainfall aggregate (mm)",
+        "server_layer_name": "r2h_dekad"
+      },
+      {
+        "id": "rainfall_agg_3month",
+        "title": "3-month rainfall aggregate (mm)",
+        "server_layer_name": "r3h_dekad"
+      },
+      {
+        "id": "rainfall_agg_6month",
+        "title": "6-month rainfall aggregate (mm)",
+        "server_layer_name": "r6h_dekad"
+      },
+      {
+        "id": "rainfall_agg_9month",
+        "title": "9-month rainfall aggregate (mm)",
+        "server_layer_name": "r9h_dekad"
+      },
+      {
+        "id": "rainfall_agg_1year",
+        "title": "1-year rainfall aggregate (mm)",
+        "server_layer_name": "ryh_dekad"
+      },
+      {
+        "id": "spi_1m",
+        "title": "SPI - 1-month",
+        "server_layer_name": "r1s_dekad"
+      },
+      {
+        "id": "spi_3m",
+        "title": "SPI - 3-month",
+        "server_layer_name": "r3s_dekad"
+      },
+      {
+        "id": "spi_6m",
+        "title": "SPI - 6-month",
+        "server_layer_name": "r6s_dekad"
+      },
+      {
+        "id": "spi_9m",
+        "title": "SPI - 9-month",
+        "server_layer_name": "r9s_dekad"
+      },
+      {
+        "id": "spi_1y",
+        "title": "SPI - 1-year",
+        "server_layer_name": "rys_dekad"
+      },
+      {
+        "id": "days_dry",
+        "title": "Days since last rain",
+        "server_layer_name": "dlc_dekad"
+      },
+      {
+        "id": "streak_dry_days",
+        "title": "Longest dry spell",
+        "server_layer_name": "dlx_dekad"
+      },
+      {
+        "id": "days_heavy_rain",
+        "title": "Number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xnh_dekad"
+      },
+      {
+        "id": "days_intense_rain",
+        "title": "Number of days with intense rainfall in the last 30 days",
+        "server_layer_name": "xni_dekad"
+      },
+      {
+        "id": "days_extreme_rain",
+        "title": "Number of days with extreme rainfall in the last 30 days",
+        "server_layer_name": "xne_dekad"
+      },
+      {
+        "id": "streak_heavy_rain",
+        "title": "Longest consecutive heavy rainfall days",
+        "server_layer_name": "xlh_dekad"
+      },
+      {
+        "id": "streak_intense_rain",
+        "title": "Longest consecutive intense rainfall days",
+        "server_layer_name": "xli_dekad"
+      },
+      {
+        "id": "streak_extreme_rain",
+        "title": "Longest consecutive extreme rainfall days",
+        "server_layer_name": "xle_dekad"
       },
       {
         "id": "ndvi_dekad",
@@ -4459,14 +4499,39 @@
         "server_layer_name": "mxd13a2_viq_dekad"
       },
       {
-        "id": "rain_anomaly_1month",
-        "title": "1-month rainfall anomaly",
-        "server_layer_name": "r1q_dekad"
+        "id": "lst_amplitude",
+        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
+        "server_layer_name": "myd11a2_taa_dekad"
       },
       {
-        "id": "rain_anomaly_1year",
-        "title": "1-year rainfall anomaly",
-        "server_layer_name": "ryq_dekad"
+        "id": "lst_daytime",
+        "title": "Daytime Land Surface Temperature - 10-day 1km (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_nighttime",
+        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_day_anomaly",
+        "title": "Daytime Land Surface Temperature - 10-day Anomaly 1km (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "daily_rainfall_forecast",
+        "title": "Rolling daily rainfall forecast",
+        "server_layer_name": "rfh_daily_forecast"
+      },
+      {
+        "id": "dekad_rainfall_forecast",
+        "title": "10-day rainfall forecast",
+        "server_layer_name": "rfh_dekad_forecast"
+      },
+      {
+        "id": "dekad_rainfall_anomaly_forecast",
+        "title": "10-day rainfall forecast anomaly",
+        "server_layer_name": "rfq_dekad"
       },
       {
         "id": "rain_anomaly_2month",
@@ -4474,9 +4539,9 @@
         "server_layer_name": "r2q_dekad"
       },
       {
-        "id": "rain_anomaly_3month",
-        "title": "3-month rainfall anomaly",
-        "server_layer_name": "r3q_dekad"
+        "id": "rainfall_agg_4month",
+        "title": "4-month rainfall aggregate (mm)",
+        "server_layer_name": "r4h_dekad"
       },
       {
         "id": "rain_anomaly_4month",
@@ -4484,69 +4549,14 @@
         "server_layer_name": "r4q_dekad"
       },
       {
-        "id": "rain_anomaly_5month",
-        "title": "5-month rainfall anomaly",
-        "server_layer_name": "r5q_dekad"
-      },
-      {
-        "id": "rain_anomaly_6month",
-        "title": "6-month rainfall anomaly",
-        "server_layer_name": "r6q_dekad"
-      },
-      {
-        "id": "rain_anomaly_7month",
-        "title": "7-month rainfall anomaly",
-        "server_layer_name": "r7q_dekad"
-      },
-      {
-        "id": "rain_anomaly_8month",
-        "title": "8-month rainfall anomaly",
-        "server_layer_name": "r8q_dekad"
-      },
-      {
-        "id": "rain_anomaly_9month",
-        "title": "9-month rainfall anomaly",
-        "server_layer_name": "r9q_dekad"
-      },
-      {
-        "id": "rain_anomaly_dekad",
-        "title": "10-day rainfall anomaly",
-        "server_layer_name": "rfq_dekad"
-      },
-      {
-        "id": "rainfall_agg_1month",
-        "title": "1-month rainfall aggregate",
-        "server_layer_name": "r1h_dekad"
-      },
-      {
-        "id": "rainfall_agg_1year",
-        "title": "1-year rainfall aggregate (mm)",
-        "server_layer_name": "ryh_dekad"
-      },
-      {
-        "id": "rainfall_agg_2month",
-        "title": "2-month rainfall aggregate (mm)",
-        "server_layer_name": "r2h_dekad"
-      },
-      {
-        "id": "rainfall_agg_3month",
-        "title": "3-month rainfall aggregate (mm)",
-        "server_layer_name": "r3h_dekad"
-      },
-      {
-        "id": "rainfall_agg_4month",
-        "title": "4-month rainfall aggregate (mm)",
-        "server_layer_name": "r4h_dekad"
-      },
-      {
         "id": "rainfall_agg_5month",
         "title": "5-month rainfall aggregate (mm)",
         "server_layer_name": "r5h_dekad"
       },
       {
-        "id": "rainfall_agg_6month",
-        "title": "6-month rainfall aggregate (mm)",
-        "server_layer_name": "r6h_dekad"
+        "id": "rain_anomaly_5month",
+        "title": "5-month rainfall anomaly",
+        "server_layer_name": "r5q_dekad"
       },
       {
         "id": "rainfall_agg_7month",
@@ -4554,29 +4564,19 @@
         "server_layer_name": "r7h_dekad"
       },
       {
+        "id": "rain_anomaly_7month",
+        "title": "7-month rainfall anomaly",
+        "server_layer_name": "r7q_dekad"
+      },
+      {
         "id": "rainfall_agg_8month",
         "title": "8-month rainfall aggregate (mm)",
         "server_layer_name": "r8h_dekad"
       },
       {
-        "id": "rainfall_agg_9month",
-        "title": "9-month rainfall aggregate (mm)",
-        "server_layer_name": "r9h_dekad"
-      },
-      {
-        "id": "rainfall_dekad",
-        "title": "10-day rainfall estimate (mm)",
-        "server_layer_name": "rfh_dekad"
-      },
-      {
-        "id": "spi_1m",
-        "title": "SPI - 1-month",
-        "server_layer_name": "r1s_dekad"
-      },
-      {
-        "id": "spi_1y",
-        "title": "SPI - 1-year",
-        "server_layer_name": "rys_dekad"
+        "id": "rain_anomaly_8month",
+        "title": "8-month rainfall anomaly",
+        "server_layer_name": "r8q_dekad"
       },
       {
         "id": "spi_2m",
@@ -4584,43 +4584,278 @@
         "server_layer_name": "r2s_dekad"
       },
       {
-        "id": "spi_3m",
-        "title": "SPI - 3-month",
-        "server_layer_name": "r3s_dekad"
+        "id": "lst_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
       },
       {
-        "id": "spi_6m",
-        "title": "SPI - 6-month",
-        "server_layer_name": "r6s_dekad"
+        "id": "monthly_water_anomaly",
+        "title": "Monthly Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_dekad"
       },
       {
-        "id": "spi_9m",
-        "title": "SPI - 9-month",
-        "server_layer_name": "r9s_dekad"
+        "id": "2m_water_anomaly",
+        "title": "2-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_2month"
       },
       {
-        "id": "streak_dry_days",
-        "title": "Longest dry spell",
-        "server_layer_name": "dlx_dekad"
+        "id": "3m_water_anomaly",
+        "title": "3-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_3month"
       },
       {
-        "id": "streak_extreme_rain",
-        "title": "Longest consecutive extreme rainfall days",
-        "server_layer_name": "xle_dekad"
+        "id": "4m_water_anomaly",
+        "title": "4-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_4month"
       },
       {
-        "id": "streak_heavy_rain",
-        "title": "Longest consecutive heavy rainfall days",
-        "server_layer_name": "xlh_dekad"
+        "id": "5m_water_anomaly",
+        "title": "5-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_5month"
       },
       {
-        "id": "streak_intense_rain",
-        "title": "Longest consecutive intense rainfall days",
-        "server_layer_name": "xli_dekad"
+        "id": "6m_water_anomaly",
+        "title": "6-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_6month"
       }
     ],
     "nepal": [
       {
+        "id": "rainfall_dekad",
+        "title": "10-day rainfall estimate (mm)",
+        "server_layer_name": "rfh_dekad"
+      },
+      {
+        "id": "rain_anomaly_dekad",
+        "title": "10-day rainfall anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rainfall_agg_1month",
+        "title": "1-month rainfall aggregate",
+        "server_layer_name": "r1h_dekad"
+      },
+      {
+        "id": "rain_anomaly_1month",
+        "title": "Monthly rainfall anomaly",
+        "server_layer_name": "r1q_dekad"
+      },
+      {
+        "id": "rainfall_agg_3month",
+        "title": "3-month rainfall aggregate (mm)",
+        "server_layer_name": "r3h_dekad"
+      },
+      {
+        "id": "rain_anomaly_3month",
+        "title": "3-month rainfall anomaly",
+        "server_layer_name": "r3q_dekad"
+      },
+      {
+        "id": "rain_anomaly_6month",
+        "title": "6-month rainfall anomaly",
+        "server_layer_name": "r6q_dekad"
+      },
+      {
+        "id": "rain_anomaly_9month",
+        "title": "9-month rainfall anomaly",
+        "server_layer_name": "r9q_dekad"
+      },
+      {
+        "id": "rain_anomaly_1year",
+        "title": "1-year rainfall anomaly",
+        "server_layer_name": "ryq_dekad"
+      },
+      {
+        "id": "rainfall_agg_6month",
+        "title": "6-month rainfall aggregate (mm)",
+        "server_layer_name": "r6h_dekad"
+      },
+      {
+        "id": "rainfall_agg_9month",
+        "title": "9-month rainfall aggregate (mm)",
+        "server_layer_name": "r9h_dekad"
+      },
+      {
+        "id": "rainfall_agg_1year",
+        "title": "1-year rainfall aggregate (mm)",
+        "server_layer_name": "ryh_dekad"
+      },
+      {
+        "id": "spi_1m",
+        "title": "SPI - 1-month",
+        "server_layer_name": "r1s_dekad"
+      },
+      {
+        "id": "spi_3m",
+        "title": "SPI - 3-month",
+        "server_layer_name": "r3s_dekad"
+      },
+      {
+        "id": "spi_6m",
+        "title": "SPI - 6-month",
+        "server_layer_name": "r6s_dekad"
+      },
+      {
+        "id": "spi_9m",
+        "title": "SPI - 9-month",
+        "server_layer_name": "r9s_dekad"
+      },
+      {
+        "id": "spi_1y",
+        "title": "SPI - 1-year",
+        "server_layer_name": "rys_dekad"
+      },
+      {
+        "id": "days_dry",
+        "title": "Days since last rain",
+        "server_layer_name": "dlc_dekad"
+      },
+      {
+        "id": "streak_dry_days",
+        "title": "Longest number of consecutive dry days",
+        "server_layer_name": "dlx_dekad"
+      },
+      {
+        "id": "days_heavy_rain",
+        "title": "Number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xnh_dekad"
+      },
+      {
+        "id": "days_intense_rain",
+        "title": "Number of days with intense rainfall in the last 30 days",
+        "server_layer_name": "xni_dekad"
+      },
+      {
+        "id": "days_extreme_rain",
+        "title": "Number of days with extreme rainfall in the last 30 days",
+        "server_layer_name": "xne_dekad"
+      },
+      {
+        "id": "streak_heavy_rain",
+        "title": "Longest consecutive number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xlh_dekad"
+      },
+      {
+        "id": "streak_intense_rain",
+        "title": "Longest consecutive intense rainfall days",
+        "server_layer_name": "xli_dekad"
+      },
+      {
+        "id": "streak_extreme_rain",
+        "title": "Longest consecutive extreme rainfall days",
+        "server_layer_name": "xle_dekad"
+      },
+      {
+        "id": "ndvi_dekad",
+        "title": "10-day NDVI (MODIS)",
+        "server_layer_name": "mxd13a2_vim_dekad"
+      },
+      {
+        "id": "ndvi_dekad_anomaly",
+        "title": "10-day NDVI anomaly (MODIS)",
+        "server_layer_name": "mxd13a2_viq_dekad"
+      },
+      {
+        "id": "lst_amplitude",
+        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
+        "server_layer_name": "myd11a2_taa_dekad"
+      },
+      {
+        "id": "lst_daytime",
+        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_anomaly",
+        "title": "Daytime Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "daily_rainfall_forecast",
+        "title": "Rolling daily rainfall forecast",
+        "server_layer_name": "rfh_daily_forecast"
+      },
+      {
+        "id": "dekad_rainfall_forecast",
+        "title": "10-day rainfall forecast",
+        "server_layer_name": "rfh_dekad_forecast"
+      },
+      {
+        "id": "dekad_rainfall_anomaly_forecast",
+        "title": "10-day rainfall forecast anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rainfall_agg_2month",
+        "title": "2-month rainfall aggregate (mm)",
+        "server_layer_name": "r2h_dekad"
+      },
+      {
+        "id": "rain_anomaly_2month",
+        "title": "2-month rainfall anomaly",
+        "server_layer_name": "r2q_dekad"
+      },
+      {
+        "id": "rainfall_agg_4month",
+        "title": "4-month rainfall aggregate (mm)",
+        "server_layer_name": "r4h_dekad"
+      },
+      {
+        "id": "rain_anomaly_4month",
+        "title": "4-month rainfall anomaly",
+        "server_layer_name": "r4q_dekad"
+      },
+      {
+        "id": "rainfall_agg_5month",
+        "title": "5-month rainfall aggregate (mm)",
+        "server_layer_name": "r5h_dekad"
+      },
+      {
+        "id": "rain_anomaly_5month",
+        "title": "5-month rainfall anomaly",
+        "server_layer_name": "r5q_dekad"
+      },
+      {
+        "id": "rainfall_agg_7month",
+        "title": "7-month rainfall aggregate (mm)",
+        "server_layer_name": "r7h_dekad"
+      },
+      {
+        "id": "rain_anomaly_7month",
+        "title": "7-month rainfall anomaly",
+        "server_layer_name": "r7q_dekad"
+      },
+      {
+        "id": "rainfall_agg_8month",
+        "title": "8-month rainfall aggregate (mm)",
+        "server_layer_name": "r8h_dekad"
+      },
+      {
+        "id": "rain_anomaly_8month",
+        "title": "8-month rainfall anomaly",
+        "server_layer_name": "r8q_dekad"
+      },
+      {
+        "id": "spi_2m",
+        "title": "SPI - 2-month",
+        "server_layer_name": "r2s_dekad"
+      },
+      {
+        "id": "lst_nighttime",
+        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_day_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "monthly_water_anomaly",
+        "title": "Monthly Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_dekad"
+      },
+      {
         "id": "2m_water_anomaly",
         "title": "2-Month Water Anomaly Index (WAI)",
         "server_layer_name": "wai_seasonal_2month"
@@ -4644,343 +4879,43 @@
         "id": "6m_water_anomaly",
         "title": "6-Month Water Anomaly Index (WAI)",
         "server_layer_name": "wai_seasonal_6month"
-      },
-      {
-        "id": "daily_rainfall_forecast",
-        "title": "Rolling daily rainfall forecast",
-        "server_layer_name": "rfh_daily_forecast"
-      },
-      {
-        "id": "days_dry",
-        "title": "Days since last rain",
-        "server_layer_name": "dlc_dekad"
-      },
-      {
-        "id": "days_extreme_rain",
-        "title": "Number of days with extreme rainfall in the last 30 days",
-        "server_layer_name": "xne_dekad"
-      },
-      {
-        "id": "days_heavy_rain",
-        "title": "Number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xnh_dekad"
-      },
-      {
-        "id": "days_intense_rain",
-        "title": "Number of days with intense rainfall in the last 30 days",
-        "server_layer_name": "xni_dekad"
-      },
-      {
-        "id": "dekad_rainfall_anomaly_forecast",
-        "title": "10-day rainfall forecast anomaly",
-        "server_layer_name": "rfq_dekad"
-      },
-      {
-        "id": "dekad_rainfall_forecast",
-        "title": "10-day rainfall forecast",
-        "server_layer_name": "rfh_dekad_forecast"
-      },
-      {
-        "id": "lst_amplitude",
-        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
-        "server_layer_name": "myd11a2_taa_dekad"
-      },
-      {
-        "id": "lst_anomaly",
-        "title": "Daytime Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_day_anomaly",
-        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_daytime",
-        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "lst_nighttime",
-        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "monthly_water_anomaly",
-        "title": "Monthly Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_dekad"
-      },
-      {
-        "id": "ndvi_dekad",
-        "title": "10-day NDVI (MODIS)",
-        "server_layer_name": "mxd13a2_vim_dekad"
-      },
-      {
-        "id": "ndvi_dekad_anomaly",
-        "title": "10-day NDVI anomaly (MODIS)",
-        "server_layer_name": "mxd13a2_viq_dekad"
-      },
-      {
-        "id": "rain_anomaly_1month",
-        "title": "Monthly rainfall anomaly",
-        "server_layer_name": "r1q_dekad"
-      },
-      {
-        "id": "rain_anomaly_1year",
-        "title": "1-year rainfall anomaly",
-        "server_layer_name": "ryq_dekad"
-      },
-      {
-        "id": "rain_anomaly_2month",
-        "title": "2-month rainfall anomaly",
-        "server_layer_name": "r2q_dekad"
-      },
-      {
-        "id": "rain_anomaly_3month",
-        "title": "3-month rainfall anomaly",
-        "server_layer_name": "r3q_dekad"
-      },
-      {
-        "id": "rain_anomaly_4month",
-        "title": "4-month rainfall anomaly",
-        "server_layer_name": "r4q_dekad"
-      },
-      {
-        "id": "rain_anomaly_5month",
-        "title": "5-month rainfall anomaly",
-        "server_layer_name": "r5q_dekad"
-      },
-      {
-        "id": "rain_anomaly_6month",
-        "title": "6-month rainfall anomaly",
-        "server_layer_name": "r6q_dekad"
-      },
-      {
-        "id": "rain_anomaly_7month",
-        "title": "7-month rainfall anomaly",
-        "server_layer_name": "r7q_dekad"
-      },
-      {
-        "id": "rain_anomaly_8month",
-        "title": "8-month rainfall anomaly",
-        "server_layer_name": "r8q_dekad"
-      },
-      {
-        "id": "rain_anomaly_9month",
-        "title": "9-month rainfall anomaly",
-        "server_layer_name": "r9q_dekad"
-      },
-      {
-        "id": "rain_anomaly_dekad",
-        "title": "10-day rainfall anomaly",
-        "server_layer_name": "rfq_dekad"
-      },
-      {
-        "id": "rainfall_agg_1month",
-        "title": "1-month rainfall aggregate",
-        "server_layer_name": "r1h_dekad"
-      },
-      {
-        "id": "rainfall_agg_1year",
-        "title": "1-year rainfall aggregate (mm)",
-        "server_layer_name": "ryh_dekad"
-      },
-      {
-        "id": "rainfall_agg_2month",
-        "title": "2-month rainfall aggregate (mm)",
-        "server_layer_name": "r2h_dekad"
-      },
-      {
-        "id": "rainfall_agg_3month",
-        "title": "3-month rainfall aggregate (mm)",
-        "server_layer_name": "r3h_dekad"
-      },
-      {
-        "id": "rainfall_agg_4month",
-        "title": "4-month rainfall aggregate (mm)",
-        "server_layer_name": "r4h_dekad"
-      },
-      {
-        "id": "rainfall_agg_5month",
-        "title": "5-month rainfall aggregate (mm)",
-        "server_layer_name": "r5h_dekad"
-      },
-      {
-        "id": "rainfall_agg_6month",
-        "title": "6-month rainfall aggregate (mm)",
-        "server_layer_name": "r6h_dekad"
-      },
-      {
-        "id": "rainfall_agg_7month",
-        "title": "7-month rainfall aggregate (mm)",
-        "server_layer_name": "r7h_dekad"
-      },
-      {
-        "id": "rainfall_agg_8month",
-        "title": "8-month rainfall aggregate (mm)",
-        "server_layer_name": "r8h_dekad"
-      },
-      {
-        "id": "rainfall_agg_9month",
-        "title": "9-month rainfall aggregate (mm)",
-        "server_layer_name": "r9h_dekad"
-      },
-      {
-        "id": "rainfall_dekad",
-        "title": "10-day rainfall estimate (mm)",
-        "server_layer_name": "rfh_dekad"
-      },
-      {
-        "id": "spi_1m",
-        "title": "SPI - 1-month",
-        "server_layer_name": "r1s_dekad"
-      },
-      {
-        "id": "spi_1y",
-        "title": "SPI - 1-year",
-        "server_layer_name": "rys_dekad"
-      },
-      {
-        "id": "spi_2m",
-        "title": "SPI - 2-month",
-        "server_layer_name": "r2s_dekad"
-      },
-      {
-        "id": "spi_3m",
-        "title": "SPI - 3-month",
-        "server_layer_name": "r3s_dekad"
-      },
-      {
-        "id": "spi_6m",
-        "title": "SPI - 6-month",
-        "server_layer_name": "r6s_dekad"
-      },
-      {
-        "id": "spi_9m",
-        "title": "SPI - 9-month",
-        "server_layer_name": "r9s_dekad"
-      },
-      {
-        "id": "streak_dry_days",
-        "title": "Longest number of consecutive dry days",
-        "server_layer_name": "dlx_dekad"
-      },
-      {
-        "id": "streak_extreme_rain",
-        "title": "Longest consecutive extreme rainfall days",
-        "server_layer_name": "xle_dekad"
-      },
-      {
-        "id": "streak_heavy_rain",
-        "title": "Longest consecutive number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xlh_dekad"
-      },
-      {
-        "id": "streak_intense_rain",
-        "title": "Longest consecutive intense rainfall days",
-        "server_layer_name": "xli_dekad"
       }
     ],
     "nigeria": [
       {
-        "id": "2m_water_anomaly",
-        "title": "2-Month Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_seasonal_2month"
+        "id": "spi_1m",
+        "title": "SPI - 1-month",
+        "server_layer_name": "r1s_dekad"
       },
       {
-        "id": "3m_water_anomaly",
-        "title": "3-Month Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_seasonal_3month"
+        "id": "spi_3m",
+        "title": "SPI - 3-month",
+        "server_layer_name": "r3s_dekad"
       },
       {
-        "id": "4m_water_anomaly",
-        "title": "4-Month Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_seasonal_4month"
+        "id": "spi_6m",
+        "title": "SPI - 6-month",
+        "server_layer_name": "r6s_dekad"
       },
       {
-        "id": "5m_water_anomaly",
-        "title": "5-Month Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_seasonal_5month"
+        "id": "spi_9m",
+        "title": "SPI - 9-month",
+        "server_layer_name": "r9s_dekad"
       },
       {
-        "id": "6m_water_anomaly",
-        "title": "6-Month Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_seasonal_6month"
+        "id": "spi_1y",
+        "title": "SPI - 1-year",
+        "server_layer_name": "rys_dekad"
       },
       {
-        "id": "daily_rainfall_forecast",
-        "title": "Rolling daily rainfall forecast",
-        "server_layer_name": "rfh_daily_forecast"
+        "id": "rainfall_dekad",
+        "title": "10-day rainfall estimate (mm)",
+        "server_layer_name": "rfh_dekad"
       },
       {
-        "id": "days_dry",
-        "title": "Days since last rain",
-        "server_layer_name": "dlc_dekad"
-      },
-      {
-        "id": "days_extreme_rain",
-        "title": "Number of days with extreme rainfall in the last 30 days",
-        "server_layer_name": "xne_dekad"
-      },
-      {
-        "id": "days_heavy_rain",
-        "title": "Number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xnh_dekad"
-      },
-      {
-        "id": "days_intense_rain",
-        "title": "Number of days with intense rainfall in the last 30 days",
-        "server_layer_name": "xni_dekad"
-      },
-      {
-        "id": "dekad_rainfall_anomaly_forecast",
-        "title": "10-day rainfall forecast anomaly",
+        "id": "rain_anomaly_dekad",
+        "title": "10-day rainfall anomaly",
         "server_layer_name": "rfq_dekad"
-      },
-      {
-        "id": "dekad_rainfall_forecast",
-        "title": "10-day rainfall forecast",
-        "server_layer_name": "rfh_dekad_forecast"
-      },
-      {
-        "id": "lst_amplitude",
-        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
-        "server_layer_name": "myd11a2_taa_dekad"
-      },
-      {
-        "id": "lst_anomaly",
-        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_day_anomaly",
-        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_daytime",
-        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "lst_nighttime",
-        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "monthly_water_anomaly",
-        "title": "Monthly Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_dekad"
-      },
-      {
-        "id": "ndvi_dekad",
-        "title": "10-day NDVI (MODIS)",
-        "server_layer_name": "mxd13a2_vim_dekad"
-      },
-      {
-        "id": "ndvi_dekad_anomaly",
-        "title": "10-day NDVI anomaly (MODIS)",
-        "server_layer_name": "mxd13a2_viq_dekad"
       },
       {
         "id": "rain_anomaly_1month",
@@ -4988,29 +4923,9 @@
         "server_layer_name": "r1q_dekad"
       },
       {
-        "id": "rain_anomaly_1year",
-        "title": "1-year rainfall anomaly",
-        "server_layer_name": "ryq_dekad"
-      },
-      {
-        "id": "rain_anomaly_2month",
-        "title": "2-month rainfall anomaly",
-        "server_layer_name": "r2q_dekad"
-      },
-      {
         "id": "rain_anomaly_3month",
         "title": "3-month rainfall anomaly",
         "server_layer_name": "r3q_dekad"
-      },
-      {
-        "id": "rain_anomaly_4month",
-        "title": "4-month rainfall anomaly",
-        "server_layer_name": "r4q_dekad"
-      },
-      {
-        "id": "rain_anomaly_5month",
-        "title": "5-month rainfall anomaly",
-        "server_layer_name": "r5q_dekad"
       },
       {
         "id": "rain_anomaly_6month",
@@ -5018,24 +4933,14 @@
         "server_layer_name": "r6q_dekad"
       },
       {
-        "id": "rain_anomaly_7month",
-        "title": "7-month rainfall anomaly",
-        "server_layer_name": "r7q_dekad"
-      },
-      {
-        "id": "rain_anomaly_8month",
-        "title": "8-month rainfall anomaly",
-        "server_layer_name": "r8q_dekad"
-      },
-      {
         "id": "rain_anomaly_9month",
         "title": "9-month rainfall anomaly",
         "server_layer_name": "r9q_dekad"
       },
       {
-        "id": "rain_anomaly_dekad",
-        "title": "10-day rainfall anomaly",
-        "server_layer_name": "rfq_dekad"
+        "id": "rain_anomaly_1year",
+        "title": "1-year rainfall anomaly",
+        "server_layer_name": "ryq_dekad"
       },
       {
         "id": "rainfall_agg_1month",
@@ -5043,29 +4948,9 @@
         "server_layer_name": "r1h_dekad"
       },
       {
-        "id": "rainfall_agg_1year",
-        "title": "1-year rainfall aggregate (mm)",
-        "server_layer_name": "ryh_dekad"
-      },
-      {
-        "id": "rainfall_agg_2month",
-        "title": "2-month rainfall aggregate (mm)",
-        "server_layer_name": "r2h_dekad"
-      },
-      {
         "id": "rainfall_agg_3month",
         "title": "3-month rainfall aggregate (mm)",
         "server_layer_name": "r3h_dekad"
-      },
-      {
-        "id": "rainfall_agg_4month",
-        "title": "4-month rainfall aggregate (mm)",
-        "server_layer_name": "r4h_dekad"
-      },
-      {
-        "id": "rainfall_agg_5month",
-        "title": "5-month rainfall aggregate (mm)",
-        "server_layer_name": "r5h_dekad"
       },
       {
         "id": "rainfall_agg_6month",
@@ -5073,54 +4958,19 @@
         "server_layer_name": "r6h_dekad"
       },
       {
-        "id": "rainfall_agg_7month",
-        "title": "7-month rainfall aggregate (mm)",
-        "server_layer_name": "r7h_dekad"
-      },
-      {
-        "id": "rainfall_agg_8month",
-        "title": "8-month rainfall aggregate (mm)",
-        "server_layer_name": "r8h_dekad"
-      },
-      {
         "id": "rainfall_agg_9month",
         "title": "9-month rainfall aggregate (mm)",
         "server_layer_name": "r9h_dekad"
       },
       {
-        "id": "rainfall_dekad",
-        "title": "10-day rainfall estimate (mm)",
-        "server_layer_name": "rfh_dekad"
+        "id": "rainfall_agg_1year",
+        "title": "1-year rainfall aggregate (mm)",
+        "server_layer_name": "ryh_dekad"
       },
       {
-        "id": "spi_1m",
-        "title": "SPI - 1-month",
-        "server_layer_name": "r1s_dekad"
-      },
-      {
-        "id": "spi_1y",
-        "title": "SPI - 1-year",
-        "server_layer_name": "rys_dekad"
-      },
-      {
-        "id": "spi_2m",
-        "title": "SPI - 2-month",
-        "server_layer_name": "r2s_dekad"
-      },
-      {
-        "id": "spi_3m",
-        "title": "SPI - 3-month",
-        "server_layer_name": "r3s_dekad"
-      },
-      {
-        "id": "spi_6m",
-        "title": "SPI - 6-month",
-        "server_layer_name": "r6s_dekad"
-      },
-      {
-        "id": "spi_9m",
-        "title": "SPI - 9-month",
-        "server_layer_name": "r9s_dekad"
+        "id": "days_dry",
+        "title": "Days since last rain",
+        "server_layer_name": "dlc_dekad"
       },
       {
         "id": "streak_dry_days",
@@ -5128,9 +4978,19 @@
         "server_layer_name": "dlx_dekad"
       },
       {
-        "id": "streak_extreme_rain",
-        "title": "Longest consecutive extreme rainfall days",
-        "server_layer_name": "xle_dekad"
+        "id": "days_heavy_rain",
+        "title": "Number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xnh_dekad"
+      },
+      {
+        "id": "days_intense_rain",
+        "title": "Number of days with intense rainfall in the last 30 days",
+        "server_layer_name": "xni_dekad"
+      },
+      {
+        "id": "days_extreme_rain",
+        "title": "Number of days with extreme rainfall in the last 30 days",
+        "server_layer_name": "xne_dekad"
       },
       {
         "id": "streak_heavy_rain",
@@ -5141,158 +5001,153 @@
         "id": "streak_intense_rain",
         "title": "Longest consecutive intense rainfall days",
         "server_layer_name": "xli_dekad"
+      },
+      {
+        "id": "streak_extreme_rain",
+        "title": "Longest consecutive extreme rainfall days",
+        "server_layer_name": "xle_dekad"
+      },
+      {
+        "id": "ndvi_dekad",
+        "title": "10-day NDVI (MODIS)",
+        "server_layer_name": "mxd13a2_vim_dekad"
+      },
+      {
+        "id": "ndvi_dekad_anomaly",
+        "title": "10-day NDVI anomaly (MODIS)",
+        "server_layer_name": "mxd13a2_viq_dekad"
+      },
+      {
+        "id": "lst_amplitude",
+        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
+        "server_layer_name": "myd11a2_taa_dekad"
+      },
+      {
+        "id": "lst_daytime",
+        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "daily_rainfall_forecast",
+        "title": "Rolling daily rainfall forecast",
+        "server_layer_name": "rfh_daily_forecast"
+      },
+      {
+        "id": "dekad_rainfall_forecast",
+        "title": "10-day rainfall forecast",
+        "server_layer_name": "rfh_dekad_forecast"
+      },
+      {
+        "id": "dekad_rainfall_anomaly_forecast",
+        "title": "10-day rainfall forecast anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rainfall_agg_2month",
+        "title": "2-month rainfall aggregate (mm)",
+        "server_layer_name": "r2h_dekad"
+      },
+      {
+        "id": "rain_anomaly_2month",
+        "title": "2-month rainfall anomaly",
+        "server_layer_name": "r2q_dekad"
+      },
+      {
+        "id": "rainfall_agg_4month",
+        "title": "4-month rainfall aggregate (mm)",
+        "server_layer_name": "r4h_dekad"
+      },
+      {
+        "id": "rain_anomaly_4month",
+        "title": "4-month rainfall anomaly",
+        "server_layer_name": "r4q_dekad"
+      },
+      {
+        "id": "rainfall_agg_5month",
+        "title": "5-month rainfall aggregate (mm)",
+        "server_layer_name": "r5h_dekad"
+      },
+      {
+        "id": "rain_anomaly_5month",
+        "title": "5-month rainfall anomaly",
+        "server_layer_name": "r5q_dekad"
+      },
+      {
+        "id": "rainfall_agg_7month",
+        "title": "7-month rainfall aggregate (mm)",
+        "server_layer_name": "r7h_dekad"
+      },
+      {
+        "id": "rain_anomaly_7month",
+        "title": "7-month rainfall anomaly",
+        "server_layer_name": "r7q_dekad"
+      },
+      {
+        "id": "rainfall_agg_8month",
+        "title": "8-month rainfall aggregate (mm)",
+        "server_layer_name": "r8h_dekad"
+      },
+      {
+        "id": "rain_anomaly_8month",
+        "title": "8-month rainfall anomaly",
+        "server_layer_name": "r8q_dekad"
+      },
+      {
+        "id": "spi_2m",
+        "title": "SPI - 2-month",
+        "server_layer_name": "r2s_dekad"
+      },
+      {
+        "id": "lst_nighttime",
+        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_day_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "monthly_water_anomaly",
+        "title": "Monthly Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_dekad"
+      },
+      {
+        "id": "2m_water_anomaly",
+        "title": "2-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_2month"
+      },
+      {
+        "id": "3m_water_anomaly",
+        "title": "3-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_3month"
+      },
+      {
+        "id": "4m_water_anomaly",
+        "title": "4-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_4month"
+      },
+      {
+        "id": "5m_water_anomaly",
+        "title": "5-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_5month"
+      },
+      {
+        "id": "6m_water_anomaly",
+        "title": "6-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_6month"
       }
     ],
     "rbd": [
       {
-        "id": "2m_water_anomaly",
-        "title": "2-Month Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_seasonal_2month"
-      },
-      {
-        "id": "3m_water_anomaly",
-        "title": "3-Month Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_seasonal_3month"
-      },
-      {
-        "id": "4m_water_anomaly",
-        "title": "4-Month Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_seasonal_4month"
-      },
-      {
-        "id": "5m_water_anomaly",
-        "title": "5-Month Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_seasonal_5month"
-      },
-      {
-        "id": "6m_water_anomaly",
-        "title": "6-Month Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_seasonal_6month"
-      },
-      {
-        "id": "daily_rainfall_forecast",
-        "title": "Rolling daily rainfall forecast",
-        "server_layer_name": "rfh_daily_forecast"
-      },
-      {
-        "id": "days_dry",
-        "title": "Days since last rain",
-        "server_layer_name": "dlc_dekad"
-      },
-      {
-        "id": "days_extreme_rain",
-        "title": "Number of days with extreme rainfall in the last 30 days",
-        "server_layer_name": "xne_dekad"
-      },
-      {
-        "id": "days_heavy_rain",
-        "title": "Number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xnh_dekad"
-      },
-      {
-        "id": "days_intense_rain",
-        "title": "Number of days with intense rainfall in the last 30 days",
-        "server_layer_name": "xni_dekad"
-      },
-      {
-        "id": "dekad_rainfall_anomaly_forecast",
-        "title": "10-day rainfall forecast anomaly",
-        "server_layer_name": "rfq_dekad"
-      },
-      {
-        "id": "dekad_rainfall_forecast",
-        "title": "10-day rainfall forecast",
-        "server_layer_name": "rfh_dekad_forecast"
-      },
-      {
-        "id": "lst_amplitude",
-        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
-        "server_layer_name": "myd11a2_taa_dekad"
-      },
-      {
-        "id": "lst_anomaly",
-        "title": "Daytime Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_day_anomaly",
-        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_daytime",
-        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "lst_nighttime",
-        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "monthly_water_anomaly",
-        "title": "Monthly Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_dekad"
-      },
-      {
-        "id": "ndvi_dekad",
-        "title": "10-day NDVI (MODIS)",
-        "server_layer_name": "mxd13a2_vim_dekad"
-      },
-      {
-        "id": "ndvi_dekad_anomaly",
-        "title": "10-day NDVI anomaly (MODIS)",
-        "server_layer_name": "mxd13a2_viq_dekad"
-      },
-      {
-        "id": "rain_anomaly_1month",
-        "title": "1-month rainfall anomaly",
-        "server_layer_name": "r1q_dekad"
-      },
-      {
-        "id": "rain_anomaly_1year",
-        "title": "1-year rainfall anomaly",
-        "server_layer_name": "ryq_dekad"
-      },
-      {
-        "id": "rain_anomaly_2month",
-        "title": "2-month rainfall anomaly",
-        "server_layer_name": "r2q_dekad"
-      },
-      {
-        "id": "rain_anomaly_3month",
-        "title": "3-month rainfall anomaly",
-        "server_layer_name": "r3q_dekad"
-      },
-      {
-        "id": "rain_anomaly_4month",
-        "title": "4-month rainfall anomaly",
-        "server_layer_name": "r4q_dekad"
-      },
-      {
-        "id": "rain_anomaly_5month",
-        "title": "5-month rainfall anomaly",
-        "server_layer_name": "r5q_dekad"
-      },
-      {
-        "id": "rain_anomaly_6month",
-        "title": "6-month rainfall anomaly",
-        "server_layer_name": "r6q_dekad"
-      },
-      {
-        "id": "rain_anomaly_7month",
-        "title": "7-month rainfall anomaly",
-        "server_layer_name": "r7q_dekad"
-      },
-      {
-        "id": "rain_anomaly_8month",
-        "title": "8-month rainfall anomaly",
-        "server_layer_name": "r8q_dekad"
-      },
-      {
-        "id": "rain_anomaly_9month",
-        "title": "9-month rainfall anomaly",
-        "server_layer_name": "r9q_dekad"
+        "id": "rainfall_dekad",
+        "title": "10-day rainfall estimate (mm)",
+        "server_layer_name": "rfh_dekad"
       },
       {
         "id": "rain_anomaly_dekad",
@@ -5305,14 +5160,9 @@
         "server_layer_name": "r1h_dekad"
       },
       {
-        "id": "rainfall_agg_1year",
-        "title": "1-year rainfall aggregate (mm)",
-        "server_layer_name": "ryh_dekad"
-      },
-      {
-        "id": "rainfall_agg_2month",
-        "title": "2-month rainfall aggregate (mm)",
-        "server_layer_name": "r2h_dekad"
+        "id": "rain_anomaly_1month",
+        "title": "1-month rainfall anomaly",
+        "server_layer_name": "r1q_dekad"
       },
       {
         "id": "rainfall_agg_3month",
@@ -5320,14 +5170,9 @@
         "server_layer_name": "r3h_dekad"
       },
       {
-        "id": "rainfall_agg_4month",
-        "title": "4-month rainfall aggregate (mm)",
-        "server_layer_name": "r4h_dekad"
-      },
-      {
-        "id": "rainfall_agg_5month",
-        "title": "5-month rainfall aggregate (mm)",
-        "server_layer_name": "r5h_dekad"
+        "id": "rain_anomaly_3month",
+        "title": "3-month rainfall anomaly",
+        "server_layer_name": "r3q_dekad"
       },
       {
         "id": "rainfall_agg_6month",
@@ -5335,14 +5180,9 @@
         "server_layer_name": "r6h_dekad"
       },
       {
-        "id": "rainfall_agg_7month",
-        "title": "7-month rainfall aggregate (mm)",
-        "server_layer_name": "r7h_dekad"
-      },
-      {
-        "id": "rainfall_agg_8month",
-        "title": "8-month rainfall aggregate (mm)",
-        "server_layer_name": "r8h_dekad"
+        "id": "rain_anomaly_6month",
+        "title": "6-month rainfall anomaly",
+        "server_layer_name": "r6q_dekad"
       },
       {
         "id": "rainfall_agg_9month",
@@ -5350,24 +5190,24 @@
         "server_layer_name": "r9h_dekad"
       },
       {
-        "id": "rainfall_dekad",
-        "title": "10-day rainfall estimate (mm)",
-        "server_layer_name": "rfh_dekad"
+        "id": "rain_anomaly_9month",
+        "title": "9-month rainfall anomaly",
+        "server_layer_name": "r9q_dekad"
+      },
+      {
+        "id": "rainfall_agg_1year",
+        "title": "1-year rainfall aggregate (mm)",
+        "server_layer_name": "ryh_dekad"
+      },
+      {
+        "id": "rain_anomaly_1year",
+        "title": "1-year rainfall anomaly",
+        "server_layer_name": "ryq_dekad"
       },
       {
         "id": "spi_1m",
         "title": "SPI - 1-month",
         "server_layer_name": "r1s_dekad"
-      },
-      {
-        "id": "spi_1y",
-        "title": "SPI - 1-year",
-        "server_layer_name": "rys_dekad"
-      },
-      {
-        "id": "spi_2m",
-        "title": "SPI - 2-month",
-        "server_layer_name": "r2s_dekad"
       },
       {
         "id": "spi_3m",
@@ -5385,14 +5225,34 @@
         "server_layer_name": "r9s_dekad"
       },
       {
+        "id": "spi_1y",
+        "title": "SPI - 1-year",
+        "server_layer_name": "rys_dekad"
+      },
+      {
+        "id": "days_dry",
+        "title": "Days since last rain",
+        "server_layer_name": "dlc_dekad"
+      },
+      {
         "id": "streak_dry_days",
         "title": "Longest number of consecutive dry days",
         "server_layer_name": "dlx_dekad"
       },
       {
-        "id": "streak_extreme_rain",
-        "title": "Longest consecutive extreme rainfall days",
-        "server_layer_name": "xle_dekad"
+        "id": "days_heavy_rain",
+        "title": "Number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xnh_dekad"
+      },
+      {
+        "id": "days_intense_rain",
+        "title": "Number of days with intense rainfall in the last 30 days",
+        "server_layer_name": "xni_dekad"
+      },
+      {
+        "id": "days_extreme_rain",
+        "title": "Number of days with extreme rainfall in the last 30 days",
+        "server_layer_name": "xne_dekad"
       },
       {
         "id": "streak_heavy_rain",
@@ -5403,9 +5263,122 @@
         "id": "streak_intense_rain",
         "title": "Longest consecutive intense rainfall days",
         "server_layer_name": "xli_dekad"
-      }
-    ],
-    "sierraleone": [
+      },
+      {
+        "id": "streak_extreme_rain",
+        "title": "Longest consecutive extreme rainfall days",
+        "server_layer_name": "xle_dekad"
+      },
+      {
+        "id": "ndvi_dekad",
+        "title": "10-day NDVI (MODIS)",
+        "server_layer_name": "mxd13a2_vim_dekad"
+      },
+      {
+        "id": "ndvi_dekad_anomaly",
+        "title": "10-day NDVI anomaly (MODIS)",
+        "server_layer_name": "mxd13a2_viq_dekad"
+      },
+      {
+        "id": "lst_amplitude",
+        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
+        "server_layer_name": "myd11a2_taa_dekad"
+      },
+      {
+        "id": "lst_daytime",
+        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_nighttime",
+        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_anomaly",
+        "title": "Daytime Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "daily_rainfall_forecast",
+        "title": "Rolling daily rainfall forecast",
+        "server_layer_name": "rfh_daily_forecast"
+      },
+      {
+        "id": "dekad_rainfall_forecast",
+        "title": "10-day rainfall forecast",
+        "server_layer_name": "rfh_dekad_forecast"
+      },
+      {
+        "id": "dekad_rainfall_anomaly_forecast",
+        "title": "10-day rainfall forecast anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rainfall_agg_2month",
+        "title": "2-month rainfall aggregate (mm)",
+        "server_layer_name": "r2h_dekad"
+      },
+      {
+        "id": "rain_anomaly_2month",
+        "title": "2-month rainfall anomaly",
+        "server_layer_name": "r2q_dekad"
+      },
+      {
+        "id": "rainfall_agg_4month",
+        "title": "4-month rainfall aggregate (mm)",
+        "server_layer_name": "r4h_dekad"
+      },
+      {
+        "id": "rain_anomaly_4month",
+        "title": "4-month rainfall anomaly",
+        "server_layer_name": "r4q_dekad"
+      },
+      {
+        "id": "rainfall_agg_5month",
+        "title": "5-month rainfall aggregate (mm)",
+        "server_layer_name": "r5h_dekad"
+      },
+      {
+        "id": "rain_anomaly_5month",
+        "title": "5-month rainfall anomaly",
+        "server_layer_name": "r5q_dekad"
+      },
+      {
+        "id": "rainfall_agg_7month",
+        "title": "7-month rainfall aggregate (mm)",
+        "server_layer_name": "r7h_dekad"
+      },
+      {
+        "id": "rain_anomaly_7month",
+        "title": "7-month rainfall anomaly",
+        "server_layer_name": "r7q_dekad"
+      },
+      {
+        "id": "rainfall_agg_8month",
+        "title": "8-month rainfall aggregate (mm)",
+        "server_layer_name": "r8h_dekad"
+      },
+      {
+        "id": "rain_anomaly_8month",
+        "title": "8-month rainfall anomaly",
+        "server_layer_name": "r8q_dekad"
+      },
+      {
+        "id": "spi_2m",
+        "title": "SPI - 2-month",
+        "server_layer_name": "r2s_dekad"
+      },
+      {
+        "id": "lst_day_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "monthly_water_anomaly",
+        "title": "Monthly Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_dekad"
+      },
       {
         "id": "2m_water_anomaly",
         "title": "2-Month Water Anomaly Index (WAI)",
@@ -5430,131 +5403,13 @@
         "id": "6m_water_anomaly",
         "title": "6-Month Water Anomaly Index (WAI)",
         "server_layer_name": "wai_seasonal_6month"
-      },
+      }
+    ],
+    "sierraleone": [
       {
-        "id": "daily_rainfall_forecast",
-        "title": "Rolling daily rainfall forecast",
-        "server_layer_name": "rfh_daily_forecast"
-      },
-      {
-        "id": "days_dry",
-        "title": "Days since last rain",
-        "server_layer_name": "dlc_dekad"
-      },
-      {
-        "id": "days_extreme_rain",
-        "title": "Number of days with extreme rainfall in the last 30 days",
-        "server_layer_name": "xne_dekad"
-      },
-      {
-        "id": "days_heavy_rain",
-        "title": "Number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xnh_dekad"
-      },
-      {
-        "id": "days_intense_rain",
-        "title": "Number of days with intense rainfall in the last 30 days",
-        "server_layer_name": "xni_dekad"
-      },
-      {
-        "id": "dekad_rainfall_anomaly_forecast",
-        "title": "10-day rainfall forecast anomaly",
-        "server_layer_name": "rfq_dekad"
-      },
-      {
-        "id": "dekad_rainfall_forecast",
-        "title": "10-day rainfall forecast",
-        "server_layer_name": "rfh_dekad_forecast"
-      },
-      {
-        "id": "lst_amplitude",
-        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
-        "server_layer_name": "myd11a2_taa_dekad"
-      },
-      {
-        "id": "lst_anomaly",
-        "title": "Daytime Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_day_anomaly",
-        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_daytime",
-        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "lst_nighttime",
-        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "monthly_water_anomaly",
-        "title": "Monthly Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_dekad"
-      },
-      {
-        "id": "ndvi_dekad",
-        "title": "10-day NDVI (MODIS)",
-        "server_layer_name": "mxd13a2_vim_dekad"
-      },
-      {
-        "id": "ndvi_dekad_anomaly",
-        "title": "10-day NDVI anomaly (MODIS)",
-        "server_layer_name": "mxd13a2_viq_dekad"
-      },
-      {
-        "id": "rain_anomaly_1month",
-        "title": "1-month rainfall anomaly",
-        "server_layer_name": "r1q_dekad"
-      },
-      {
-        "id": "rain_anomaly_1year",
-        "title": "1-year rainfall anomaly",
-        "server_layer_name": "ryq_dekad"
-      },
-      {
-        "id": "rain_anomaly_2month",
-        "title": "2-month rainfall anomaly",
-        "server_layer_name": "r2q_dekad"
-      },
-      {
-        "id": "rain_anomaly_3month",
-        "title": "3-month rainfall anomaly",
-        "server_layer_name": "r3q_dekad"
-      },
-      {
-        "id": "rain_anomaly_4month",
-        "title": "4-month rainfall anomaly",
-        "server_layer_name": "r4q_dekad"
-      },
-      {
-        "id": "rain_anomaly_5month",
-        "title": "5-month rainfall anomaly",
-        "server_layer_name": "r5q_dekad"
-      },
-      {
-        "id": "rain_anomaly_6month",
-        "title": "6-month rainfall anomaly",
-        "server_layer_name": "r6q_dekad"
-      },
-      {
-        "id": "rain_anomaly_7month",
-        "title": "7-month rainfall anomaly",
-        "server_layer_name": "r7q_dekad"
-      },
-      {
-        "id": "rain_anomaly_8month",
-        "title": "8-month rainfall anomaly",
-        "server_layer_name": "r8q_dekad"
-      },
-      {
-        "id": "rain_anomaly_9month",
-        "title": "9-month rainfall anomaly",
-        "server_layer_name": "r9q_dekad"
+        "id": "rainfall_dekad",
+        "title": "10-day rainfall estimate (mm)",
+        "server_layer_name": "rfh_dekad"
       },
       {
         "id": "rain_anomaly_dekad",
@@ -5562,19 +5417,34 @@
         "server_layer_name": "rfq_dekad"
       },
       {
+        "id": "rain_anomaly_1month",
+        "title": "1-month rainfall anomaly",
+        "server_layer_name": "r1q_dekad"
+      },
+      {
+        "id": "rain_anomaly_3month",
+        "title": "3-month rainfall anomaly",
+        "server_layer_name": "r3q_dekad"
+      },
+      {
+        "id": "rain_anomaly_6month",
+        "title": "6-month rainfall anomaly",
+        "server_layer_name": "r6q_dekad"
+      },
+      {
+        "id": "rain_anomaly_9month",
+        "title": "9-month rainfall anomaly",
+        "server_layer_name": "r9q_dekad"
+      },
+      {
+        "id": "rain_anomaly_1year",
+        "title": "1-year rainfall anomaly",
+        "server_layer_name": "ryq_dekad"
+      },
+      {
         "id": "rainfall_agg_1month",
         "title": "1-month rainfall aggregate (mm)",
         "server_layer_name": "r1h_dekad"
-      },
-      {
-        "id": "rainfall_agg_1year",
-        "title": "1-year rainfall aggregate (mm)",
-        "server_layer_name": "ryh_dekad"
-      },
-      {
-        "id": "rainfall_agg_2month",
-        "title": "2-month rainfall aggregate (mm)",
-        "server_layer_name": "r2h_dekad"
       },
       {
         "id": "rainfall_agg_3month",
@@ -5582,29 +5452,9 @@
         "server_layer_name": "r3h_dekad"
       },
       {
-        "id": "rainfall_agg_4month",
-        "title": "4-month rainfall aggregate (mm)",
-        "server_layer_name": "r4h_dekad"
-      },
-      {
-        "id": "rainfall_agg_5month",
-        "title": "5-month rainfall aggregate (mm)",
-        "server_layer_name": "r5h_dekad"
-      },
-      {
         "id": "rainfall_agg_6month",
         "title": "6-month rainfall aggregate (mm)",
         "server_layer_name": "r6h_dekad"
-      },
-      {
-        "id": "rainfall_agg_7month",
-        "title": "7-month rainfall aggregate (mm)",
-        "server_layer_name": "r7h_dekad"
-      },
-      {
-        "id": "rainfall_agg_8month",
-        "title": "8-month rainfall aggregate (mm)",
-        "server_layer_name": "r8h_dekad"
       },
       {
         "id": "rainfall_agg_9month",
@@ -5612,24 +5462,14 @@
         "server_layer_name": "r9h_dekad"
       },
       {
-        "id": "rainfall_dekad",
-        "title": "10-day rainfall estimate (mm)",
-        "server_layer_name": "rfh_dekad"
+        "id": "rainfall_agg_1year",
+        "title": "1-year rainfall aggregate (mm)",
+        "server_layer_name": "ryh_dekad"
       },
       {
         "id": "spi_1m",
         "title": "SPI - 1-month",
         "server_layer_name": "r1s_dekad"
-      },
-      {
-        "id": "spi_1y",
-        "title": "SPI - 1-year",
-        "server_layer_name": "rys_dekad"
-      },
-      {
-        "id": "spi_2m",
-        "title": "SPI - 2-month",
-        "server_layer_name": "r2s_dekad"
       },
       {
         "id": "spi_3m",
@@ -5645,6 +5485,16 @@
         "id": "spi_9m",
         "title": "SPI - 9-month",
         "server_layer_name": "r9s_dekad"
+      },
+      {
+        "id": "spi_1y",
+        "title": "SPI - 1-year",
+        "server_layer_name": "rys_dekad"
+      },
+      {
+        "id": "days_dry",
+        "title": "Days since last rain",
+        "server_layer_name": "dlc_dekad"
       },
       {
         "id": "streak_dry_days",
@@ -5652,9 +5502,19 @@
         "server_layer_name": "dlx_dekad"
       },
       {
-        "id": "streak_extreme_rain",
-        "title": "Longest consecutive extreme rainfall days",
-        "server_layer_name": "xle_dekad"
+        "id": "days_heavy_rain",
+        "title": "Number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xnh_dekad"
+      },
+      {
+        "id": "days_intense_rain",
+        "title": "Number of days with intense rainfall in the last 30 days",
+        "server_layer_name": "xni_dekad"
+      },
+      {
+        "id": "days_extreme_rain",
+        "title": "Number of days with extreme rainfall in the last 30 days",
+        "server_layer_name": "xne_dekad"
       },
       {
         "id": "streak_heavy_rain",
@@ -5665,9 +5525,122 @@
         "id": "streak_intense_rain",
         "title": "Longest consecutive intense rainfall days",
         "server_layer_name": "xli_dekad"
-      }
-    ],
-    "somalia": [
+      },
+      {
+        "id": "streak_extreme_rain",
+        "title": "Longest consecutive extreme rainfall days",
+        "server_layer_name": "xle_dekad"
+      },
+      {
+        "id": "ndvi_dekad",
+        "title": "10-day NDVI (MODIS)",
+        "server_layer_name": "mxd13a2_vim_dekad"
+      },
+      {
+        "id": "ndvi_dekad_anomaly",
+        "title": "10-day NDVI anomaly (MODIS)",
+        "server_layer_name": "mxd13a2_viq_dekad"
+      },
+      {
+        "id": "lst_amplitude",
+        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
+        "server_layer_name": "myd11a2_taa_dekad"
+      },
+      {
+        "id": "lst_daytime",
+        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_nighttime",
+        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_anomaly",
+        "title": "Daytime Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "daily_rainfall_forecast",
+        "title": "Rolling daily rainfall forecast",
+        "server_layer_name": "rfh_daily_forecast"
+      },
+      {
+        "id": "dekad_rainfall_forecast",
+        "title": "10-day rainfall forecast",
+        "server_layer_name": "rfh_dekad_forecast"
+      },
+      {
+        "id": "dekad_rainfall_anomaly_forecast",
+        "title": "10-day rainfall forecast anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rainfall_agg_2month",
+        "title": "2-month rainfall aggregate (mm)",
+        "server_layer_name": "r2h_dekad"
+      },
+      {
+        "id": "rain_anomaly_2month",
+        "title": "2-month rainfall anomaly",
+        "server_layer_name": "r2q_dekad"
+      },
+      {
+        "id": "rainfall_agg_4month",
+        "title": "4-month rainfall aggregate (mm)",
+        "server_layer_name": "r4h_dekad"
+      },
+      {
+        "id": "rain_anomaly_4month",
+        "title": "4-month rainfall anomaly",
+        "server_layer_name": "r4q_dekad"
+      },
+      {
+        "id": "rainfall_agg_5month",
+        "title": "5-month rainfall aggregate (mm)",
+        "server_layer_name": "r5h_dekad"
+      },
+      {
+        "id": "rain_anomaly_5month",
+        "title": "5-month rainfall anomaly",
+        "server_layer_name": "r5q_dekad"
+      },
+      {
+        "id": "rainfall_agg_7month",
+        "title": "7-month rainfall aggregate (mm)",
+        "server_layer_name": "r7h_dekad"
+      },
+      {
+        "id": "rain_anomaly_7month",
+        "title": "7-month rainfall anomaly",
+        "server_layer_name": "r7q_dekad"
+      },
+      {
+        "id": "rainfall_agg_8month",
+        "title": "8-month rainfall aggregate (mm)",
+        "server_layer_name": "r8h_dekad"
+      },
+      {
+        "id": "rain_anomaly_8month",
+        "title": "8-month rainfall anomaly",
+        "server_layer_name": "r8q_dekad"
+      },
+      {
+        "id": "spi_2m",
+        "title": "SPI - 2-month",
+        "server_layer_name": "r2s_dekad"
+      },
+      {
+        "id": "lst_day_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "monthly_water_anomaly",
+        "title": "Monthly Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_dekad"
+      },
       {
         "id": "2m_water_anomaly",
         "title": "2-Month Water Anomaly Index (WAI)",
@@ -5692,131 +5665,13 @@
         "id": "6m_water_anomaly",
         "title": "6-Month Water Anomaly Index (WAI)",
         "server_layer_name": "wai_seasonal_6month"
-      },
+      }
+    ],
+    "somalia": [
       {
-        "id": "daily_rainfall_forecast",
-        "title": "Rolling daily rainfall forecast",
-        "server_layer_name": "rfh_daily_forecast"
-      },
-      {
-        "id": "days_dry",
-        "title": "Days since last rain",
-        "server_layer_name": "dlc_dekad"
-      },
-      {
-        "id": "days_extreme_rain",
-        "title": "Number of days with extreme rainfall in the last 30 days",
-        "server_layer_name": "xne_dekad"
-      },
-      {
-        "id": "days_heavy_rain",
-        "title": "Number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xnh_dekad"
-      },
-      {
-        "id": "days_intense_rain",
-        "title": "Number of days with intense rainfall in the last 30 days",
-        "server_layer_name": "xni_dekad"
-      },
-      {
-        "id": "dekad_rainfall_anomaly_forecast",
-        "title": "10-day rainfall forecast anomaly",
-        "server_layer_name": "rfq_dekad"
-      },
-      {
-        "id": "dekad_rainfall_forecast",
-        "title": "10-day rainfall forecast",
-        "server_layer_name": "rfh_dekad_forecast"
-      },
-      {
-        "id": "lst_amplitude",
-        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
-        "server_layer_name": "myd11a2_taa_dekad"
-      },
-      {
-        "id": "lst_anomaly",
-        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_day_anomaly",
-        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_daytime",
-        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "lst_nighttime",
-        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "monthly_water_anomaly",
-        "title": "Monthly Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_dekad"
-      },
-      {
-        "id": "ndvi_dekad",
-        "title": "10-day NDVI (MODIS)",
-        "server_layer_name": "mxd13a2_vim_dekad"
-      },
-      {
-        "id": "ndvi_dekad_anomaly",
-        "title": "10-day NDVI anomaly (MODIS)",
-        "server_layer_name": "mxd13a2_viq_dekad"
-      },
-      {
-        "id": "rain_anomaly_1month",
-        "title": "Monthly rainfall anomaly",
-        "server_layer_name": "r1q_dekad"
-      },
-      {
-        "id": "rain_anomaly_1year",
-        "title": "1-year rainfall anomaly",
-        "server_layer_name": "ryq_dekad"
-      },
-      {
-        "id": "rain_anomaly_2month",
-        "title": "2-month rainfall anomaly",
-        "server_layer_name": "r2q_dekad"
-      },
-      {
-        "id": "rain_anomaly_3month",
-        "title": "3-month rainfall anomaly",
-        "server_layer_name": "r3q_dekad"
-      },
-      {
-        "id": "rain_anomaly_4month",
-        "title": "4-month rainfall anomaly",
-        "server_layer_name": "r4q_dekad"
-      },
-      {
-        "id": "rain_anomaly_5month",
-        "title": "5-month rainfall anomaly",
-        "server_layer_name": "r5q_dekad"
-      },
-      {
-        "id": "rain_anomaly_6month",
-        "title": "6-month rainfall anomaly",
-        "server_layer_name": "r6q_dekad"
-      },
-      {
-        "id": "rain_anomaly_7month",
-        "title": "7-month rainfall anomaly",
-        "server_layer_name": "r7q_dekad"
-      },
-      {
-        "id": "rain_anomaly_8month",
-        "title": "8-month rainfall anomaly",
-        "server_layer_name": "r8q_dekad"
-      },
-      {
-        "id": "rain_anomaly_9month",
-        "title": "9-month rainfall anomaly",
-        "server_layer_name": "r9q_dekad"
+        "id": "rainfall_dekad",
+        "title": "10-day rainfall estimate (mm)",
+        "server_layer_name": "rfh_dekad"
       },
       {
         "id": "rain_anomaly_dekad",
@@ -5829,14 +5684,9 @@
         "server_layer_name": "r1h_dekad"
       },
       {
-        "id": "rainfall_agg_1year",
-        "title": "1-year rainfall aggregate (mm)",
-        "server_layer_name": "ryh_dekad"
-      },
-      {
-        "id": "rainfall_agg_2month",
-        "title": "2-month rainfall aggregate (mm)",
-        "server_layer_name": "r2h_dekad"
+        "id": "rain_anomaly_1month",
+        "title": "Monthly rainfall anomaly",
+        "server_layer_name": "r1q_dekad"
       },
       {
         "id": "rainfall_agg_3month",
@@ -5844,9 +5694,54 @@
         "server_layer_name": "r3h_dekad"
       },
       {
+        "id": "rain_anomaly_3month",
+        "title": "3-month rainfall anomaly",
+        "server_layer_name": "r3q_dekad"
+      },
+      {
+        "id": "ndvi_dekad",
+        "title": "10-day NDVI (MODIS)",
+        "server_layer_name": "mxd13a2_vim_dekad"
+      },
+      {
+        "id": "ndvi_dekad_anomaly",
+        "title": "10-day NDVI anomaly (MODIS)",
+        "server_layer_name": "mxd13a2_viq_dekad"
+      },
+      {
+        "id": "daily_rainfall_forecast",
+        "title": "Rolling daily rainfall forecast",
+        "server_layer_name": "rfh_daily_forecast"
+      },
+      {
+        "id": "dekad_rainfall_forecast",
+        "title": "10-day rainfall forecast",
+        "server_layer_name": "rfh_dekad_forecast"
+      },
+      {
+        "id": "dekad_rainfall_anomaly_forecast",
+        "title": "10-day rainfall forecast anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rainfall_agg_2month",
+        "title": "2-month rainfall aggregate (mm)",
+        "server_layer_name": "r2h_dekad"
+      },
+      {
+        "id": "rain_anomaly_2month",
+        "title": "2-month rainfall anomaly",
+        "server_layer_name": "r2q_dekad"
+      },
+      {
         "id": "rainfall_agg_4month",
         "title": "4-month rainfall aggregate (mm)",
         "server_layer_name": "r4h_dekad"
+      },
+      {
+        "id": "rain_anomaly_4month",
+        "title": "4-month rainfall anomaly",
+        "server_layer_name": "r4q_dekad"
       },
       {
         "id": "rainfall_agg_5month",
@@ -5854,9 +5749,19 @@
         "server_layer_name": "r5h_dekad"
       },
       {
+        "id": "rain_anomaly_5month",
+        "title": "5-month rainfall anomaly",
+        "server_layer_name": "r5q_dekad"
+      },
+      {
         "id": "rainfall_agg_6month",
         "title": "6-month rainfall aggregate (mm)",
         "server_layer_name": "r6h_dekad"
+      },
+      {
+        "id": "rain_anomaly_6month",
+        "title": "6-month rainfall anomaly",
+        "server_layer_name": "r6q_dekad"
       },
       {
         "id": "rainfall_agg_7month",
@@ -5864,9 +5769,19 @@
         "server_layer_name": "r7h_dekad"
       },
       {
+        "id": "rain_anomaly_7month",
+        "title": "7-month rainfall anomaly",
+        "server_layer_name": "r7q_dekad"
+      },
+      {
         "id": "rainfall_agg_8month",
         "title": "8-month rainfall aggregate (mm)",
         "server_layer_name": "r8h_dekad"
+      },
+      {
+        "id": "rain_anomaly_8month",
+        "title": "8-month rainfall anomaly",
+        "server_layer_name": "r8q_dekad"
       },
       {
         "id": "rainfall_agg_9month",
@@ -5874,19 +5789,24 @@
         "server_layer_name": "r9h_dekad"
       },
       {
-        "id": "rainfall_dekad",
-        "title": "10-day rainfall estimate (mm)",
-        "server_layer_name": "rfh_dekad"
+        "id": "rain_anomaly_9month",
+        "title": "9-month rainfall anomaly",
+        "server_layer_name": "r9q_dekad"
+      },
+      {
+        "id": "rainfall_agg_1year",
+        "title": "1-year rainfall aggregate (mm)",
+        "server_layer_name": "ryh_dekad"
+      },
+      {
+        "id": "rain_anomaly_1year",
+        "title": "1-year rainfall anomaly",
+        "server_layer_name": "ryq_dekad"
       },
       {
         "id": "spi_1m",
         "title": "SPI - 1-month",
         "server_layer_name": "r1s_dekad"
-      },
-      {
-        "id": "spi_1y",
-        "title": "SPI - 1-year",
-        "server_layer_name": "rys_dekad"
       },
       {
         "id": "spi_2m",
@@ -5909,14 +5829,34 @@
         "server_layer_name": "r9s_dekad"
       },
       {
+        "id": "spi_1y",
+        "title": "SPI - 1-year",
+        "server_layer_name": "rys_dekad"
+      },
+      {
+        "id": "days_dry",
+        "title": "Days since last rain",
+        "server_layer_name": "dlc_dekad"
+      },
+      {
         "id": "streak_dry_days",
         "title": "Longest dry spell",
         "server_layer_name": "dlx_dekad"
       },
       {
-        "id": "streak_extreme_rain",
-        "title": "Longest consecutive extreme rainfall days",
-        "server_layer_name": "xle_dekad"
+        "id": "days_heavy_rain",
+        "title": "Number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xnh_dekad"
+      },
+      {
+        "id": "days_intense_rain",
+        "title": "Number of days with intense rainfall in the last 30 days",
+        "server_layer_name": "xni_dekad"
+      },
+      {
+        "id": "days_extreme_rain",
+        "title": "Number of days with extreme rainfall in the last 30 days",
+        "server_layer_name": "xne_dekad"
       },
       {
         "id": "streak_heavy_rain",
@@ -5927,9 +5867,42 @@
         "id": "streak_intense_rain",
         "title": "Longest consecutive intense rainfall days",
         "server_layer_name": "xli_dekad"
-      }
-    ],
-    "southsudan": [
+      },
+      {
+        "id": "streak_extreme_rain",
+        "title": "Longest consecutive extreme rainfall days",
+        "server_layer_name": "xle_dekad"
+      },
+      {
+        "id": "lst_amplitude",
+        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
+        "server_layer_name": "myd11a2_taa_dekad"
+      },
+      {
+        "id": "lst_daytime",
+        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_nighttime",
+        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_day_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "monthly_water_anomaly",
+        "title": "Monthly Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_dekad"
+      },
       {
         "id": "2m_water_anomaly",
         "title": "2-Month Water Anomaly Index (WAI)",
@@ -5954,131 +5927,13 @@
         "id": "6m_water_anomaly",
         "title": "6-Month Water Anomaly Index (WAI)",
         "server_layer_name": "wai_seasonal_6month"
-      },
+      }
+    ],
+    "southsudan": [
       {
-        "id": "daily_rainfall_forecast",
-        "title": "Rolling daily rainfall forecast",
-        "server_layer_name": "rfh_daily_forecast"
-      },
-      {
-        "id": "days_dry",
-        "title": "Days since last rain",
-        "server_layer_name": "dlc_dekad"
-      },
-      {
-        "id": "days_extreme_rain",
-        "title": "Number of days with extreme rainfall in the last 30 days",
-        "server_layer_name": "xne_dekad"
-      },
-      {
-        "id": "days_heavy_rain",
-        "title": "Number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xnh_dekad"
-      },
-      {
-        "id": "days_intense_rain",
-        "title": "Number of days with intense rainfall in the last 30 days",
-        "server_layer_name": "xni_dekad"
-      },
-      {
-        "id": "dekad_rainfall_anomaly_forecast",
-        "title": "10-day rainfall forecast anomaly",
-        "server_layer_name": "rfq_dekad"
-      },
-      {
-        "id": "dekad_rainfall_forecast",
-        "title": "10-day rainfall forecast",
-        "server_layer_name": "rfh_dekad_forecast"
-      },
-      {
-        "id": "lst_amplitude",
-        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
-        "server_layer_name": "myd11a2_taa_dekad"
-      },
-      {
-        "id": "lst_anomaly",
-        "title": "Daytime Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_day_anomaly",
-        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_daytime",
-        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "lst_nighttime",
-        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "monthly_water_anomaly",
-        "title": "Monthly Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_dekad"
-      },
-      {
-        "id": "ndvi_dekad",
-        "title": "10-day NDVI (MODIS)",
-        "server_layer_name": "mxd13a2_vim_dekad"
-      },
-      {
-        "id": "ndvi_dekad_anomaly",
-        "title": "10-day NDVI anomaly (MODIS)",
-        "server_layer_name": "mxd13a2_viq_dekad"
-      },
-      {
-        "id": "rain_anomaly_1month",
-        "title": "1-month rainfall anomaly",
-        "server_layer_name": "r1q_dekad"
-      },
-      {
-        "id": "rain_anomaly_1year",
-        "title": "1-year rainfall anomaly",
-        "server_layer_name": "ryq_dekad"
-      },
-      {
-        "id": "rain_anomaly_2month",
-        "title": "2-month rainfall anomaly",
-        "server_layer_name": "r2q_dekad"
-      },
-      {
-        "id": "rain_anomaly_3month",
-        "title": "3-month rainfall anomaly",
-        "server_layer_name": "r3q_dekad"
-      },
-      {
-        "id": "rain_anomaly_4month",
-        "title": "4-month rainfall anomaly",
-        "server_layer_name": "r4q_dekad"
-      },
-      {
-        "id": "rain_anomaly_5month",
-        "title": "5-month rainfall anomaly",
-        "server_layer_name": "r5q_dekad"
-      },
-      {
-        "id": "rain_anomaly_6month",
-        "title": "6-month rainfall anomaly",
-        "server_layer_name": "r6q_dekad"
-      },
-      {
-        "id": "rain_anomaly_7month",
-        "title": "7-month rainfall anomaly",
-        "server_layer_name": "r7q_dekad"
-      },
-      {
-        "id": "rain_anomaly_8month",
-        "title": "8-month rainfall anomaly",
-        "server_layer_name": "r8q_dekad"
-      },
-      {
-        "id": "rain_anomaly_9month",
-        "title": "9-month rainfall anomaly",
-        "server_layer_name": "r9q_dekad"
+        "id": "rainfall_dekad",
+        "title": "10-day rainfall estimate (mm)",
+        "server_layer_name": "rfh_dekad"
       },
       {
         "id": "rain_anomaly_dekad",
@@ -6091,14 +5946,9 @@
         "server_layer_name": "r1h_dekad"
       },
       {
-        "id": "rainfall_agg_1year",
-        "title": "1-year rainfall aggregate (mm)",
-        "server_layer_name": "ryh_dekad"
-      },
-      {
-        "id": "rainfall_agg_2month",
-        "title": "2-month rainfall aggregate (mm)",
-        "server_layer_name": "r2h_dekad"
+        "id": "rain_anomaly_1month",
+        "title": "1-month rainfall anomaly",
+        "server_layer_name": "r1q_dekad"
       },
       {
         "id": "rainfall_agg_3month",
@@ -6106,14 +5956,9 @@
         "server_layer_name": "r3h_dekad"
       },
       {
-        "id": "rainfall_agg_4month",
-        "title": "4-month rainfall aggregate (mm)",
-        "server_layer_name": "r4h_dekad"
-      },
-      {
-        "id": "rainfall_agg_5month",
-        "title": "5-month rainfall aggregate (mm)",
-        "server_layer_name": "r5h_dekad"
+        "id": "rain_anomaly_3month",
+        "title": "3-month rainfall anomaly",
+        "server_layer_name": "r3q_dekad"
       },
       {
         "id": "rainfall_agg_6month",
@@ -6121,14 +5966,9 @@
         "server_layer_name": "r6h_dekad"
       },
       {
-        "id": "rainfall_agg_7month",
-        "title": "7-month rainfall aggregate (mm)",
-        "server_layer_name": "r7h_dekad"
-      },
-      {
-        "id": "rainfall_agg_8month",
-        "title": "8-month rainfall aggregate (mm)",
-        "server_layer_name": "r8h_dekad"
+        "id": "rain_anomaly_6month",
+        "title": "6-month rainfall anomaly",
+        "server_layer_name": "r6q_dekad"
       },
       {
         "id": "rainfall_agg_9month",
@@ -6136,24 +5976,24 @@
         "server_layer_name": "r9h_dekad"
       },
       {
-        "id": "rainfall_dekad",
-        "title": "10-day rainfall estimate (mm)",
-        "server_layer_name": "rfh_dekad"
+        "id": "rain_anomaly_9month",
+        "title": "9-month rainfall anomaly",
+        "server_layer_name": "r9q_dekad"
+      },
+      {
+        "id": "rainfall_agg_1year",
+        "title": "1-year rainfall aggregate (mm)",
+        "server_layer_name": "ryh_dekad"
+      },
+      {
+        "id": "rain_anomaly_1year",
+        "title": "1-year rainfall anomaly",
+        "server_layer_name": "ryq_dekad"
       },
       {
         "id": "spi_1m",
         "title": "SPI - 1-month",
         "server_layer_name": "r1s_dekad"
-      },
-      {
-        "id": "spi_1y",
-        "title": "SPI - 1-year",
-        "server_layer_name": "rys_dekad"
-      },
-      {
-        "id": "spi_2m",
-        "title": "SPI - 2-month",
-        "server_layer_name": "r2s_dekad"
       },
       {
         "id": "spi_3m",
@@ -6171,14 +6011,34 @@
         "server_layer_name": "r9s_dekad"
       },
       {
+        "id": "spi_1y",
+        "title": "SPI - 1-year",
+        "server_layer_name": "rys_dekad"
+      },
+      {
+        "id": "days_dry",
+        "title": "Days since last rain",
+        "server_layer_name": "dlc_dekad"
+      },
+      {
         "id": "streak_dry_days",
         "title": "Longest dry spell",
         "server_layer_name": "dlx_dekad"
       },
       {
-        "id": "streak_extreme_rain",
-        "title": "Longest consecutive extreme rainfall days",
-        "server_layer_name": "xle_dekad"
+        "id": "days_heavy_rain",
+        "title": "Number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xnh_dekad"
+      },
+      {
+        "id": "days_intense_rain",
+        "title": "Number of days with intense rainfall in the last 30 days",
+        "server_layer_name": "xni_dekad"
+      },
+      {
+        "id": "days_extreme_rain",
+        "title": "Number of days with extreme rainfall in the last 30 days",
+        "server_layer_name": "xne_dekad"
       },
       {
         "id": "streak_heavy_rain",
@@ -6189,9 +6049,122 @@
         "id": "streak_intense_rain",
         "title": "Longest consecutive intense rainfall days",
         "server_layer_name": "xli_dekad"
-      }
-    ],
-    "srilanka": [
+      },
+      {
+        "id": "streak_extreme_rain",
+        "title": "Longest consecutive extreme rainfall days",
+        "server_layer_name": "xle_dekad"
+      },
+      {
+        "id": "ndvi_dekad",
+        "title": "10-day NDVI (MODIS)",
+        "server_layer_name": "mxd13a2_vim_dekad"
+      },
+      {
+        "id": "ndvi_dekad_anomaly",
+        "title": "10-day NDVI anomaly (MODIS)",
+        "server_layer_name": "mxd13a2_viq_dekad"
+      },
+      {
+        "id": "lst_amplitude",
+        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
+        "server_layer_name": "myd11a2_taa_dekad"
+      },
+      {
+        "id": "lst_daytime",
+        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_nighttime",
+        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_anomaly",
+        "title": "Daytime Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "daily_rainfall_forecast",
+        "title": "Rolling daily rainfall forecast",
+        "server_layer_name": "rfh_daily_forecast"
+      },
+      {
+        "id": "dekad_rainfall_forecast",
+        "title": "10-day rainfall forecast",
+        "server_layer_name": "rfh_dekad_forecast"
+      },
+      {
+        "id": "dekad_rainfall_anomaly_forecast",
+        "title": "10-day rainfall forecast anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rainfall_agg_2month",
+        "title": "2-month rainfall aggregate (mm)",
+        "server_layer_name": "r2h_dekad"
+      },
+      {
+        "id": "rain_anomaly_2month",
+        "title": "2-month rainfall anomaly",
+        "server_layer_name": "r2q_dekad"
+      },
+      {
+        "id": "rainfall_agg_4month",
+        "title": "4-month rainfall aggregate (mm)",
+        "server_layer_name": "r4h_dekad"
+      },
+      {
+        "id": "rain_anomaly_4month",
+        "title": "4-month rainfall anomaly",
+        "server_layer_name": "r4q_dekad"
+      },
+      {
+        "id": "rainfall_agg_5month",
+        "title": "5-month rainfall aggregate (mm)",
+        "server_layer_name": "r5h_dekad"
+      },
+      {
+        "id": "rain_anomaly_5month",
+        "title": "5-month rainfall anomaly",
+        "server_layer_name": "r5q_dekad"
+      },
+      {
+        "id": "rainfall_agg_7month",
+        "title": "7-month rainfall aggregate (mm)",
+        "server_layer_name": "r7h_dekad"
+      },
+      {
+        "id": "rain_anomaly_7month",
+        "title": "7-month rainfall anomaly",
+        "server_layer_name": "r7q_dekad"
+      },
+      {
+        "id": "rainfall_agg_8month",
+        "title": "8-month rainfall aggregate (mm)",
+        "server_layer_name": "r8h_dekad"
+      },
+      {
+        "id": "rain_anomaly_8month",
+        "title": "8-month rainfall anomaly",
+        "server_layer_name": "r8q_dekad"
+      },
+      {
+        "id": "spi_2m",
+        "title": "SPI - 2-month",
+        "server_layer_name": "r2s_dekad"
+      },
+      {
+        "id": "lst_day_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "monthly_water_anomaly",
+        "title": "Monthly Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_dekad"
+      },
       {
         "id": "2m_water_anomaly",
         "title": "2-Month Water Anomaly Index (WAI)",
@@ -6216,90 +6189,77 @@
         "id": "6m_water_anomaly",
         "title": "6-Month Water Anomaly Index (WAI)",
         "server_layer_name": "wai_seasonal_6month"
+      }
+    ],
+    "srilanka": [
+      {
+        "id": "rainfall_dekad",
+        "title": "10-day rainfall estimate (mm)",
+        "server_layer_name": "rfh_dekad"
       },
       {
-        "id": "daily_rainfall_forecast",
-        "title": "Rolling daily rainfall forecast",
-        "server_layer_name": "rfh_daily_forecast"
-      },
-      {
-        "id": "days_dry",
-        "title": "Days since last rain",
-        "server_layer_name": "dlc_dekad"
-      },
-      {
-        "id": "days_extreme_rain",
-        "title": "Number of days with extreme rainfall in the last 30 days",
-        "server_layer_name": "xne_dekad"
-      },
-      {
-        "id": "days_heavy_rain",
-        "title": "Number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xnh_dekad"
-      },
-      {
-        "id": "days_intense_rain",
-        "title": "Number of days with intense rainfall in the last 30 days",
-        "server_layer_name": "xni_dekad"
-      },
-      {
-        "id": "dekad_rainfall_anomaly_forecast",
-        "title": "10-day rainfall forecast anomaly",
+        "id": "rain_anomaly_dekad",
+        "title": "10-day rainfall anomaly",
         "server_layer_name": "rfq_dekad"
       },
       {
-        "id": "dekad_rainfall_forecast",
-        "title": "10-day rainfall forecast",
-        "server_layer_name": "rfh_dekad_forecast"
+        "id": "rainfall_agg_1month",
+        "title": "1-month rainfall aggregate",
+        "server_layer_name": "r1h_dekad"
       },
       {
-        "id": "lst_amplitude",
-        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
-        "server_layer_name": "myd11a2_taa_dekad"
+        "id": "rain_anomaly_1month",
+        "title": "Monthly rainfall anomaly",
+        "server_layer_name": "r1q_dekad"
       },
       {
-        "id": "lst_anomaly",
-        "title": "Daytime Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
+        "id": "rainfall_agg_3month",
+        "title": "3-month rainfall aggregate (mm)",
+        "server_layer_name": "r3h_dekad"
       },
       {
-        "id": "lst_day_anomaly",
-        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
+        "id": "rain_anomaly_3month",
+        "title": "3-month rainfall anomaly",
+        "server_layer_name": "r3q_dekad"
       },
       {
-        "id": "lst_daytime",
-        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
+        "id": "rain_anomaly_6month",
+        "title": "6-month rainfall anomaly",
+        "server_layer_name": "r6q_dekad"
       },
       {
-        "id": "lst_nighttime",
-        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
+        "id": "rain_anomaly_9month",
+        "title": "9-month rainfall anomaly",
+        "server_layer_name": "r9q_dekad"
       },
       {
-        "id": "monthly_water_anomaly",
-        "title": "Monthly Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_dekad"
+        "id": "rain_anomaly_1year",
+        "title": "1-year rainfall anomaly",
+        "server_layer_name": "ryq_dekad"
       },
       {
-        "id": "ndvi_dekad",
-        "title": "10-day NDVI (MODIS)",
-        "server_layer_name": "mxd13a2_vim_dekad"
+        "id": "rainfall_agg_6month",
+        "title": "6-month rainfall aggregate (mm)",
+        "server_layer_name": "r6h_dekad"
       },
       {
-        "id": "ndvi_dekad_anomaly",
-        "title": "10-day NDVI anomaly (MODIS)",
-        "server_layer_name": "mxd13a2_viq_dekad"
+        "id": "rainfall_agg_9month",
+        "title": "9-month rainfall aggregate (mm)",
+        "server_layer_name": "r9h_dekad"
+      },
+      {
+        "id": "rainfall_agg_1year",
+        "title": "1-year rainfall aggregate (mm)",
+        "server_layer_name": "ryh_dekad"
+      },
+      {
+        "id": "precip_blended_dekad",
+        "title": "Blended rainfall estimates (10-day)",
+        "server_layer_name": "rfb_blended_lka_dekad"
       },
       {
         "id": "precip_blended_1m",
         "title": "Blended rainfall aggregate (1-month)",
-        "server_layer_name": "rfb_blended_lka_dekad"
-      },
-      {
-        "id": "precip_blended_1y",
-        "title": "Blended rainfall aggregate (1-year)",
         "server_layer_name": "rfb_blended_lka_dekad"
       },
       {
@@ -6318,13 +6278,18 @@
         "server_layer_name": "rfb_blended_lka_dekad"
       },
       {
-        "id": "precip_blended_anomaly_1m",
-        "title": "Blended rainfall anomaly (1-month)",
+        "id": "precip_blended_1y",
+        "title": "Blended rainfall aggregate (1-year)",
+        "server_layer_name": "rfb_blended_lka_dekad"
+      },
+      {
+        "id": "precip_blended_dekad_anomaly",
+        "title": "Blended rainfall anomaly (10-day)",
         "server_layer_name": "rfq_blended_lka_dekad"
       },
       {
-        "id": "precip_blended_anomaly_1y",
-        "title": "Blended rainfall anomaly (1-year)",
+        "id": "precip_blended_anomaly_1m",
+        "title": "Blended rainfall anomaly (1-month)",
         "server_layer_name": "rfq_blended_lka_dekad"
       },
       {
@@ -6343,9 +6308,9 @@
         "server_layer_name": "rfq_blended_lka_dekad"
       },
       {
-        "id": "precip_blended_dekad",
-        "title": "Blended rainfall estimates (10-day)",
-        "server_layer_name": "rfb_blended_lka_dekad"
+        "id": "precip_blended_anomaly_1y",
+        "title": "Blended rainfall anomaly (1-year)",
+        "server_layer_name": "rfq_blended_lka_dekad"
       },
       {
         "id": "precip_blended_dekad_agg",
@@ -6353,134 +6318,9 @@
         "server_layer_name": "rnb_blended_dekad"
       },
       {
-        "id": "precip_blended_dekad_anomaly",
-        "title": "Blended rainfall anomaly (10-day)",
-        "server_layer_name": "rfq_blended_lka_dekad"
-      },
-      {
-        "id": "rain_anomaly_1month",
-        "title": "Monthly rainfall anomaly",
-        "server_layer_name": "r1q_dekad"
-      },
-      {
-        "id": "rain_anomaly_1year",
-        "title": "1-year rainfall anomaly",
-        "server_layer_name": "ryq_dekad"
-      },
-      {
-        "id": "rain_anomaly_2month",
-        "title": "2-month rainfall anomaly",
-        "server_layer_name": "r2q_dekad"
-      },
-      {
-        "id": "rain_anomaly_3month",
-        "title": "3-month rainfall anomaly",
-        "server_layer_name": "r3q_dekad"
-      },
-      {
-        "id": "rain_anomaly_4month",
-        "title": "4-month rainfall anomaly",
-        "server_layer_name": "r4q_dekad"
-      },
-      {
-        "id": "rain_anomaly_5month",
-        "title": "5-month rainfall anomaly",
-        "server_layer_name": "r5q_dekad"
-      },
-      {
-        "id": "rain_anomaly_6month",
-        "title": "6-month rainfall anomaly",
-        "server_layer_name": "r6q_dekad"
-      },
-      {
-        "id": "rain_anomaly_7month",
-        "title": "7-month rainfall anomaly",
-        "server_layer_name": "r7q_dekad"
-      },
-      {
-        "id": "rain_anomaly_8month",
-        "title": "8-month rainfall anomaly",
-        "server_layer_name": "r8q_dekad"
-      },
-      {
-        "id": "rain_anomaly_9month",
-        "title": "9-month rainfall anomaly",
-        "server_layer_name": "r9q_dekad"
-      },
-      {
-        "id": "rain_anomaly_dekad",
-        "title": "10-day rainfall anomaly",
-        "server_layer_name": "rfq_dekad"
-      },
-      {
-        "id": "rainfall_agg_1month",
-        "title": "1-month rainfall aggregate",
-        "server_layer_name": "r1h_dekad"
-      },
-      {
-        "id": "rainfall_agg_1year",
-        "title": "1-year rainfall aggregate (mm)",
-        "server_layer_name": "ryh_dekad"
-      },
-      {
-        "id": "rainfall_agg_2month",
-        "title": "2-month rainfall aggregate (mm)",
-        "server_layer_name": "r2h_dekad"
-      },
-      {
-        "id": "rainfall_agg_3month",
-        "title": "3-month rainfall aggregate (mm)",
-        "server_layer_name": "r3h_dekad"
-      },
-      {
-        "id": "rainfall_agg_4month",
-        "title": "4-month rainfall aggregate (mm)",
-        "server_layer_name": "r4h_dekad"
-      },
-      {
-        "id": "rainfall_agg_5month",
-        "title": "5-month rainfall aggregate (mm)",
-        "server_layer_name": "r5h_dekad"
-      },
-      {
-        "id": "rainfall_agg_6month",
-        "title": "6-month rainfall aggregate (mm)",
-        "server_layer_name": "r6h_dekad"
-      },
-      {
-        "id": "rainfall_agg_7month",
-        "title": "7-month rainfall aggregate (mm)",
-        "server_layer_name": "r7h_dekad"
-      },
-      {
-        "id": "rainfall_agg_8month",
-        "title": "8-month rainfall aggregate (mm)",
-        "server_layer_name": "r8h_dekad"
-      },
-      {
-        "id": "rainfall_agg_9month",
-        "title": "9-month rainfall aggregate (mm)",
-        "server_layer_name": "r9h_dekad"
-      },
-      {
-        "id": "rainfall_dekad",
-        "title": "10-day rainfall estimate (mm)",
-        "server_layer_name": "rfh_dekad"
-      },
-      {
         "id": "spi_1m",
         "title": "SPI - 1-month",
         "server_layer_name": "r1s_dekad"
-      },
-      {
-        "id": "spi_1y",
-        "title": "SPI - 1-year",
-        "server_layer_name": "rys_dekad"
-      },
-      {
-        "id": "spi_2m",
-        "title": "SPI - 2-month",
-        "server_layer_name": "r2s_dekad"
       },
       {
         "id": "spi_3m",
@@ -6498,14 +6338,34 @@
         "server_layer_name": "r9s_dekad"
       },
       {
+        "id": "spi_1y",
+        "title": "SPI - 1-year",
+        "server_layer_name": "rys_dekad"
+      },
+      {
+        "id": "days_dry",
+        "title": "Days since last rain",
+        "server_layer_name": "dlc_dekad"
+      },
+      {
         "id": "streak_dry_days",
         "title": "Longest number of consecutive dry days",
         "server_layer_name": "dlx_dekad"
       },
       {
-        "id": "streak_extreme_rain",
-        "title": "Longest consecutive extreme rainfall days",
-        "server_layer_name": "xle_dekad"
+        "id": "days_heavy_rain",
+        "title": "Number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xnh_dekad"
+      },
+      {
+        "id": "days_intense_rain",
+        "title": "Number of days with intense rainfall in the last 30 days",
+        "server_layer_name": "xni_dekad"
+      },
+      {
+        "id": "days_extreme_rain",
+        "title": "Number of days with extreme rainfall in the last 30 days",
+        "server_layer_name": "xne_dekad"
       },
       {
         "id": "streak_heavy_rain",
@@ -6516,9 +6376,122 @@
         "id": "streak_intense_rain",
         "title": "Longest consecutive intense rainfall days",
         "server_layer_name": "xli_dekad"
-      }
-    ],
-    "sudan": [
+      },
+      {
+        "id": "streak_extreme_rain",
+        "title": "Longest consecutive extreme rainfall days",
+        "server_layer_name": "xle_dekad"
+      },
+      {
+        "id": "ndvi_dekad",
+        "title": "10-day NDVI (MODIS)",
+        "server_layer_name": "mxd13a2_vim_dekad"
+      },
+      {
+        "id": "ndvi_dekad_anomaly",
+        "title": "10-day NDVI anomaly (MODIS)",
+        "server_layer_name": "mxd13a2_viq_dekad"
+      },
+      {
+        "id": "lst_amplitude",
+        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
+        "server_layer_name": "myd11a2_taa_dekad"
+      },
+      {
+        "id": "lst_daytime",
+        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_anomaly",
+        "title": "Daytime Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "daily_rainfall_forecast",
+        "title": "Rolling daily rainfall forecast",
+        "server_layer_name": "rfh_daily_forecast"
+      },
+      {
+        "id": "dekad_rainfall_forecast",
+        "title": "10-day rainfall forecast",
+        "server_layer_name": "rfh_dekad_forecast"
+      },
+      {
+        "id": "dekad_rainfall_anomaly_forecast",
+        "title": "10-day rainfall forecast anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rainfall_agg_2month",
+        "title": "2-month rainfall aggregate (mm)",
+        "server_layer_name": "r2h_dekad"
+      },
+      {
+        "id": "rain_anomaly_2month",
+        "title": "2-month rainfall anomaly",
+        "server_layer_name": "r2q_dekad"
+      },
+      {
+        "id": "rainfall_agg_4month",
+        "title": "4-month rainfall aggregate (mm)",
+        "server_layer_name": "r4h_dekad"
+      },
+      {
+        "id": "rain_anomaly_4month",
+        "title": "4-month rainfall anomaly",
+        "server_layer_name": "r4q_dekad"
+      },
+      {
+        "id": "rainfall_agg_5month",
+        "title": "5-month rainfall aggregate (mm)",
+        "server_layer_name": "r5h_dekad"
+      },
+      {
+        "id": "rain_anomaly_5month",
+        "title": "5-month rainfall anomaly",
+        "server_layer_name": "r5q_dekad"
+      },
+      {
+        "id": "rainfall_agg_7month",
+        "title": "7-month rainfall aggregate (mm)",
+        "server_layer_name": "r7h_dekad"
+      },
+      {
+        "id": "rain_anomaly_7month",
+        "title": "7-month rainfall anomaly",
+        "server_layer_name": "r7q_dekad"
+      },
+      {
+        "id": "rainfall_agg_8month",
+        "title": "8-month rainfall aggregate (mm)",
+        "server_layer_name": "r8h_dekad"
+      },
+      {
+        "id": "rain_anomaly_8month",
+        "title": "8-month rainfall anomaly",
+        "server_layer_name": "r8q_dekad"
+      },
+      {
+        "id": "spi_2m",
+        "title": "SPI - 2-month",
+        "server_layer_name": "r2s_dekad"
+      },
+      {
+        "id": "lst_nighttime",
+        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_day_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "monthly_water_anomaly",
+        "title": "Monthly Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_dekad"
+      },
       {
         "id": "2m_water_anomaly",
         "title": "2-Month Water Anomaly Index (WAI)",
@@ -6543,131 +6516,13 @@
         "id": "6m_water_anomaly",
         "title": "6-Month Water Anomaly Index (WAI)",
         "server_layer_name": "wai_seasonal_6month"
-      },
+      }
+    ],
+    "sudan": [
       {
-        "id": "daily_rainfall_forecast",
-        "title": "Rolling daily rainfall forecast",
-        "server_layer_name": "rfh_daily_forecast"
-      },
-      {
-        "id": "days_dry",
-        "title": "Days since last rain",
-        "server_layer_name": "dlc_dekad"
-      },
-      {
-        "id": "days_extreme_rain",
-        "title": "Number of days with extreme rainfall in the last 30 days",
-        "server_layer_name": "xne_dekad"
-      },
-      {
-        "id": "days_heavy_rain",
-        "title": "Number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xnh_dekad"
-      },
-      {
-        "id": "days_intense_rain",
-        "title": "Number of days with intense rainfall in the last 30 days",
-        "server_layer_name": "xni_dekad"
-      },
-      {
-        "id": "dekad_rainfall_anomaly_forecast",
-        "title": "10-day rainfall forecast anomaly",
-        "server_layer_name": "rfq_dekad"
-      },
-      {
-        "id": "dekad_rainfall_forecast",
-        "title": "10-day rainfall forecast",
-        "server_layer_name": "rfh_dekad_forecast"
-      },
-      {
-        "id": "lst_amplitude",
-        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
-        "server_layer_name": "myd11a2_taa_dekad"
-      },
-      {
-        "id": "lst_anomaly",
-        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_day_anomaly",
-        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_daytime",
-        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "lst_nighttime",
-        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "monthly_water_anomaly",
-        "title": "Monthly Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_dekad"
-      },
-      {
-        "id": "ndvi_dekad",
-        "title": "10-day NDVI (MODIS)",
-        "server_layer_name": "mxd13a2_vim_dekad"
-      },
-      {
-        "id": "ndvi_dekad_anomaly",
-        "title": "10-day NDVI anomaly (MODIS)",
-        "server_layer_name": "mxd13a2_viq_dekad"
-      },
-      {
-        "id": "rain_anomaly_1month",
-        "title": "Monthly rainfall anomaly",
-        "server_layer_name": "r1q_dekad"
-      },
-      {
-        "id": "rain_anomaly_1year",
-        "title": "1-year rainfall anomaly",
-        "server_layer_name": "ryq_dekad"
-      },
-      {
-        "id": "rain_anomaly_2month",
-        "title": "2-month rainfall anomaly",
-        "server_layer_name": "r2q_dekad"
-      },
-      {
-        "id": "rain_anomaly_3month",
-        "title": "3-month rainfall anomaly",
-        "server_layer_name": "r3q_dekad"
-      },
-      {
-        "id": "rain_anomaly_4month",
-        "title": "4-month rainfall anomaly",
-        "server_layer_name": "r4q_dekad"
-      },
-      {
-        "id": "rain_anomaly_5month",
-        "title": "5-month rainfall anomaly",
-        "server_layer_name": "r5q_dekad"
-      },
-      {
-        "id": "rain_anomaly_6month",
-        "title": "6-month rainfall anomaly",
-        "server_layer_name": "r6q_dekad"
-      },
-      {
-        "id": "rain_anomaly_7month",
-        "title": "7-month rainfall anomaly",
-        "server_layer_name": "r7q_dekad"
-      },
-      {
-        "id": "rain_anomaly_8month",
-        "title": "8-month rainfall anomaly",
-        "server_layer_name": "r8q_dekad"
-      },
-      {
-        "id": "rain_anomaly_9month",
-        "title": "9-month rainfall anomaly",
-        "server_layer_name": "r9q_dekad"
+        "id": "rainfall_dekad",
+        "title": "10-day rainfall estimate (mm)",
+        "server_layer_name": "rfh_dekad"
       },
       {
         "id": "rain_anomaly_dekad",
@@ -6680,14 +6535,9 @@
         "server_layer_name": "r1h_dekad"
       },
       {
-        "id": "rainfall_agg_1year",
-        "title": "1-year rainfall aggregate (mm)",
-        "server_layer_name": "ryh_dekad"
-      },
-      {
-        "id": "rainfall_agg_2month",
-        "title": "2-month rainfall aggregate (mm)",
-        "server_layer_name": "r2h_dekad"
+        "id": "rain_anomaly_1month",
+        "title": "Monthly rainfall anomaly",
+        "server_layer_name": "r1q_dekad"
       },
       {
         "id": "rainfall_agg_3month",
@@ -6695,9 +6545,54 @@
         "server_layer_name": "r3h_dekad"
       },
       {
+        "id": "rain_anomaly_3month",
+        "title": "3-month rainfall anomaly",
+        "server_layer_name": "r3q_dekad"
+      },
+      {
+        "id": "ndvi_dekad",
+        "title": "10-day NDVI (MODIS)",
+        "server_layer_name": "mxd13a2_vim_dekad"
+      },
+      {
+        "id": "ndvi_dekad_anomaly",
+        "title": "10-day NDVI anomaly (MODIS)",
+        "server_layer_name": "mxd13a2_viq_dekad"
+      },
+      {
+        "id": "daily_rainfall_forecast",
+        "title": "Rolling daily rainfall forecast",
+        "server_layer_name": "rfh_daily_forecast"
+      },
+      {
+        "id": "dekad_rainfall_forecast",
+        "title": "10-day rainfall forecast",
+        "server_layer_name": "rfh_dekad_forecast"
+      },
+      {
+        "id": "dekad_rainfall_anomaly_forecast",
+        "title": "10-day rainfall forecast anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rainfall_agg_2month",
+        "title": "2-month rainfall aggregate (mm)",
+        "server_layer_name": "r2h_dekad"
+      },
+      {
+        "id": "rain_anomaly_2month",
+        "title": "2-month rainfall anomaly",
+        "server_layer_name": "r2q_dekad"
+      },
+      {
         "id": "rainfall_agg_4month",
         "title": "4-month rainfall aggregate (mm)",
         "server_layer_name": "r4h_dekad"
+      },
+      {
+        "id": "rain_anomaly_4month",
+        "title": "4-month rainfall anomaly",
+        "server_layer_name": "r4q_dekad"
       },
       {
         "id": "rainfall_agg_5month",
@@ -6705,9 +6600,19 @@
         "server_layer_name": "r5h_dekad"
       },
       {
+        "id": "rain_anomaly_5month",
+        "title": "5-month rainfall anomaly",
+        "server_layer_name": "r5q_dekad"
+      },
+      {
         "id": "rainfall_agg_6month",
         "title": "6-month rainfall aggregate (mm)",
         "server_layer_name": "r6h_dekad"
+      },
+      {
+        "id": "rain_anomaly_6month",
+        "title": "6-month rainfall anomaly",
+        "server_layer_name": "r6q_dekad"
       },
       {
         "id": "rainfall_agg_7month",
@@ -6715,9 +6620,19 @@
         "server_layer_name": "r7h_dekad"
       },
       {
+        "id": "rain_anomaly_7month",
+        "title": "7-month rainfall anomaly",
+        "server_layer_name": "r7q_dekad"
+      },
+      {
         "id": "rainfall_agg_8month",
         "title": "8-month rainfall aggregate (mm)",
         "server_layer_name": "r8h_dekad"
+      },
+      {
+        "id": "rain_anomaly_8month",
+        "title": "8-month rainfall anomaly",
+        "server_layer_name": "r8q_dekad"
       },
       {
         "id": "rainfall_agg_9month",
@@ -6725,19 +6640,24 @@
         "server_layer_name": "r9h_dekad"
       },
       {
-        "id": "rainfall_dekad",
-        "title": "10-day rainfall estimate (mm)",
-        "server_layer_name": "rfh_dekad"
+        "id": "rain_anomaly_9month",
+        "title": "9-month rainfall anomaly",
+        "server_layer_name": "r9q_dekad"
+      },
+      {
+        "id": "rainfall_agg_1year",
+        "title": "1-year rainfall aggregate (mm)",
+        "server_layer_name": "ryh_dekad"
+      },
+      {
+        "id": "rain_anomaly_1year",
+        "title": "1-year rainfall anomaly",
+        "server_layer_name": "ryq_dekad"
       },
       {
         "id": "spi_1m",
         "title": "SPI - 1-month",
         "server_layer_name": "r1s_dekad"
-      },
-      {
-        "id": "spi_1y",
-        "title": "SPI - 1-year",
-        "server_layer_name": "rys_dekad"
       },
       {
         "id": "spi_2m",
@@ -6760,14 +6680,34 @@
         "server_layer_name": "r9s_dekad"
       },
       {
+        "id": "spi_1y",
+        "title": "SPI - 1-year",
+        "server_layer_name": "rys_dekad"
+      },
+      {
+        "id": "days_dry",
+        "title": "Days since last rain",
+        "server_layer_name": "dlc_dekad"
+      },
+      {
         "id": "streak_dry_days",
         "title": "Longest dry spell",
         "server_layer_name": "dlx_dekad"
       },
       {
-        "id": "streak_extreme_rain",
-        "title": "Longest consecutive extreme rainfall days",
-        "server_layer_name": "xle_dekad"
+        "id": "days_heavy_rain",
+        "title": "Number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xnh_dekad"
+      },
+      {
+        "id": "days_intense_rain",
+        "title": "Number of days with intense rainfall in the last 30 days",
+        "server_layer_name": "xni_dekad"
+      },
+      {
+        "id": "days_extreme_rain",
+        "title": "Number of days with extreme rainfall in the last 30 days",
+        "server_layer_name": "xne_dekad"
       },
       {
         "id": "streak_heavy_rain",
@@ -6778,9 +6718,42 @@
         "id": "streak_intense_rain",
         "title": "Longest consecutive intense rainfall days",
         "server_layer_name": "xli_dekad"
-      }
-    ],
-    "tajikistan": [
+      },
+      {
+        "id": "streak_extreme_rain",
+        "title": "Longest consecutive extreme rainfall days",
+        "server_layer_name": "xle_dekad"
+      },
+      {
+        "id": "lst_amplitude",
+        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
+        "server_layer_name": "myd11a2_taa_dekad"
+      },
+      {
+        "id": "lst_daytime",
+        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_nighttime",
+        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_day_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "monthly_water_anomaly",
+        "title": "Monthly Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_dekad"
+      },
       {
         "id": "2m_water_anomaly",
         "title": "2-Month Water Anomaly Index (WAI)",
@@ -6805,81 +6778,13 @@
         "id": "6m_water_anomaly",
         "title": "6-Month Water Anomaly Index (WAI)",
         "server_layer_name": "wai_seasonal_6month"
-      },
+      }
+    ],
+    "tajikistan": [
       {
-        "id": "daily_rainfall_forecast",
-        "title": "Rolling daily rainfall forecast",
-        "server_layer_name": "rfh_daily_forecast"
-      },
-      {
-        "id": "days_dry",
-        "title": "Days since last rain",
-        "server_layer_name": "dlc_dekad"
-      },
-      {
-        "id": "days_extreme_rain",
-        "title": "Number of days with extreme rainfall in the last 30 days",
-        "server_layer_name": "xne_dekad"
-      },
-      {
-        "id": "days_heavy_rain",
-        "title": "Number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xnh_dekad"
-      },
-      {
-        "id": "days_intense_rain",
-        "title": "Number of days with intense rainfall in the last 30 days",
-        "server_layer_name": "xni_dekad"
-      },
-      {
-        "id": "dekad_rainfall_anomaly_forecast",
-        "title": "10-day rainfall forecast anomaly",
-        "server_layer_name": "rfq_dekad"
-      },
-      {
-        "id": "dekad_rainfall_forecast",
-        "title": "10-day rainfall forecast",
-        "server_layer_name": "rfh_dekad_forecast"
-      },
-      {
-        "id": "lst_amplitude",
-        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
-        "server_layer_name": "myd11a2_taa_dekad"
-      },
-      {
-        "id": "lst_anomaly",
-        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_day_anomaly",
-        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_daytime",
-        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "lst_nighttime",
-        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "monthly_water_anomaly",
-        "title": "Monthly Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_dekad"
-      },
-      {
-        "id": "ndvi_dekad",
-        "title": "10-day NDVI (MODIS)",
-        "server_layer_name": "mxd13a2_vim_dekad"
-      },
-      {
-        "id": "ndvi_dekad_anomaly",
-        "title": "10-day NDVI anomaly (MODIS)",
-        "server_layer_name": "mxd13a2_viq_dekad"
+        "id": "rain_anomaly_dekad",
+        "title": "10-day rainfall anomaly",
+        "server_layer_name": "r1q_dekad"
       },
       {
         "id": "rain_anomaly_1month",
@@ -6887,29 +6792,9 @@
         "server_layer_name": "rfq_dekad"
       },
       {
-        "id": "rain_anomaly_1year",
-        "title": "1-year rainfall anomaly",
-        "server_layer_name": "ryq_dekad"
-      },
-      {
-        "id": "rain_anomaly_2month",
-        "title": "2-month rainfall anomaly",
-        "server_layer_name": "r2q_dekad"
-      },
-      {
         "id": "rain_anomaly_3month",
         "title": "3-month rainfall anomaly",
         "server_layer_name": "r3q_dekad"
-      },
-      {
-        "id": "rain_anomaly_4month",
-        "title": "4-month rainfall anomaly",
-        "server_layer_name": "r4q_dekad"
-      },
-      {
-        "id": "rain_anomaly_5month",
-        "title": "5-month rainfall anomaly",
-        "server_layer_name": "r5q_dekad"
       },
       {
         "id": "rain_anomaly_6month",
@@ -6917,74 +6802,14 @@
         "server_layer_name": "r6q_dekad"
       },
       {
-        "id": "rain_anomaly_7month",
-        "title": "7-month rainfall anomaly",
-        "server_layer_name": "r7q_dekad"
-      },
-      {
-        "id": "rain_anomaly_8month",
-        "title": "8-month rainfall anomaly",
-        "server_layer_name": "r8q_dekad"
-      },
-      {
         "id": "rain_anomaly_9month",
         "title": "9-month rainfall anomaly",
         "server_layer_name": "r9q_dekad"
       },
       {
-        "id": "rain_anomaly_dekad",
-        "title": "10-day rainfall anomaly",
-        "server_layer_name": "r1q_dekad"
-      },
-      {
-        "id": "rainfall_agg_1month",
-        "title": "1-month rainfall aggregate",
-        "server_layer_name": "r1h_dekad"
-      },
-      {
-        "id": "rainfall_agg_1year",
-        "title": "1-year rainfall aggregate (mm)",
-        "server_layer_name": "ryh_dekad"
-      },
-      {
-        "id": "rainfall_agg_2month",
-        "title": "2-month rainfall aggregate (mm)",
-        "server_layer_name": "r2h_dekad"
-      },
-      {
-        "id": "rainfall_agg_3month",
-        "title": "3-month rainfall aggregate (mm)",
-        "server_layer_name": "r3h_dekad"
-      },
-      {
-        "id": "rainfall_agg_4month",
-        "title": "4-month rainfall aggregate (mm)",
-        "server_layer_name": "r4h_dekad"
-      },
-      {
-        "id": "rainfall_agg_5month",
-        "title": "5-month rainfall aggregate (mm)",
-        "server_layer_name": "r5h_dekad"
-      },
-      {
-        "id": "rainfall_agg_6month",
-        "title": "6-month rainfall aggregate (mm)",
-        "server_layer_name": "r6h_dekad"
-      },
-      {
-        "id": "rainfall_agg_7month",
-        "title": "7-month rainfall aggregate (mm)",
-        "server_layer_name": "r7h_dekad"
-      },
-      {
-        "id": "rainfall_agg_8month",
-        "title": "8-month rainfall aggregate (mm)",
-        "server_layer_name": "r8h_dekad"
-      },
-      {
-        "id": "rainfall_agg_9month",
-        "title": "9-month rainfall aggregate (mm)",
-        "server_layer_name": "r9h_dekad"
+        "id": "rain_anomaly_1year",
+        "title": "1-year rainfall anomaly",
+        "server_layer_name": "ryq_dekad"
       },
       {
         "id": "rainfall_dekad",
@@ -6992,19 +6817,34 @@
         "server_layer_name": "rfh_dekad"
       },
       {
+        "id": "rainfall_agg_1month",
+        "title": "1-month rainfall aggregate",
+        "server_layer_name": "r1h_dekad"
+      },
+      {
+        "id": "rainfall_agg_3month",
+        "title": "3-month rainfall aggregate (mm)",
+        "server_layer_name": "r3h_dekad"
+      },
+      {
+        "id": "rainfall_agg_6month",
+        "title": "6-month rainfall aggregate (mm)",
+        "server_layer_name": "r6h_dekad"
+      },
+      {
+        "id": "rainfall_agg_9month",
+        "title": "9-month rainfall aggregate (mm)",
+        "server_layer_name": "r9h_dekad"
+      },
+      {
+        "id": "rainfall_agg_1year",
+        "title": "1-year rainfall aggregate (mm)",
+        "server_layer_name": "ryh_dekad"
+      },
+      {
         "id": "spi_1m",
         "title": "SPI - 1-month",
         "server_layer_name": "r1s_dekad"
-      },
-      {
-        "id": "spi_1y",
-        "title": "SPI - 1-year",
-        "server_layer_name": "rys_dekad"
-      },
-      {
-        "id": "spi_2m",
-        "title": "SPI - 2-month",
-        "server_layer_name": "r2s_dekad"
       },
       {
         "id": "spi_3m",
@@ -7022,14 +6862,34 @@
         "server_layer_name": "r9s_dekad"
       },
       {
+        "id": "spi_1y",
+        "title": "SPI - 1-year",
+        "server_layer_name": "rys_dekad"
+      },
+      {
+        "id": "days_dry",
+        "title": "Days since last rain",
+        "server_layer_name": "dlc_dekad"
+      },
+      {
         "id": "streak_dry_days",
         "title": "Longest number of consecutive dry days",
         "server_layer_name": "dlx_dekad"
       },
       {
-        "id": "streak_extreme_rain",
-        "title": "Longest consecutive extreme rainfall days",
-        "server_layer_name": "xle_dekad"
+        "id": "days_heavy_rain",
+        "title": "Number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xnh_dekad"
+      },
+      {
+        "id": "days_intense_rain",
+        "title": "Number of days with intense rainfall in the last 30 days",
+        "server_layer_name": "xni_dekad"
+      },
+      {
+        "id": "days_extreme_rain",
+        "title": "Number of days with extreme rainfall in the last 30 days",
+        "server_layer_name": "xne_dekad"
       },
       {
         "id": "streak_heavy_rain",
@@ -7040,9 +6900,122 @@
         "id": "streak_intense_rain",
         "title": "Longest consecutive intense rainfall days",
         "server_layer_name": "xli_dekad"
-      }
-    ],
-    "tanzania": [
+      },
+      {
+        "id": "streak_extreme_rain",
+        "title": "Longest consecutive extreme rainfall days",
+        "server_layer_name": "xle_dekad"
+      },
+      {
+        "id": "ndvi_dekad",
+        "title": "10-day NDVI (MODIS)",
+        "server_layer_name": "mxd13a2_vim_dekad"
+      },
+      {
+        "id": "ndvi_dekad_anomaly",
+        "title": "10-day NDVI anomaly (MODIS)",
+        "server_layer_name": "mxd13a2_viq_dekad"
+      },
+      {
+        "id": "lst_amplitude",
+        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
+        "server_layer_name": "myd11a2_taa_dekad"
+      },
+      {
+        "id": "lst_daytime",
+        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_nighttime",
+        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "daily_rainfall_forecast",
+        "title": "Rolling daily rainfall forecast",
+        "server_layer_name": "rfh_daily_forecast"
+      },
+      {
+        "id": "dekad_rainfall_forecast",
+        "title": "10-day rainfall forecast",
+        "server_layer_name": "rfh_dekad_forecast"
+      },
+      {
+        "id": "dekad_rainfall_anomaly_forecast",
+        "title": "10-day rainfall forecast anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rainfall_agg_2month",
+        "title": "2-month rainfall aggregate (mm)",
+        "server_layer_name": "r2h_dekad"
+      },
+      {
+        "id": "rain_anomaly_2month",
+        "title": "2-month rainfall anomaly",
+        "server_layer_name": "r2q_dekad"
+      },
+      {
+        "id": "rainfall_agg_4month",
+        "title": "4-month rainfall aggregate (mm)",
+        "server_layer_name": "r4h_dekad"
+      },
+      {
+        "id": "rain_anomaly_4month",
+        "title": "4-month rainfall anomaly",
+        "server_layer_name": "r4q_dekad"
+      },
+      {
+        "id": "rainfall_agg_5month",
+        "title": "5-month rainfall aggregate (mm)",
+        "server_layer_name": "r5h_dekad"
+      },
+      {
+        "id": "rain_anomaly_5month",
+        "title": "5-month rainfall anomaly",
+        "server_layer_name": "r5q_dekad"
+      },
+      {
+        "id": "rainfall_agg_7month",
+        "title": "7-month rainfall aggregate (mm)",
+        "server_layer_name": "r7h_dekad"
+      },
+      {
+        "id": "rain_anomaly_7month",
+        "title": "7-month rainfall anomaly",
+        "server_layer_name": "r7q_dekad"
+      },
+      {
+        "id": "rainfall_agg_8month",
+        "title": "8-month rainfall aggregate (mm)",
+        "server_layer_name": "r8h_dekad"
+      },
+      {
+        "id": "rain_anomaly_8month",
+        "title": "8-month rainfall anomaly",
+        "server_layer_name": "r8q_dekad"
+      },
+      {
+        "id": "spi_2m",
+        "title": "SPI - 2-month",
+        "server_layer_name": "r2s_dekad"
+      },
+      {
+        "id": "lst_day_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "monthly_water_anomaly",
+        "title": "Monthly Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_dekad"
+      },
       {
         "id": "2m_water_anomaly",
         "title": "2-Month Water Anomaly Index (WAI)",
@@ -7067,131 +7040,38 @@
         "id": "6m_water_anomaly",
         "title": "6-Month Water Anomaly Index (WAI)",
         "server_layer_name": "wai_seasonal_6month"
+      }
+    ],
+    "tanzania": [
+      {
+        "id": "spi_1m",
+        "title": "SPI - 1-month",
+        "server_layer_name": "r1s_dekad"
       },
       {
-        "id": "daily_rainfall_forecast",
-        "title": "Rolling daily rainfall forecast",
-        "server_layer_name": "rfh_daily_forecast"
+        "id": "spi_3m",
+        "title": "SPI - 3-month",
+        "server_layer_name": "r3s_dekad"
       },
       {
-        "id": "days_dry",
-        "title": "Days since last rain",
-        "server_layer_name": "dlc_dekad"
+        "id": "spi_6m",
+        "title": "SPI - 6-month",
+        "server_layer_name": "r6s_dekad"
       },
       {
-        "id": "days_extreme_rain",
-        "title": "Number of days with extreme rainfall in the last 30 days",
-        "server_layer_name": "xne_dekad"
+        "id": "spi_9m",
+        "title": "SPI - 9-month",
+        "server_layer_name": "r9s_dekad"
       },
       {
-        "id": "days_heavy_rain",
-        "title": "Number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xnh_dekad"
+        "id": "spi_1y",
+        "title": "SPI - 1-year",
+        "server_layer_name": "rys_dekad"
       },
       {
-        "id": "days_intense_rain",
-        "title": "Number of days with intense rainfall in the last 30 days",
-        "server_layer_name": "xni_dekad"
-      },
-      {
-        "id": "dekad_rainfall_anomaly_forecast",
-        "title": "10-day rainfall forecast anomaly",
-        "server_layer_name": "rfq_dekad"
-      },
-      {
-        "id": "dekad_rainfall_forecast",
-        "title": "10-day rainfall forecast",
-        "server_layer_name": "rfh_dekad_forecast"
-      },
-      {
-        "id": "lst_amplitude",
-        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
-        "server_layer_name": "myd11a2_taa_dekad"
-      },
-      {
-        "id": "lst_anomaly",
-        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_day_anomaly",
-        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_daytime",
-        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "lst_nighttime",
-        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "monthly_water_anomaly",
-        "title": "Monthly Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_dekad"
-      },
-      {
-        "id": "ndvi_dekad",
-        "title": "10-day NDVI (MODIS)",
-        "server_layer_name": "mxd13a2_vim_dekad"
-      },
-      {
-        "id": "ndvi_dekad_anomaly",
-        "title": "10-day NDVI anomaly (MODIS)",
-        "server_layer_name": "mxd13a2_viq_dekad"
-      },
-      {
-        "id": "rain_anomaly_1month",
-        "title": "Monthly rainfall anomaly",
-        "server_layer_name": "r1q_dekad"
-      },
-      {
-        "id": "rain_anomaly_1year",
-        "title": "1-year rainfall anomaly",
-        "server_layer_name": "ryq_dekad"
-      },
-      {
-        "id": "rain_anomaly_2month",
-        "title": "2-month rainfall anomaly",
-        "server_layer_name": "r2q_dekad"
-      },
-      {
-        "id": "rain_anomaly_3month",
-        "title": "3-month rainfall anomaly",
-        "server_layer_name": "r3q_dekad"
-      },
-      {
-        "id": "rain_anomaly_4month",
-        "title": "4-month rainfall anomaly",
-        "server_layer_name": "r4q_dekad"
-      },
-      {
-        "id": "rain_anomaly_5month",
-        "title": "5-month rainfall anomaly",
-        "server_layer_name": "r5q_dekad"
-      },
-      {
-        "id": "rain_anomaly_6month",
-        "title": "6-month rainfall anomaly",
-        "server_layer_name": "r6q_dekad"
-      },
-      {
-        "id": "rain_anomaly_7month",
-        "title": "7-month rainfall anomaly",
-        "server_layer_name": "r7q_dekad"
-      },
-      {
-        "id": "rain_anomaly_8month",
-        "title": "8-month rainfall anomaly",
-        "server_layer_name": "r8q_dekad"
-      },
-      {
-        "id": "rain_anomaly_9month",
-        "title": "9-month rainfall anomaly",
-        "server_layer_name": "r9q_dekad"
+        "id": "rainfall_dekad",
+        "title": "10-day rainfall estimate (mm)",
+        "server_layer_name": "rfh_dekad"
       },
       {
         "id": "rain_anomaly_dekad",
@@ -7204,236 +7084,9 @@
         "server_layer_name": "r1h_dekad"
       },
       {
-        "id": "rainfall_agg_1year",
-        "title": "1-year rainfall aggregate (mm)",
-        "server_layer_name": "ryh_dekad"
-      },
-      {
-        "id": "rainfall_agg_2month",
-        "title": "2-month rainfall aggregate (mm)",
-        "server_layer_name": "r2h_dekad"
-      },
-      {
-        "id": "rainfall_agg_3month",
-        "title": "3-month rainfall aggregate (mm)",
-        "server_layer_name": "r3h_dekad"
-      },
-      {
-        "id": "rainfall_agg_4month",
-        "title": "4-month rainfall aggregate (mm)",
-        "server_layer_name": "r4h_dekad"
-      },
-      {
-        "id": "rainfall_agg_5month",
-        "title": "5-month rainfall aggregate (mm)",
-        "server_layer_name": "r5h_dekad"
-      },
-      {
-        "id": "rainfall_agg_6month",
-        "title": "6-month rainfall aggregate (mm)",
-        "server_layer_name": "r6h_dekad"
-      },
-      {
-        "id": "rainfall_agg_7month",
-        "title": "7-month rainfall aggregate (mm)",
-        "server_layer_name": "r7h_dekad"
-      },
-      {
-        "id": "rainfall_agg_8month",
-        "title": "8-month rainfall aggregate (mm)",
-        "server_layer_name": "r8h_dekad"
-      },
-      {
-        "id": "rainfall_agg_9month",
-        "title": "9-month rainfall aggregate (mm)",
-        "server_layer_name": "r9h_dekad"
-      },
-      {
-        "id": "rainfall_dekad",
-        "title": "10-day rainfall estimate (mm)",
-        "server_layer_name": "rfh_dekad"
-      },
-      {
-        "id": "spi_1m",
-        "title": "SPI - 1-month",
-        "server_layer_name": "r1s_dekad"
-      },
-      {
-        "id": "spi_1y",
-        "title": "SPI - 1-year",
-        "server_layer_name": "rys_dekad"
-      },
-      {
-        "id": "spi_2m",
-        "title": "SPI - 2-month",
-        "server_layer_name": "r2s_dekad"
-      },
-      {
-        "id": "spi_3m",
-        "title": "SPI - 3-month",
-        "server_layer_name": "r3s_dekad"
-      },
-      {
-        "id": "spi_6m",
-        "title": "SPI - 6-month",
-        "server_layer_name": "r6s_dekad"
-      },
-      {
-        "id": "spi_9m",
-        "title": "SPI - 9-month",
-        "server_layer_name": "r9s_dekad"
-      },
-      {
-        "id": "streak_dry_days",
-        "title": "Longest number of consecutive dry days",
-        "server_layer_name": "dlx_dekad"
-      },
-      {
-        "id": "streak_extreme_rain",
-        "title": "Longest consecutive extreme rainfall days",
-        "server_layer_name": "xle_dekad"
-      },
-      {
-        "id": "streak_heavy_rain",
-        "title": "Longest consecutive number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xlh_dekad"
-      },
-      {
-        "id": "streak_intense_rain",
-        "title": "Longest consecutive intense rainfall days",
-        "server_layer_name": "xli_dekad"
-      }
-    ],
-    "ukraine": [
-      {
-        "id": "2m_water_anomaly",
-        "title": "2-Month Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_seasonal_2month"
-      },
-      {
-        "id": "3m_water_anomaly",
-        "title": "3-Month Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_seasonal_3month"
-      },
-      {
-        "id": "4m_water_anomaly",
-        "title": "4-Month Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_seasonal_4month"
-      },
-      {
-        "id": "5m_water_anomaly",
-        "title": "5-Month Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_seasonal_5month"
-      },
-      {
-        "id": "6m_water_anomaly",
-        "title": "6-Month Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_seasonal_6month"
-      },
-      {
-        "id": "daily_rainfall_forecast",
-        "title": "Rolling daily rainfall forecast",
-        "server_layer_name": "rfh_daily_forecast"
-      },
-      {
-        "id": "days_dry",
-        "title": "Number of dry days",
-        "server_layer_name": "dlc_dekad"
-      },
-      {
-        "id": "days_extreme_rain",
-        "title": "Number of days with extreme rainfall in the last 30 days",
-        "server_layer_name": "xne_dekad"
-      },
-      {
-        "id": "days_heavy_rain",
-        "title": "Number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xnh_dekad"
-      },
-      {
-        "id": "days_intense_rain",
-        "title": "Number of days with intense rainfall in the last 30 days",
-        "server_layer_name": "xni_dekad"
-      },
-      {
-        "id": "dekad_rainfall_anomaly_forecast",
-        "title": "10-day rainfall forecast anomaly",
-        "server_layer_name": "rfq_dekad"
-      },
-      {
-        "id": "dekad_rainfall_forecast",
-        "title": "10-day rainfall forecast",
-        "server_layer_name": "rfh_dekad_forecast"
-      },
-      {
-        "id": "lst_amplitude",
-        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
-        "server_layer_name": "myd11a2_taa_dekad"
-      },
-      {
-        "id": "lst_anomaly",
-        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_day_anomaly",
-        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_daytime",
-        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "lst_nighttime",
-        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "monthly_water_anomaly",
-        "title": "Monthly Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_dekad"
-      },
-      {
-        "id": "ndvi_dekad",
-        "title": "10-day NDVI (MODIS)",
-        "server_layer_name": "mxd13a2_vim_dekad"
-      },
-      {
-        "id": "ndvi_dekad_anomaly",
-        "title": "10-day NDVI anomaly (MODIS)",
-        "server_layer_name": "mxd13a2_viq_dekad"
-      },
-      {
         "id": "rain_anomaly_1month",
         "title": "Monthly rainfall anomaly",
-        "server_layer_name": "rfq_dekad"
-      },
-      {
-        "id": "rain_anomaly_1year",
-        "title": "1-year rainfall anomaly",
-        "server_layer_name": "ryq_dekad"
-      },
-      {
-        "id": "rain_anomaly_2month",
-        "title": "2-month rainfall anomaly",
-        "server_layer_name": "r2q_dekad"
-      },
-      {
-        "id": "rain_anomaly_3month",
-        "title": "3-month rainfall anomaly",
-        "server_layer_name": "r3q_dekad"
-      },
-      {
-        "id": "rain_anomaly_4month",
-        "title": "4-month rainfall anomaly",
-        "server_layer_name": "r4q_dekad"
-      },
-      {
-        "id": "rain_anomaly_5month",
-        "title": "5-month rainfall anomaly",
-        "server_layer_name": "r5q_dekad"
+        "server_layer_name": "r1q_dekad"
       },
       {
         "id": "rain_anomaly_6month",
@@ -7441,34 +7094,14 @@
         "server_layer_name": "r6q_dekad"
       },
       {
-        "id": "rain_anomaly_7month",
-        "title": "7-month rainfall anomaly",
-        "server_layer_name": "r7q_dekad"
-      },
-      {
-        "id": "rain_anomaly_8month",
-        "title": "8-month rainfall anomaly",
-        "server_layer_name": "r8q_dekad"
-      },
-      {
         "id": "rain_anomaly_9month",
         "title": "9-month rainfall anomaly",
         "server_layer_name": "r9q_dekad"
       },
       {
-        "id": "rain_anomaly_dekad",
-        "title": "10-day rainfall anomaly",
-        "server_layer_name": "r1q_dekad"
-      },
-      {
-        "id": "rainfall_agg_1month",
-        "title": "1-month rainfall aggregate",
-        "server_layer_name": "r1h_dekad"
-      },
-      {
-        "id": "rainfall_agg_1year",
-        "title": "1-year rainfall aggregate (mm)",
-        "server_layer_name": "ryh_dekad"
+        "id": "rain_anomaly_1year",
+        "title": "1-year rainfall anomaly",
+        "server_layer_name": "ryq_dekad"
       },
       {
         "id": "rainfall_agg_2month",
@@ -7476,9 +7109,19 @@
         "server_layer_name": "r2h_dekad"
       },
       {
+        "id": "rain_anomaly_2month",
+        "title": "2-month rainfall anomaly",
+        "server_layer_name": "r2q_dekad"
+      },
+      {
         "id": "rainfall_agg_3month",
         "title": "3-month rainfall aggregate (mm)",
         "server_layer_name": "r3h_dekad"
+      },
+      {
+        "id": "rain_anomaly_3month",
+        "title": "3-month rainfall anomaly",
+        "server_layer_name": "r3q_dekad"
       },
       {
         "id": "rainfall_agg_4month",
@@ -7486,9 +7129,19 @@
         "server_layer_name": "r4h_dekad"
       },
       {
+        "id": "rain_anomaly_4month",
+        "title": "4-month rainfall anomaly",
+        "server_layer_name": "r4q_dekad"
+      },
+      {
         "id": "rainfall_agg_5month",
         "title": "5-month rainfall aggregate (mm)",
         "server_layer_name": "r5h_dekad"
+      },
+      {
+        "id": "rain_anomaly_5month",
+        "title": "5-month rainfall anomaly",
+        "server_layer_name": "r5q_dekad"
       },
       {
         "id": "rainfall_agg_6month",
@@ -7496,106 +7149,29 @@
         "server_layer_name": "r6h_dekad"
       },
       {
-        "id": "rainfall_agg_7month",
-        "title": "7-month rainfall aggregate (mm)",
-        "server_layer_name": "r7h_dekad"
-      },
-      {
-        "id": "rainfall_agg_8month",
-        "title": "8-month rainfall aggregate (mm)",
-        "server_layer_name": "r8h_dekad"
-      },
-      {
         "id": "rainfall_agg_9month",
         "title": "9-month rainfall aggregate (mm)",
         "server_layer_name": "r9h_dekad"
       },
       {
-        "id": "rainfall_dekad",
-        "title": "10-day rainfall estimate (mm)",
-        "server_layer_name": "rfh_dekad"
-      },
-      {
-        "id": "spi_1m",
-        "title": "SPI - 1-month",
-        "server_layer_name": "r1s_dekad"
-      },
-      {
-        "id": "spi_1y",
-        "title": "SPI - 1-year",
-        "server_layer_name": "rys_dekad"
-      },
-      {
-        "id": "spi_2m",
-        "title": "SPI - 2-month",
-        "server_layer_name": "r2s_dekad"
-      },
-      {
-        "id": "spi_3m",
-        "title": "SPI - 3-month",
-        "server_layer_name": "r3s_dekad"
-      },
-      {
-        "id": "spi_6m",
-        "title": "SPI - 6-month",
-        "server_layer_name": "r6s_dekad"
-      },
-      {
-        "id": "spi_9m",
-        "title": "SPI - 9-month",
-        "server_layer_name": "r9s_dekad"
-      },
-      {
-        "id": "streak_dry_days",
-        "title": "Longest number of consecutive dry days",
-        "server_layer_name": "dlx_dekad"
-      },
-      {
-        "id": "streak_extreme_rain",
-        "title": "Longest consecutive extreme rainfall days",
-        "server_layer_name": "xle_dekad"
-      },
-      {
-        "id": "streak_heavy_rain",
-        "title": "Longest consecutive number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xlh_dekad"
-      },
-      {
-        "id": "streak_intense_rain",
-        "title": "Longest consecutive intense rainfall days",
-        "server_layer_name": "xli_dekad"
-      }
-    ],
-    "zambia": [
-      {
-        "id": "2m_water_anomaly",
-        "title": "2-Month Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_seasonal_2month"
-      },
-      {
-        "id": "3m_water_anomaly",
-        "title": "3-Month Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_seasonal_3month"
-      },
-      {
-        "id": "4m_water_anomaly",
-        "title": "4-Month Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_seasonal_4month"
-      },
-      {
-        "id": "5m_water_anomaly",
-        "title": "5-Month Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_seasonal_5month"
-      },
-      {
-        "id": "6m_water_anomaly",
-        "title": "6-Month Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_seasonal_6month"
+        "id": "rainfall_agg_1year",
+        "title": "1-year rainfall aggregate (mm)",
+        "server_layer_name": "ryh_dekad"
       },
       {
         "id": "daily_rainfall_forecast",
         "title": "Rolling daily rainfall forecast",
         "server_layer_name": "rfh_daily_forecast"
+      },
+      {
+        "id": "dekad_rainfall_forecast",
+        "title": "10-day rainfall forecast",
+        "server_layer_name": "rfh_dekad_forecast"
+      },
+      {
+        "id": "dekad_rainfall_anomaly_forecast",
+        "title": "10-day rainfall forecast anomaly",
+        "server_layer_name": "rfq_dekad"
       },
       {
         "id": "days_dry",
@@ -7603,9 +7179,9 @@
         "server_layer_name": "dlc_dekad"
       },
       {
-        "id": "days_extreme_rain",
-        "title": "Number of days with extreme rainfall in the last 30 days",
-        "server_layer_name": "xne_dekad"
+        "id": "streak_dry_days",
+        "title": "Longest number of consecutive dry days",
+        "server_layer_name": "dlx_dekad"
       },
       {
         "id": "days_heavy_rain",
@@ -7618,44 +7194,24 @@
         "server_layer_name": "xni_dekad"
       },
       {
-        "id": "dekad_rainfall_anomaly_forecast",
-        "title": "10-day rainfall forecast anomaly",
-        "server_layer_name": "rfq_dekad"
+        "id": "days_extreme_rain",
+        "title": "Number of days with extreme rainfall in the last 30 days",
+        "server_layer_name": "xne_dekad"
       },
       {
-        "id": "dekad_rainfall_forecast",
-        "title": "10-day rainfall forecast",
-        "server_layer_name": "rfh_dekad_forecast"
+        "id": "streak_heavy_rain",
+        "title": "Longest consecutive number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xlh_dekad"
       },
       {
-        "id": "lst_amplitude",
-        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
-        "server_layer_name": "myd11a2_taa_dekad"
+        "id": "streak_intense_rain",
+        "title": "Longest consecutive intense rainfall days",
+        "server_layer_name": "xli_dekad"
       },
       {
-        "id": "lst_anomaly",
-        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_day_anomaly",
-        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_daytime",
-        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "lst_nighttime",
-        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "monthly_water_anomaly",
-        "title": "Monthly Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_dekad"
+        "id": "streak_extreme_rain",
+        "title": "Longest consecutive extreme rainfall days",
+        "server_layer_name": "xle_dekad"
       },
       {
         "id": "ndvi_dekad",
@@ -7668,39 +7224,24 @@
         "server_layer_name": "mxd13a2_viq_dekad"
       },
       {
-        "id": "rain_anomaly_1month",
-        "title": "Monthly rainfall anomaly",
-        "server_layer_name": "r1q_dekad"
+        "id": "lst_amplitude",
+        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
+        "server_layer_name": "myd11a2_taa_dekad"
       },
       {
-        "id": "rain_anomaly_1year",
-        "title": "1-year rainfall anomaly",
-        "server_layer_name": "ryq_dekad"
+        "id": "lst_daytime",
+        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
       },
       {
-        "id": "rain_anomaly_2month",
-        "title": "2-month rainfall anomaly",
-        "server_layer_name": "r2q_dekad"
+        "id": "lst_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
       },
       {
-        "id": "rain_anomaly_3month",
-        "title": "3-month rainfall anomaly",
-        "server_layer_name": "r3q_dekad"
-      },
-      {
-        "id": "rain_anomaly_4month",
-        "title": "4-month rainfall anomaly",
-        "server_layer_name": "r4q_dekad"
-      },
-      {
-        "id": "rain_anomaly_5month",
-        "title": "5-month rainfall anomaly",
-        "server_layer_name": "r5q_dekad"
-      },
-      {
-        "id": "rain_anomaly_6month",
-        "title": "6-month rainfall anomaly",
-        "server_layer_name": "r6q_dekad"
+        "id": "rainfall_agg_7month",
+        "title": "7-month rainfall aggregate (mm)",
+        "server_layer_name": "r7h_dekad"
       },
       {
         "id": "rain_anomaly_7month",
@@ -7708,14 +7249,328 @@
         "server_layer_name": "r7q_dekad"
       },
       {
+        "id": "rainfall_agg_8month",
+        "title": "8-month rainfall aggregate (mm)",
+        "server_layer_name": "r8h_dekad"
+      },
+      {
         "id": "rain_anomaly_8month",
         "title": "8-month rainfall anomaly",
         "server_layer_name": "r8q_dekad"
       },
       {
+        "id": "spi_2m",
+        "title": "SPI - 2-month",
+        "server_layer_name": "r2s_dekad"
+      },
+      {
+        "id": "lst_nighttime",
+        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_day_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "monthly_water_anomaly",
+        "title": "Monthly Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_dekad"
+      },
+      {
+        "id": "2m_water_anomaly",
+        "title": "2-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_2month"
+      },
+      {
+        "id": "3m_water_anomaly",
+        "title": "3-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_3month"
+      },
+      {
+        "id": "4m_water_anomaly",
+        "title": "4-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_4month"
+      },
+      {
+        "id": "5m_water_anomaly",
+        "title": "5-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_5month"
+      },
+      {
+        "id": "6m_water_anomaly",
+        "title": "6-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_6month"
+      }
+    ],
+    "ukraine": [
+      {
+        "id": "rain_anomaly_dekad",
+        "title": "10-day rainfall anomaly",
+        "server_layer_name": "r1q_dekad"
+      },
+      {
+        "id": "rain_anomaly_1month",
+        "title": "Monthly rainfall anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rain_anomaly_3month",
+        "title": "3-month rainfall anomaly",
+        "server_layer_name": "r3q_dekad"
+      },
+      {
+        "id": "rain_anomaly_6month",
+        "title": "6-month rainfall anomaly",
+        "server_layer_name": "r6q_dekad"
+      },
+      {
         "id": "rain_anomaly_9month",
         "title": "9-month rainfall anomaly",
         "server_layer_name": "r9q_dekad"
+      },
+      {
+        "id": "rain_anomaly_1year",
+        "title": "1-year rainfall anomaly",
+        "server_layer_name": "ryq_dekad"
+      },
+      {
+        "id": "rainfall_dekad",
+        "title": "10-day rainfall estimate (mm)",
+        "server_layer_name": "rfh_dekad"
+      },
+      {
+        "id": "rainfall_agg_3month",
+        "title": "3-month rainfall aggregate (mm)",
+        "server_layer_name": "r3h_dekad"
+      },
+      {
+        "id": "rainfall_agg_6month",
+        "title": "6-month rainfall aggregate (mm)",
+        "server_layer_name": "r6h_dekad"
+      },
+      {
+        "id": "rainfall_agg_9month",
+        "title": "9-month rainfall aggregate (mm)",
+        "server_layer_name": "r9h_dekad"
+      },
+      {
+        "id": "rainfall_agg_1year",
+        "title": "1-year rainfall aggregate (mm)",
+        "server_layer_name": "ryh_dekad"
+      },
+      {
+        "id": "days_dry",
+        "title": "Number of dry days",
+        "server_layer_name": "dlc_dekad"
+      },
+      {
+        "id": "streak_dry_days",
+        "title": "Longest number of consecutive dry days",
+        "server_layer_name": "dlx_dekad"
+      },
+      {
+        "id": "days_heavy_rain",
+        "title": "Number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xnh_dekad"
+      },
+      {
+        "id": "days_intense_rain",
+        "title": "Number of days with intense rainfall in the last 30 days",
+        "server_layer_name": "xni_dekad"
+      },
+      {
+        "id": "days_extreme_rain",
+        "title": "Number of days with extreme rainfall in the last 30 days",
+        "server_layer_name": "xne_dekad"
+      },
+      {
+        "id": "streak_heavy_rain",
+        "title": "Longest consecutive number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xlh_dekad"
+      },
+      {
+        "id": "ndvi_dekad",
+        "title": "10-day NDVI (MODIS)",
+        "server_layer_name": "mxd13a2_vim_dekad"
+      },
+      {
+        "id": "ndvi_dekad_anomaly",
+        "title": "10-day NDVI anomaly (MODIS)",
+        "server_layer_name": "mxd13a2_viq_dekad"
+      },
+      {
+        "id": "lst_amplitude",
+        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
+        "server_layer_name": "myd11a2_taa_dekad"
+      },
+      {
+        "id": "lst_daytime",
+        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_nighttime",
+        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "spi_1m",
+        "title": "SPI - 1-month",
+        "server_layer_name": "r1s_dekad"
+      },
+      {
+        "id": "spi_3m",
+        "title": "SPI - 3-month",
+        "server_layer_name": "r3s_dekad"
+      },
+      {
+        "id": "spi_6m",
+        "title": "SPI - 6-month",
+        "server_layer_name": "r6s_dekad"
+      },
+      {
+        "id": "spi_9m",
+        "title": "SPI - 9-month",
+        "server_layer_name": "r9s_dekad"
+      },
+      {
+        "id": "spi_1y",
+        "title": "SPI - 1-year",
+        "server_layer_name": "rys_dekad"
+      },
+      {
+        "id": "daily_rainfall_forecast",
+        "title": "Rolling daily rainfall forecast",
+        "server_layer_name": "rfh_daily_forecast"
+      },
+      {
+        "id": "dekad_rainfall_forecast",
+        "title": "10-day rainfall forecast",
+        "server_layer_name": "rfh_dekad_forecast"
+      },
+      {
+        "id": "dekad_rainfall_anomaly_forecast",
+        "title": "10-day rainfall forecast anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rainfall_agg_1month",
+        "title": "1-month rainfall aggregate",
+        "server_layer_name": "r1h_dekad"
+      },
+      {
+        "id": "rainfall_agg_2month",
+        "title": "2-month rainfall aggregate (mm)",
+        "server_layer_name": "r2h_dekad"
+      },
+      {
+        "id": "rain_anomaly_2month",
+        "title": "2-month rainfall anomaly",
+        "server_layer_name": "r2q_dekad"
+      },
+      {
+        "id": "rainfall_agg_4month",
+        "title": "4-month rainfall aggregate (mm)",
+        "server_layer_name": "r4h_dekad"
+      },
+      {
+        "id": "rain_anomaly_4month",
+        "title": "4-month rainfall anomaly",
+        "server_layer_name": "r4q_dekad"
+      },
+      {
+        "id": "rainfall_agg_5month",
+        "title": "5-month rainfall aggregate (mm)",
+        "server_layer_name": "r5h_dekad"
+      },
+      {
+        "id": "rain_anomaly_5month",
+        "title": "5-month rainfall anomaly",
+        "server_layer_name": "r5q_dekad"
+      },
+      {
+        "id": "rainfall_agg_7month",
+        "title": "7-month rainfall aggregate (mm)",
+        "server_layer_name": "r7h_dekad"
+      },
+      {
+        "id": "rain_anomaly_7month",
+        "title": "7-month rainfall anomaly",
+        "server_layer_name": "r7q_dekad"
+      },
+      {
+        "id": "rainfall_agg_8month",
+        "title": "8-month rainfall aggregate (mm)",
+        "server_layer_name": "r8h_dekad"
+      },
+      {
+        "id": "rain_anomaly_8month",
+        "title": "8-month rainfall anomaly",
+        "server_layer_name": "r8q_dekad"
+      },
+      {
+        "id": "spi_2m",
+        "title": "SPI - 2-month",
+        "server_layer_name": "r2s_dekad"
+      },
+      {
+        "id": "streak_intense_rain",
+        "title": "Longest consecutive intense rainfall days",
+        "server_layer_name": "xli_dekad"
+      },
+      {
+        "id": "streak_extreme_rain",
+        "title": "Longest consecutive extreme rainfall days",
+        "server_layer_name": "xle_dekad"
+      },
+      {
+        "id": "lst_day_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "monthly_water_anomaly",
+        "title": "Monthly Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_dekad"
+      },
+      {
+        "id": "2m_water_anomaly",
+        "title": "2-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_2month"
+      },
+      {
+        "id": "3m_water_anomaly",
+        "title": "3-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_3month"
+      },
+      {
+        "id": "4m_water_anomaly",
+        "title": "4-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_4month"
+      },
+      {
+        "id": "5m_water_anomaly",
+        "title": "5-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_5month"
+      },
+      {
+        "id": "6m_water_anomaly",
+        "title": "6-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_6month"
+      }
+    ],
+    "zambia": [
+      {
+        "id": "rainfall_dekad",
+        "title": "10-day rainfall estimate (mm)",
+        "server_layer_name": "rfh_dekad"
       },
       {
         "id": "rain_anomaly_dekad",
@@ -7728,14 +7583,9 @@
         "server_layer_name": "r1h_dekad"
       },
       {
-        "id": "rainfall_agg_1year",
-        "title": "1-year rainfall aggregate (mm)",
-        "server_layer_name": "ryh_dekad"
-      },
-      {
-        "id": "rainfall_agg_2month",
-        "title": "2-month rainfall aggregate (mm)",
-        "server_layer_name": "r2h_dekad"
+        "id": "rain_anomaly_1month",
+        "title": "Monthly rainfall anomaly",
+        "server_layer_name": "r1q_dekad"
       },
       {
         "id": "rainfall_agg_3month",
@@ -7743,9 +7593,54 @@
         "server_layer_name": "r3h_dekad"
       },
       {
+        "id": "rain_anomaly_3month",
+        "title": "3-month rainfall anomaly",
+        "server_layer_name": "r3q_dekad"
+      },
+      {
+        "id": "ndvi_dekad",
+        "title": "10-day NDVI (MODIS)",
+        "server_layer_name": "mxd13a2_vim_dekad"
+      },
+      {
+        "id": "ndvi_dekad_anomaly",
+        "title": "10-day NDVI anomaly (MODIS)",
+        "server_layer_name": "mxd13a2_viq_dekad"
+      },
+      {
+        "id": "daily_rainfall_forecast",
+        "title": "Rolling daily rainfall forecast",
+        "server_layer_name": "rfh_daily_forecast"
+      },
+      {
+        "id": "dekad_rainfall_forecast",
+        "title": "10-day rainfall forecast",
+        "server_layer_name": "rfh_dekad_forecast"
+      },
+      {
+        "id": "dekad_rainfall_anomaly_forecast",
+        "title": "10-day rainfall forecast anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rainfall_agg_2month",
+        "title": "2-month rainfall aggregate (mm)",
+        "server_layer_name": "r2h_dekad"
+      },
+      {
+        "id": "rain_anomaly_2month",
+        "title": "2-month rainfall anomaly",
+        "server_layer_name": "r2q_dekad"
+      },
+      {
         "id": "rainfall_agg_4month",
         "title": "4-month rainfall aggregate (mm)",
         "server_layer_name": "r4h_dekad"
+      },
+      {
+        "id": "rain_anomaly_4month",
+        "title": "4-month rainfall anomaly",
+        "server_layer_name": "r4q_dekad"
       },
       {
         "id": "rainfall_agg_5month",
@@ -7753,9 +7648,19 @@
         "server_layer_name": "r5h_dekad"
       },
       {
+        "id": "rain_anomaly_5month",
+        "title": "5-month rainfall anomaly",
+        "server_layer_name": "r5q_dekad"
+      },
+      {
         "id": "rainfall_agg_6month",
         "title": "6-month rainfall aggregate (mm)",
         "server_layer_name": "r6h_dekad"
+      },
+      {
+        "id": "rain_anomaly_6month",
+        "title": "6-month rainfall anomaly",
+        "server_layer_name": "r6q_dekad"
       },
       {
         "id": "rainfall_agg_7month",
@@ -7763,9 +7668,19 @@
         "server_layer_name": "r7h_dekad"
       },
       {
+        "id": "rain_anomaly_7month",
+        "title": "7-month rainfall anomaly",
+        "server_layer_name": "r7q_dekad"
+      },
+      {
         "id": "rainfall_agg_8month",
         "title": "8-month rainfall aggregate (mm)",
         "server_layer_name": "r8h_dekad"
+      },
+      {
+        "id": "rain_anomaly_8month",
+        "title": "8-month rainfall anomaly",
+        "server_layer_name": "r8q_dekad"
       },
       {
         "id": "rainfall_agg_9month",
@@ -7773,19 +7688,24 @@
         "server_layer_name": "r9h_dekad"
       },
       {
-        "id": "rainfall_dekad",
-        "title": "10-day rainfall estimate (mm)",
-        "server_layer_name": "rfh_dekad"
+        "id": "rain_anomaly_9month",
+        "title": "9-month rainfall anomaly",
+        "server_layer_name": "r9q_dekad"
+      },
+      {
+        "id": "rainfall_agg_1year",
+        "title": "1-year rainfall aggregate (mm)",
+        "server_layer_name": "ryh_dekad"
+      },
+      {
+        "id": "rain_anomaly_1year",
+        "title": "1-year rainfall anomaly",
+        "server_layer_name": "ryq_dekad"
       },
       {
         "id": "spi_1m",
         "title": "SPI - 1-month",
         "server_layer_name": "r1s_dekad"
-      },
-      {
-        "id": "spi_1y",
-        "title": "SPI - 1-year",
-        "server_layer_name": "rys_dekad"
       },
       {
         "id": "spi_2m",
@@ -7808,14 +7728,34 @@
         "server_layer_name": "r9s_dekad"
       },
       {
+        "id": "spi_1y",
+        "title": "SPI - 1-year",
+        "server_layer_name": "rys_dekad"
+      },
+      {
+        "id": "days_dry",
+        "title": "Days since last rain",
+        "server_layer_name": "dlc_dekad"
+      },
+      {
         "id": "streak_dry_days",
         "title": "Longest dry spell",
         "server_layer_name": "dlx_dekad"
       },
       {
-        "id": "streak_extreme_rain",
-        "title": "Longest consecutive extreme rainfall days",
-        "server_layer_name": "xle_dekad"
+        "id": "days_heavy_rain",
+        "title": "Number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xnh_dekad"
+      },
+      {
+        "id": "days_intense_rain",
+        "title": "Number of days with intense rainfall in the last 30 days",
+        "server_layer_name": "xni_dekad"
+      },
+      {
+        "id": "days_extreme_rain",
+        "title": "Number of days with extreme rainfall in the last 30 days",
+        "server_layer_name": "xne_dekad"
       },
       {
         "id": "streak_heavy_rain",
@@ -7826,9 +7766,42 @@
         "id": "streak_intense_rain",
         "title": "Longest consecutive intense rainfall days",
         "server_layer_name": "xli_dekad"
-      }
-    ],
-    "zimbabwe": [
+      },
+      {
+        "id": "streak_extreme_rain",
+        "title": "Longest consecutive extreme rainfall days",
+        "server_layer_name": "xle_dekad"
+      },
+      {
+        "id": "lst_amplitude",
+        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
+        "server_layer_name": "myd11a2_taa_dekad"
+      },
+      {
+        "id": "lst_daytime",
+        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_nighttime",
+        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_day_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "lst_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "monthly_water_anomaly",
+        "title": "Monthly Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_dekad"
+      },
       {
         "id": "2m_water_anomaly",
         "title": "2-Month Water Anomaly Index (WAI)",
@@ -7853,81 +7826,43 @@
         "id": "6m_water_anomaly",
         "title": "6-Month Water Anomaly Index (WAI)",
         "server_layer_name": "wai_seasonal_6month"
+      }
+    ],
+    "zimbabwe": [
+      {
+        "id": "spi_1m",
+        "title": "SPI - 1-month",
+        "server_layer_name": "r1s_dekad"
       },
       {
-        "id": "daily_rainfall_forecast",
-        "title": "Rolling daily rainfall forecast",
-        "server_layer_name": "rfh_daily_forecast"
+        "id": "spi_3m",
+        "title": "SPI - 3-month",
+        "server_layer_name": "r3s_dekad"
       },
       {
-        "id": "days_dry",
-        "title": "Days since last rain",
-        "server_layer_name": "dlc_dekad"
+        "id": "spi_6m",
+        "title": "SPI - 6-month",
+        "server_layer_name": "r6s_dekad"
       },
       {
-        "id": "days_extreme_rain",
-        "title": "Number of days with extreme rainfall in the last 30 days",
-        "server_layer_name": "xne_dekad"
+        "id": "spi_9m",
+        "title": "SPI - 9-month",
+        "server_layer_name": "r9s_dekad"
       },
       {
-        "id": "days_heavy_rain",
-        "title": "Number of days with heavy rainfall in the last 30 days",
-        "server_layer_name": "xnh_dekad"
+        "id": "spi_1y",
+        "title": "SPI - 1-year",
+        "server_layer_name": "rys_dekad"
       },
       {
-        "id": "days_intense_rain",
-        "title": "Number of days with intense rainfall in the last 30 days",
-        "server_layer_name": "xni_dekad"
+        "id": "precip_blended_dekad",
+        "title": "Blended rainfall aggregate (10-day)",
+        "server_layer_name": "rfb_blended_zwe_dekad"
       },
       {
-        "id": "dekad_rainfall_anomaly_forecast",
-        "title": "10-day rainfall forecast anomaly",
-        "server_layer_name": "rfq_dekad"
-      },
-      {
-        "id": "dekad_rainfall_forecast",
-        "title": "10-day rainfall forecast",
-        "server_layer_name": "rfh_dekad_forecast"
-      },
-      {
-        "id": "lst_amplitude",
-        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
-        "server_layer_name": "myd11a2_taa_dekad"
-      },
-      {
-        "id": "lst_anomaly",
-        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_day_anomaly",
-        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
-        "server_layer_name": "myd11a2_txd_dekad"
-      },
-      {
-        "id": "lst_daytime",
-        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "lst_nighttime",
-        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
-        "server_layer_name": "myd11a2_txa_dekad"
-      },
-      {
-        "id": "monthly_water_anomaly",
-        "title": "Monthly Water Anomaly Index (WAI)",
-        "server_layer_name": "wai_dekad"
-      },
-      {
-        "id": "ndvi_dekad",
-        "title": "10-day NDVI (MODIS)",
-        "server_layer_name": "mxd13a2_vim_dekad"
-      },
-      {
-        "id": "ndvi_dekad_anomaly",
-        "title": "10-day NDVI anomaly (MODIS)",
-        "server_layer_name": "mxd13a2_viq_dekad"
+        "id": "precip_blended_dekad_anomaly",
+        "title": "Blended rainfall anomaly (10-day)",
+        "server_layer_name": "rfq_blended_zwe_dekad"
       },
       {
         "id": "precip_blended_1m",
@@ -7935,18 +7870,113 @@
         "server_layer_name": "rfb_blended_zwe_dekad"
       },
       {
-        "id": "precip_blended_1y",
-        "title": "Blended rainfall aggregate (1-year)",
-        "server_layer_name": "rfb_blended_zwe_dekad"
-      },
-      {
-        "id": "precip_blended_2m",
-        "title": "Blended rainfall aggregate (2-month)",
-        "server_layer_name": "rfb_blended_zwe_dekad"
+        "id": "precip_blended_anomaly_1m",
+        "title": "Blended rainfall anomaly (1-month)",
+        "server_layer_name": "rfq_blended_zwe_dekad"
       },
       {
         "id": "precip_blended_3m",
         "title": "Blended rainfall aggregate (3-month)",
+        "server_layer_name": "rfb_blended_zwe_dekad"
+      },
+      {
+        "id": "precip_blended_anomaly_3m",
+        "title": "Blended rainfall anomaly (3-month)",
+        "server_layer_name": "rfq_blended_zwe_dekad"
+      },
+      {
+        "id": "rainfall_dekad",
+        "title": "10-day rainfall estimate (mm)",
+        "server_layer_name": "rfh_dekad"
+      },
+      {
+        "id": "rain_anomaly_dekad",
+        "title": "10-day rainfall anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rainfall_agg_1month",
+        "title": "1-month rainfall aggregate (mm)",
+        "server_layer_name": "r1h_dekad"
+      },
+      {
+        "id": "rain_anomaly_1month",
+        "title": "Monthly rainfall anomaly",
+        "server_layer_name": "r1q_dekad"
+      },
+      {
+        "id": "rainfall_agg_3month",
+        "title": "3-month rainfall aggregate (mm)",
+        "server_layer_name": "r3h_dekad"
+      },
+      {
+        "id": "rain_anomaly_3month",
+        "title": "3-month rainfall anomaly",
+        "server_layer_name": "r3q_dekad"
+      },
+      {
+        "id": "rain_anomaly_6month",
+        "title": "6-month rainfall anomaly",
+        "server_layer_name": "r6q_dekad"
+      },
+      {
+        "id": "rain_anomaly_9month",
+        "title": "9-month rainfall anomaly",
+        "server_layer_name": "r9q_dekad"
+      },
+      {
+        "id": "rain_anomaly_1year",
+        "title": "1-year rainfall anomaly",
+        "server_layer_name": "ryq_dekad"
+      },
+      {
+        "id": "rainfall_agg_2month",
+        "title": "2-month rainfall aggregate (mm)",
+        "server_layer_name": "r2h_dekad"
+      },
+      {
+        "id": "rain_anomaly_2month",
+        "title": "2-month rainfall anomaly",
+        "server_layer_name": "r2q_dekad"
+      },
+      {
+        "id": "rainfall_agg_4month",
+        "title": "4-month rainfall aggregate (mm)",
+        "server_layer_name": "r4h_dekad"
+      },
+      {
+        "id": "rain_anomaly_4month",
+        "title": "4-month rainfall anomaly",
+        "server_layer_name": "r4q_dekad"
+      },
+      {
+        "id": "rainfall_agg_5month",
+        "title": "5-month rainfall aggregate (mm)",
+        "server_layer_name": "r5h_dekad"
+      },
+      {
+        "id": "rain_anomaly_5month",
+        "title": "5-month rainfall anomaly",
+        "server_layer_name": "r5q_dekad"
+      },
+      {
+        "id": "rainfall_agg_6month",
+        "title": "6-month rainfall aggregate (mm)",
+        "server_layer_name": "r6h_dekad"
+      },
+      {
+        "id": "rainfall_agg_9month",
+        "title": "9-month rainfall aggregate (mm)",
+        "server_layer_name": "r9h_dekad"
+      },
+      {
+        "id": "rainfall_agg_1year",
+        "title": "1-year rainfall aggregate (mm)",
+        "server_layer_name": "ryh_dekad"
+      },
+      {
+        "id": "precip_blended_2m",
+        "title": "Blended rainfall aggregate (2-month)",
         "server_layer_name": "rfb_blended_zwe_dekad"
       },
       {
@@ -7975,23 +8005,13 @@
         "server_layer_name": "rfb_blended_zwe_dekad"
       },
       {
-        "id": "precip_blended_anomaly_1m",
-        "title": "Blended rainfall anomaly (1-month)",
-        "server_layer_name": "rfq_blended_zwe_dekad"
-      },
-      {
-        "id": "precip_blended_anomaly_1y",
-        "title": "Blended rainfall anomaly (1-year)",
-        "server_layer_name": "rfq_blended_zwe_dekad"
+        "id": "precip_blended_1y",
+        "title": "Blended rainfall aggregate (1-year)",
+        "server_layer_name": "rfb_blended_zwe_dekad"
       },
       {
         "id": "precip_blended_anomaly_2m",
         "title": "Blended rainfall anomaly (2-month)",
-        "server_layer_name": "rfq_blended_zwe_dekad"
-      },
-      {
-        "id": "precip_blended_anomaly_3m",
-        "title": "Blended rainfall anomaly (3-month)",
         "server_layer_name": "rfq_blended_zwe_dekad"
       },
       {
@@ -8020,154 +8040,14 @@
         "server_layer_name": "rfq_blended_zwe_dekad"
       },
       {
-        "id": "precip_blended_dekad",
-        "title": "Blended rainfall aggregate (10-day)",
-        "server_layer_name": "rfb_blended_zwe_dekad"
-      },
-      {
-        "id": "precip_blended_dekad_anomaly",
-        "title": "Blended rainfall anomaly (10-day)",
+        "id": "precip_blended_anomaly_1y",
+        "title": "Blended rainfall anomaly (1-year)",
         "server_layer_name": "rfq_blended_zwe_dekad"
       },
       {
-        "id": "rain_anomaly_1month",
-        "title": "Monthly rainfall anomaly",
-        "server_layer_name": "r1q_dekad"
-      },
-      {
-        "id": "rain_anomaly_1year",
-        "title": "1-year rainfall anomaly",
-        "server_layer_name": "ryq_dekad"
-      },
-      {
-        "id": "rain_anomaly_2month",
-        "title": "2-month rainfall anomaly",
-        "server_layer_name": "r2q_dekad"
-      },
-      {
-        "id": "rain_anomaly_3month",
-        "title": "3-month rainfall anomaly",
-        "server_layer_name": "r3q_dekad"
-      },
-      {
-        "id": "rain_anomaly_4month",
-        "title": "4-month rainfall anomaly",
-        "server_layer_name": "r4q_dekad"
-      },
-      {
-        "id": "rain_anomaly_5month",
-        "title": "5-month rainfall anomaly",
-        "server_layer_name": "r5q_dekad"
-      },
-      {
-        "id": "rain_anomaly_6month",
-        "title": "6-month rainfall anomaly",
-        "server_layer_name": "r6q_dekad"
-      },
-      {
-        "id": "rain_anomaly_7month",
-        "title": "7-month rainfall anomaly",
-        "server_layer_name": "r7q_dekad"
-      },
-      {
-        "id": "rain_anomaly_8month",
-        "title": "8-month rainfall anomaly",
-        "server_layer_name": "r8q_dekad"
-      },
-      {
-        "id": "rain_anomaly_9month",
-        "title": "9-month rainfall anomaly",
-        "server_layer_name": "r9q_dekad"
-      },
-      {
-        "id": "rain_anomaly_dekad",
-        "title": "10-day rainfall anomaly",
-        "server_layer_name": "rfq_dekad"
-      },
-      {
-        "id": "rainfall_agg_1month",
-        "title": "1-month rainfall aggregate (mm)",
-        "server_layer_name": "r1h_dekad"
-      },
-      {
-        "id": "rainfall_agg_1year",
-        "title": "1-year rainfall aggregate (mm)",
-        "server_layer_name": "ryh_dekad"
-      },
-      {
-        "id": "rainfall_agg_2month",
-        "title": "2-month rainfall aggregate (mm)",
-        "server_layer_name": "r2h_dekad"
-      },
-      {
-        "id": "rainfall_agg_3month",
-        "title": "3-month rainfall aggregate (mm)",
-        "server_layer_name": "r3h_dekad"
-      },
-      {
-        "id": "rainfall_agg_4month",
-        "title": "4-month rainfall aggregate (mm)",
-        "server_layer_name": "r4h_dekad"
-      },
-      {
-        "id": "rainfall_agg_5month",
-        "title": "5-month rainfall aggregate (mm)",
-        "server_layer_name": "r5h_dekad"
-      },
-      {
-        "id": "rainfall_agg_6month",
-        "title": "6-month rainfall aggregate (mm)",
-        "server_layer_name": "r6h_dekad"
-      },
-      {
-        "id": "rainfall_agg_7month",
-        "title": "7-month rainfall aggregate (mm)",
-        "server_layer_name": "r7h_dekad"
-      },
-      {
-        "id": "rainfall_agg_8month",
-        "title": "8-month rainfall aggregate (mm)",
-        "server_layer_name": "r8h_dekad"
-      },
-      {
-        "id": "rainfall_agg_9month",
-        "title": "9-month rainfall aggregate (mm)",
-        "server_layer_name": "r9h_dekad"
-      },
-      {
-        "id": "rainfall_dekad",
-        "title": "10-day rainfall estimate (mm)",
-        "server_layer_name": "rfh_dekad"
-      },
-      {
-        "id": "spi_1m",
-        "title": "SPI - 1-month",
-        "server_layer_name": "r1s_dekad"
-      },
-      {
-        "id": "spi_1y",
-        "title": "SPI - 1-year",
-        "server_layer_name": "rys_dekad"
-      },
-      {
-        "id": "spi_2m",
-        "title": "SPI - 2-month",
-        "server_layer_name": "r2s_dekad"
-      },
-      {
-        "id": "spi_3m",
-        "title": "SPI - 3-month",
-        "server_layer_name": "r3s_dekad"
-      },
-      {
-        "id": "spi_6m",
-        "title": "SPI - 6-month",
-        "server_layer_name": "r6s_dekad"
-      },
-      {
-        "id": "spi_9m",
-        "title": "SPI - 9-month",
-        "server_layer_name": "r9s_dekad"
+        "id": "days_dry",
+        "title": "Days since last rain",
+        "server_layer_name": "dlc_dekad"
       },
       {
         "id": "streak_dry_days",
@@ -8175,9 +8055,19 @@
         "server_layer_name": "dlx_dekad"
       },
       {
-        "id": "streak_extreme_rain",
-        "title": "Longest consecutive extreme rainfall days",
-        "server_layer_name": "xle_dekad"
+        "id": "days_heavy_rain",
+        "title": "Number of days with heavy rainfall in the last 30 days",
+        "server_layer_name": "xnh_dekad"
+      },
+      {
+        "id": "days_intense_rain",
+        "title": "Number of days with intense rainfall in the last 30 days",
+        "server_layer_name": "xni_dekad"
+      },
+      {
+        "id": "days_extreme_rain",
+        "title": "Number of days with extreme rainfall in the last 30 days",
+        "server_layer_name": "xne_dekad"
       },
       {
         "id": "streak_heavy_rain",
@@ -8188,6 +8078,116 @@
         "id": "streak_intense_rain",
         "title": "Longest consecutive intense rainfall days",
         "server_layer_name": "xli_dekad"
+      },
+      {
+        "id": "streak_extreme_rain",
+        "title": "Longest consecutive extreme rainfall days",
+        "server_layer_name": "xle_dekad"
+      },
+      {
+        "id": "ndvi_dekad",
+        "title": "10-day NDVI (MODIS)",
+        "server_layer_name": "mxd13a2_vim_dekad"
+      },
+      {
+        "id": "ndvi_dekad_anomaly",
+        "title": "10-day NDVI anomaly (MODIS)",
+        "server_layer_name": "mxd13a2_viq_dekad"
+      },
+      {
+        "id": "lst_amplitude",
+        "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
+        "server_layer_name": "myd11a2_taa_dekad"
+      },
+      {
+        "id": "lst_daytime",
+        "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "daily_rainfall_forecast",
+        "title": "Rolling daily rainfall forecast",
+        "server_layer_name": "rfh_daily_forecast"
+      },
+      {
+        "id": "dekad_rainfall_forecast",
+        "title": "10-day rainfall forecast",
+        "server_layer_name": "rfh_dekad_forecast"
+      },
+      {
+        "id": "dekad_rainfall_anomaly_forecast",
+        "title": "10-day rainfall forecast anomaly",
+        "server_layer_name": "rfq_dekad"
+      },
+      {
+        "id": "rainfall_agg_7month",
+        "title": "7-month rainfall aggregate (mm)",
+        "server_layer_name": "r7h_dekad"
+      },
+      {
+        "id": "rain_anomaly_7month",
+        "title": "7-month rainfall anomaly",
+        "server_layer_name": "r7q_dekad"
+      },
+      {
+        "id": "rainfall_agg_8month",
+        "title": "8-month rainfall aggregate (mm)",
+        "server_layer_name": "r8h_dekad"
+      },
+      {
+        "id": "rain_anomaly_8month",
+        "title": "8-month rainfall anomaly",
+        "server_layer_name": "r8q_dekad"
+      },
+      {
+        "id": "spi_2m",
+        "title": "SPI - 2-month",
+        "server_layer_name": "r2s_dekad"
+      },
+      {
+        "id": "lst_nighttime",
+        "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
+        "server_layer_name": "myd11a2_txa_dekad"
+      },
+      {
+        "id": "lst_day_anomaly",
+        "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+        "server_layer_name": "myd11a2_txd_dekad"
+      },
+      {
+        "id": "monthly_water_anomaly",
+        "title": "Monthly Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_dekad"
+      },
+      {
+        "id": "2m_water_anomaly",
+        "title": "2-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_2month"
+      },
+      {
+        "id": "3m_water_anomaly",
+        "title": "3-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_3month"
+      },
+      {
+        "id": "4m_water_anomaly",
+        "title": "4-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_4month"
+      },
+      {
+        "id": "5m_water_anomaly",
+        "title": "5-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_5month"
+      },
+      {
+        "id": "6m_water_anomaly",
+        "title": "6-Month Water Anomaly Index (WAI)",
+        "server_layer_name": "wai_seasonal_6month"
       }
     ]
   }

--- a/api/prism_app/map_export_layer_catalog.py
+++ b/api/prism_app/map_export_layer_catalog.py
@@ -87,4 +87,4 @@ def schedule_layer_choices_with_extra(
         if layer_id and layer_id not in known:
             choices.append((layer_id, layer_id))
             known.add(layer_id)
-    return tuple(sorted(choices, key=lambda pair: pair[0]))
+    return tuple(choices)

--- a/api/prism_app/tests/test_map_export_layer_catalog.py
+++ b/api/prism_app/tests/test_map_export_layer_catalog.py
@@ -14,6 +14,8 @@ from prism_app.map_export_layer_catalog import (
 def test_mozambique_schedule_layers_include_wms_with_coverage() -> None:
     ids = schedule_layer_ids("mozambique")
     assert "precip_blended_dekad" in ids
+    # Shared layer referenced in prism.json but not defined in country layers.json
+    assert "spi_2m" in ids
 
 
 def test_schedule_layer_wms_name_resolves_server_layer_name() -> None:

--- a/api/prism_app/tests/test_map_export_layer_catalog.py
+++ b/api/prism_app/tests/test_map_export_layer_catalog.py
@@ -33,11 +33,13 @@ def test_boundary_layers_are_not_schedule_eligible() -> None:
     assert "admin_boundaries" not in ids
 
 
-def test_schedule_layer_choices_sorted_and_non_empty() -> None:
+def test_schedule_layer_choices_follow_raw_layers_order() -> None:
+    """Manifest order matches frontend batch picker (country keys, then shared-only)."""
     choices = schedule_layer_choices("mozambique")
     assert len(choices) > 0
     ids = [layer_id for layer_id, _ in choices]
-    assert ids == sorted(ids)
+    assert ids[0] == "precip_blended_dekad"
+    assert ids != sorted(ids)
     assert "precip_blended_dekad" in schedule_layer_ids("mozambique")
 
 
@@ -70,6 +72,7 @@ def test_schedule_layer_choices_with_extra_includes_legacy_id() -> None:
         extra_layer_ids=("legacy_layer_xyz",),
     )
     assert ("legacy_layer_xyz", "legacy_layer_xyz") in choices
+    assert choices[-1] == ("legacy_layer_xyz", "legacy_layer_xyz")
 
 
 def test_schedule_layer_label_uses_country_manifest() -> None:

--- a/frontend/scripts/generate-schedule-layer-manifest.ts
+++ b/frontend/scripts/generate-schedule-layer-manifest.ts
@@ -33,12 +33,14 @@ const MANIFEST_PATH = path.join(
   '../../api/prism_app/data/schedule_layer_manifest.json',
 );
 
-/** All WMS hazard layers for a country (batch print may use server dates when config has none). */
+/** WMS layers eligible for batch print when server dates are not loaded yet. */
 function isScheduleEligibleLayer(layer: LayerConfig): boolean {
-  return layer.type === 'wms';
+  return (
+    layer.type === 'wms' && Boolean(layer.coverageWindow || layer.validity)
+  );
 }
 
-/** Merge shared + country layers; country keys win (see ``getRawLayers`` / backend catalog). */
+/** Same merge as ``getRawLayers`` (country → shared → country; country wins). */
 function mergedCountryLayers(country: string): Record<string, LayerConfig> {
   const countryPath = path.join(CONFIG_ROOT, country, 'layers.json');
   const sharedPath = path.join(CONFIG_ROOT, 'shared', 'layers.json');
@@ -51,12 +53,10 @@ function mergedCountryLayers(country: string): Record<string, LayerConfig> {
         LayerConfig
       >)
     : {};
-  const merged = { ...sharedLayers, ...countryLayers };
-  return Object.fromEntries(
-    Object.keys(countryLayers)
-      .filter(layerId => layerId in merged)
-      .map(layerId => [layerId, merged[layerId]]),
-  );
+  return merge({}, countryLayers, sharedLayers, countryLayers) as Record<
+    string,
+    LayerConfig
+  >;
 }
 
 function scheduleLayersForCountry(country: string): ManifestLayer[] {

--- a/frontend/scripts/generate-schedule-layer-manifest.ts
+++ b/frontend/scripts/generate-schedule-layer-manifest.ts
@@ -1,10 +1,12 @@
 /**
  * Build-time manifest of schedule-eligible WMS layers for map export admin.
- * All WMS layers per country (batch print may also use server-loaded dates).
+ * Mirrors the batch/scheduled map layer picker (`rawLayers` +
+ * `isWmsSelectableForBatchPrint` in PrintImage).
  *
  * Output: api/prism_app/data/schedule_layer_manifest.json
  */
 import fs from 'fs';
+import { merge } from 'lodash';
 import path from 'path';
 
 type LayerConfig = {

--- a/frontend/scripts/generate-schedule-layer-manifest.ts
+++ b/frontend/scripts/generate-schedule-layer-manifest.ts
@@ -59,6 +59,7 @@ function mergedCountryLayers(country: string): Record<string, LayerConfig> {
   >;
 }
 
+/** Preserve ``getRawLayers`` / ``LayerDefinitions`` key order (matching frontend). */
 function scheduleLayersForCountry(country: string): ManifestLayer[] {
   return Object.entries(mergedCountryLayers(country))
     .filter(([, layer]) => isScheduleEligibleLayer(layer))
@@ -68,8 +69,7 @@ function scheduleLayersForCountry(country: string): ManifestLayer[] {
       ...(layer.server_layer_name
         ? { server_layer_name: layer.server_layer_name }
         : {}),
-    }))
-    .sort((a, b) => a.id.localeCompare(b.id));
+    }));
 }
 
 const countryDirs = fs

--- a/frontend/src/components/NavBar/PrintImage/image.tsx
+++ b/frontend/src/components/NavBar/PrintImage/image.tsx
@@ -7,7 +7,7 @@ import {
 } from '@material-ui/core';
 import { usePostHog } from '@posthog/react';
 import mask from '@turf/mask';
-import { appConfig, configMap, safeCountry } from 'config';
+import { appConfig, rawLayers, safeCountry } from 'config';
 import { AdminCodeString, LayerKey } from 'config/types';
 import { getBoundaryLayerSingleton, LayerDefinitions } from 'config/utils';
 import {
@@ -198,9 +198,11 @@ function DownloadImage({ open, handleClose }: DownloadImageProps) {
   );
 
   const [isDownloading, setIsDownloading] = useState(false);
-  const countryLayerIds = new Set(
-    Object.keys(configMap[safeCountry].rawLayers),
-  );
+  // Use the merged layer set (shared + country-specific) so shared layers a
+  // country only references via prism.json categories — e.g. `days_dry` — are
+  // not excluded. `configMap[safeCountry].rawLayers` holds only the country's
+  // own layers.json and would drop every referenced shared layer.
+  const countryLayerIds = new Set(Object.keys(rawLayers));
   const availableDates = useSelector(availableDatesSelector);
   const selectableLayers = Object.values(LayerDefinitions).filter(
     (l): l is DateCompatibleLayer =>


### PR DESCRIPTION
### Description

Attempt to synchronize the layers in the layer_id dropdown in admin for scheduled maps. There are some edge cases where the frontend allows layers that aren't currently exposed in admin. For example:

`rainfall_daily` is not in the layer dropdown. When the user selects `rainfall_daily` as the map hazard, PRISM fetches WMS available dates and stores them in Redux. Open batch/scheduled maps again and `rainfall_daily` appears in the dropdown, because frontend sees dates in Redux and treats it as date-compatible.

In admin, `rainfall_daily` is not in schedule_layer_manifest.json, so the admin scheduled-map layer list won’t offer it unless it’s a legacy stored layer_id on an existing schedule.

## How to test the feature:

Follow steps from #1922 to create a scheduled with layer.

- [ ] View schedule in admin and ensure the layer dropdown is in the same order and has the same layers as the frontend

## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [ ] `REACT_APP_COUNTRY=rbd yarn start`
- [ ] `REACT_APP_COUNTRY=cambodia yarn start`
- [x] `REACT_APP_COUNTRY=mozambique yarn start`
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

