### PR TITLE
Fix RBD charts sending id_code=undefined for multi-country deployments; country=RDB

### DIFF
--- a/frontend/src/components/Common/ChartFormComponents/ChartLocationSelector.multicountry.test.tsx
+++ b/frontend/src/components/Common/ChartFormComponents/ChartLocationSelector.multicountry.test.tsx
@@ -90,7 +90,10 @@ jest.mock('@material-ui/core', () => {
 
 import ChartLocationSelector from './ChartLocationSelector';
 
-describe('ChartLocationSelector (multi-country / RBD)', () => {
+// Flat mode (no country dropdown): used by the Dashboard editor's ChartBlock,
+// which does not wire up onAdmin0Change. The two dropdowns collapse the country
+// into "Admin 1" but still resolve a valid id_code.
+describe('ChartLocationSelector (multi-country / RBD, no country dropdown)', () => {
   it('resolves a defined id_code when a country is selected', () => {
     const onAdmin1Change = jest.fn();
 
@@ -143,5 +146,115 @@ describe('ChartLocationSelector (multi-country / RBD)', () => {
     expect(level).toBe(1);
     expect(properties).not.toEqual({});
     expect(properties.dv_adm1_id).toBe(1927);
+  });
+});
+
+// Country-dropdown mode (used by the charts panel): wiring up onAdmin0Change
+// surfaces a dedicated Country dropdown so the hierarchy is Country -> Admin 1
+// -> Admin 2 with chart levels 0/1/2. This guards the regression where the
+// country level was dropped and the dropdowns were mislabeled.
+describe('ChartLocationSelector (multi-country / RBD, with country dropdown)', () => {
+  it('shows a dedicated Country dropdown listing all countries', () => {
+    const { container } = render(
+      <ChartLocationSelector
+        boundaryLayerData={BOUNDARY_DATA}
+        boundaryLayer={BOUNDARY_LAYER}
+        admin0Key={'' as any}
+        admin1Key={'' as any}
+        admin2Key={'' as any}
+        onAdmin0Change={jest.fn()}
+        onAdmin1Change={jest.fn()}
+        onAdmin2Change={jest.fn()}
+      />,
+    );
+
+    const [countrySelect] = container.querySelectorAll('select');
+    const optionValues = Array.from(
+      countrySelect.querySelectorAll('option'),
+    ).map(o => (o as HTMLOptionElement).value);
+
+    // The first dropdown lists countries (not admin-1 areas).
+    expect(optionValues).toEqual(expect.arrayContaining(['ML', 'BF']));
+  });
+
+  it('resolves the country at chart level 0', () => {
+    const onAdmin0Change = jest.fn();
+
+    const { container } = render(
+      <ChartLocationSelector
+        boundaryLayerData={BOUNDARY_DATA}
+        boundaryLayer={BOUNDARY_LAYER}
+        admin0Key={'' as any}
+        admin1Key={'' as any}
+        admin2Key={'' as any}
+        onAdmin0Change={onAdmin0Change}
+        onAdmin1Change={jest.fn()}
+        onAdmin2Change={jest.fn()}
+      />,
+    );
+
+    const [countrySelect] = container.querySelectorAll('select');
+    fireEvent.change(countrySelect, { target: { value: 'ML' } });
+
+    expect(onAdmin0Change).toHaveBeenCalledTimes(1);
+    const [code, properties, level] = onAdmin0Change.mock.calls[0];
+    expect(code).toBe('ML');
+    expect(level).toBe(0);
+    expect(properties.dv_adm0_id).toBe(155);
+  });
+
+  it('resolves admin 1 at chart level 1 under the selected country', () => {
+    const onAdmin1Change = jest.fn();
+
+    const { container } = render(
+      <ChartLocationSelector
+        boundaryLayerData={BOUNDARY_DATA}
+        boundaryLayer={BOUNDARY_LAYER}
+        admin0Key={'ML' as any}
+        admin1Key={'' as any}
+        admin2Key={'' as any}
+        onAdmin0Change={jest.fn()}
+        onAdmin1Change={onAdmin1Change}
+        onAdmin2Change={jest.fn()}
+      />,
+    );
+
+    // [country, admin1]
+    const selects = container.querySelectorAll('select');
+    fireEvent.change(selects[1], { target: { value: 'ML07' } });
+
+    expect(onAdmin1Change).toHaveBeenCalledTimes(1);
+    const [code, properties, level] = onAdmin1Change.mock.calls[0];
+    expect(code).toBe('ML07');
+    expect(level).toBe(1);
+    expect(properties.dv_adm1_id).toBe(1927);
+  });
+
+  it('resolves admin 2 at chart level 2 under the selected admin 1', () => {
+    const onAdmin2Change = jest.fn();
+
+    const { container } = render(
+      <ChartLocationSelector
+        boundaryLayerData={BOUNDARY_DATA}
+        boundaryLayer={BOUNDARY_LAYER}
+        admin0Key={'ML' as any}
+        admin1Key={'ML07' as any}
+        admin2Key={'' as any}
+        onAdmin0Change={jest.fn()}
+        onAdmin1Change={jest.fn()}
+        onAdmin2Change={onAdmin2Change}
+      />,
+    );
+
+    // [country, admin1, admin2]
+    const selects = container.querySelectorAll('select');
+    expect(selects.length).toBe(3);
+    fireEvent.change(selects[2], { target: { value: 'ML0701' } });
+
+    expect(onAdmin2Change).toHaveBeenCalledTimes(1);
+    const [code, properties, level] = onAdmin2Change.mock.calls[0];
+    expect(code).toBe('ML0701');
+    expect(level).toBe(2);
+    expect(properties.dv_adm2_id).toBe(19375);
   });
 });

--- a/frontend/src/components/Common/ChartFormComponents/ChartLocationSelector.multicountry.test.tsx
+++ b/frontend/src/components/Common/ChartFormComponents/ChartLocationSelector.multicountry.test.tsx
@@ -1,0 +1,147 @@
+/**
+ * Regression test for the RBD (multi-country) charts bug where selecting a
+ * location produced a request with `id_code=undefined`.
+ *
+ * The chart pipeline reads the admin code from the boundary feature properties
+ * that the selector resolves (via getProperties) for the chosen admin level.
+ * In multi-country deployments the "Admin 1" dropdown is actually the country
+ * (chart level 0) and "Admin 2" is admin 1 (chart level 1); passing the
+ * single-country levels (1, 2) made getProperties return {} and the id_code
+ * came out undefined.
+ */
+import { fireEvent, render } from '@testing-library/react';
+import { BoundaryLayerProps } from 'config/types';
+
+// RBD-shaped boundary layer: includes admin 0 (country) as the first level.
+const BOUNDARY_LAYER = {
+  id: 'admin_boundaries',
+  adminCode: 'admin2Pcod',
+  adminLevelCodes: ['admin0Pcod', 'admin1Pcod', 'admin2Pcod'],
+  adminLevelNames: ['admin0Name', 'admin1Name', 'admin2Name'],
+  adminLevelLocalNames: ['admin0Name', 'admin1Name', 'admin2Name'],
+} as unknown as BoundaryLayerProps;
+
+const BOUNDARY_DATA = {
+  features: [
+    {
+      properties: {
+        admin0Pcod: 'ML',
+        admin0Name: 'Mali',
+        admin1Pcod: 'ML07',
+        admin1Name: 'Gao',
+        admin2Pcod: 'ML0701',
+        admin2Name: 'Ansongo',
+        dv_adm0_id: 155,
+        dv_adm1_id: 1927,
+        dv_adm2_id: 19375,
+      },
+    },
+    {
+      properties: {
+        admin0Pcod: 'BF',
+        admin0Name: 'Burkina Faso',
+        admin1Pcod: 'BF46',
+        admin1Name: 'Centre',
+        admin2Pcod: 'BF4601',
+        admin2Name: 'Kadiogo',
+        dv_adm0_id: 42,
+        dv_adm1_id: 900,
+        dv_adm2_id: 9001,
+      },
+    },
+  ],
+} as any;
+
+// Force a multi-country deployment regardless of the test runner's COUNTRY.
+jest.mock('config', () => {
+  const actual = jest.requireActual('config');
+  return {
+    ...actual,
+    appConfig: { ...actual.appConfig, multiCountry: true },
+  };
+});
+jest.mock('config/utils', () => ({
+  ...jest.requireActual('config/utils'),
+  getBoundaryLayersByAdminLevel: () => BOUNDARY_LAYER,
+}));
+
+// The global test setup stubs Material-UI components to strings, which makes
+// the <TextField select> impossible to interact with. Replace the few pieces
+// this component uses with native equivalents so onChange actually fires.
+jest.mock('@material-ui/core', () => {
+  const React = require('react');
+  const actual = jest.requireActual('@material-ui/core');
+  return {
+    ...actual,
+    Box: ({ children }: any) =>
+      React.createElement(React.Fragment, null, children),
+    Typography: ({ children }: any) =>
+      React.createElement('div', null, children),
+    MenuItem: ({ value, children }: any) =>
+      React.createElement('option', { value }, children),
+    TextField: ({ label, value, onChange, children }: any) =>
+      React.createElement(
+        'select',
+        { 'aria-label': label, value: value ?? '', onChange },
+        children,
+      ),
+  };
+});
+
+import ChartLocationSelector from './ChartLocationSelector';
+
+describe('ChartLocationSelector (multi-country / RBD)', () => {
+  it('resolves a defined id_code when a country is selected', () => {
+    const onAdmin1Change = jest.fn();
+
+    const { container } = render(
+      <ChartLocationSelector
+        boundaryLayerData={BOUNDARY_DATA}
+        boundaryLayer={BOUNDARY_LAYER}
+        admin1Key={'' as any}
+        admin2Key={'' as any}
+        onAdmin1Change={onAdmin1Change}
+        onAdmin2Change={jest.fn()}
+      />,
+    );
+
+    // First (and only) dropdown is the country/"Admin 1" selector.
+    const [admin1Select] = container.querySelectorAll('select');
+    fireEvent.change(admin1Select, { target: { value: 'ML' } });
+
+    expect(onAdmin1Change).toHaveBeenCalledTimes(1);
+    const [code, properties, level] = onAdmin1Change.mock.calls[0];
+    expect(code).toBe('ML');
+    // Country selection => chart level 0, not 1.
+    expect(level).toBe(0);
+    // The regression: these were undefined because getProperties returned {}.
+    expect(properties).not.toEqual({});
+    expect(properties.dv_adm0_id).toBe(155);
+  });
+
+  it('resolves a defined id_code when an admin 1 area is selected', () => {
+    const onAdmin2Change = jest.fn();
+
+    const { container } = render(
+      <ChartLocationSelector
+        boundaryLayerData={BOUNDARY_DATA}
+        boundaryLayer={BOUNDARY_LAYER}
+        admin1Key={'ML' as any}
+        admin2Key={'' as any}
+        onAdmin1Change={jest.fn()}
+        onAdmin2Change={onAdmin2Change}
+      />,
+    );
+
+    // With a country selected, the second dropdown is the admin-1 selector.
+    const selects = container.querySelectorAll('select');
+    fireEvent.change(selects[1], { target: { value: 'ML07' } });
+
+    expect(onAdmin2Change).toHaveBeenCalledTimes(1);
+    const [code, properties, level] = onAdmin2Change.mock.calls[0];
+    expect(code).toBe('ML07');
+    expect(level).toBe(1);
+    expect(properties).not.toEqual({});
+    expect(properties.dv_adm1_id).toBe(1927);
+  });
+});

--- a/frontend/src/components/Common/ChartFormComponents/ChartLocationSelector.singlecountry.test.tsx
+++ b/frontend/src/components/Common/ChartFormComponents/ChartLocationSelector.singlecountry.test.tsx
@@ -42,8 +42,15 @@ const BOUNDARY_DATA = {
   ],
 } as any;
 
-// No `config` mock here: the test runner's default deployment is
-// single-country (multiCountry === false).
+// Force a single-country deployment regardless of the test runner's COUNTRY.
+jest.mock('config', () => {
+  const actual = jest.requireActual('config');
+  return {
+    ...actual,
+    appConfig: { ...actual.appConfig, multiCountry: false },
+  };
+});
+
 jest.mock('config/utils', () => ({
   ...jest.requireActual('config/utils'),
   getBoundaryLayersByAdminLevel: () => BOUNDARY_LAYER,

--- a/frontend/src/components/Common/ChartFormComponents/ChartLocationSelector.singlecountry.test.tsx
+++ b/frontend/src/components/Common/ChartFormComponents/ChartLocationSelector.singlecountry.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * Single-country counterpart to ChartLocationSelector.multicountry.test.tsx.
+ *
+ * Confirms the dropdowns keep mapping to the 1-based admin levels (admin 1 =>
+ * level 1, admin 2 => level 2) that single-country deployments expect, so the
+ * multi-country fix doesn't regress the common case.
+ */
+import { fireEvent, render } from '@testing-library/react';
+import { BoundaryLayerProps } from 'config/types';
+
+// Single-country boundary layer: starts at admin 1 (no country level).
+const BOUNDARY_LAYER = {
+  id: 'admin_boundaries',
+  adminCode: 'admin2Pcod',
+  adminLevelCodes: ['admin1Pcod', 'admin2Pcod'],
+  adminLevelNames: ['admin1Name', 'admin2Name'],
+  adminLevelLocalNames: ['admin1Name', 'admin2Name'],
+} as unknown as BoundaryLayerProps;
+
+const BOUNDARY_DATA = {
+  features: [
+    {
+      properties: {
+        admin1Pcod: 'KH1',
+        admin1Name: 'Banteay Meanchey',
+        admin2Pcod: 'KH101',
+        admin2Name: 'Mongkol Borei',
+        dataviz_adm1_id: 11,
+        dataviz_adm2_id: 1101,
+      },
+    },
+    {
+      properties: {
+        admin1Pcod: 'KH2',
+        admin1Name: 'Battambang',
+        admin2Pcod: 'KH201',
+        admin2Name: 'Banan',
+        dataviz_adm1_id: 12,
+        dataviz_adm2_id: 1201,
+      },
+    },
+  ],
+} as any;
+
+// No `config` mock here: the test runner's default deployment is
+// single-country (multiCountry === false).
+jest.mock('config/utils', () => ({
+  ...jest.requireActual('config/utils'),
+  getBoundaryLayersByAdminLevel: () => BOUNDARY_LAYER,
+}));
+
+jest.mock('@material-ui/core', () => {
+  const React = require('react');
+  const actual = jest.requireActual('@material-ui/core');
+  return {
+    ...actual,
+    Box: ({ children }: any) =>
+      React.createElement(React.Fragment, null, children),
+    Typography: ({ children }: any) =>
+      React.createElement('div', null, children),
+    MenuItem: ({ value, children }: any) =>
+      React.createElement('option', { value }, children),
+    TextField: ({ label, value, onChange, children }: any) =>
+      React.createElement(
+        'select',
+        { 'aria-label': label, value: value ?? '', onChange },
+        children,
+      ),
+  };
+});
+
+import ChartLocationSelector from './ChartLocationSelector';
+
+describe('ChartLocationSelector (single-country)', () => {
+  it('maps the admin 1 dropdown to chart level 1', () => {
+    const onAdmin1Change = jest.fn();
+
+    const { container } = render(
+      <ChartLocationSelector
+        boundaryLayerData={BOUNDARY_DATA}
+        boundaryLayer={BOUNDARY_LAYER}
+        admin1Key={'' as any}
+        admin2Key={'' as any}
+        onAdmin1Change={onAdmin1Change}
+        onAdmin2Change={jest.fn()}
+      />,
+    );
+
+    const [admin1Select] = container.querySelectorAll('select');
+    fireEvent.change(admin1Select, { target: { value: 'KH1' } });
+
+    expect(onAdmin1Change).toHaveBeenCalledTimes(1);
+    const [code, properties, level] = onAdmin1Change.mock.calls[0];
+    expect(code).toBe('KH1');
+    expect(level).toBe(1);
+    expect(properties).not.toEqual({});
+    expect(properties.dataviz_adm1_id).toBe(11);
+  });
+
+  it('maps the admin 2 dropdown to chart level 2', () => {
+    const onAdmin2Change = jest.fn();
+
+    const { container } = render(
+      <ChartLocationSelector
+        boundaryLayerData={BOUNDARY_DATA}
+        boundaryLayer={BOUNDARY_LAYER}
+        admin1Key={'KH1' as any}
+        admin2Key={'' as any}
+        onAdmin1Change={jest.fn()}
+        onAdmin2Change={onAdmin2Change}
+      />,
+    );
+
+    const selects = container.querySelectorAll('select');
+    fireEvent.change(selects[1], { target: { value: 'KH101' } });
+
+    expect(onAdmin2Change).toHaveBeenCalledTimes(1);
+    const [code, properties, level] = onAdmin2Change.mock.calls[0];
+    expect(code).toBe('KH101');
+    expect(level).toBe(2);
+    expect(properties).not.toEqual({});
+    expect(properties.dataviz_adm2_id).toBe(1101);
+  });
+});

--- a/frontend/src/components/Common/ChartFormComponents/ChartLocationSelector.tsx
+++ b/frontend/src/components/Common/ChartFormComponents/ChartLocationSelector.tsx
@@ -10,6 +10,7 @@ import {
   getAdminBoundaryTree,
 } from 'components/MapView/Layers/BoundaryDropdown/utils';
 import { getProperties } from 'components/MapView/utils';
+import { appConfig } from 'config';
 import {
   AdminCodeString,
   AdminLevelType,
@@ -57,6 +58,14 @@ function ChartLocationSelector({
   const classes = useStyles();
   const { t, i18n: i18nLocale } = useSafeTranslation();
 
+  // The chart `levels` config (and getProperties) uses a 0-based admin level
+  // for multi-country deployments (level 0 = country) and a 1-based level for
+  // single-country deployments (level 1 = admin 1). The two dropdowns below
+  // therefore map to different admin levels depending on the deployment.
+  const { multiCountry } = appConfig;
+  const admin1Level = (multiCountry ? 0 : 1) as AdminLevelType;
+  const admin2Level = (multiCountry ? 1 : 2) as AdminLevelType;
+
   if (!boundaryLayerData) {
     return null;
   }
@@ -102,8 +111,8 @@ function ChartLocationSelector({
     }
 
     const admin1Id = value as AdminCodeString;
-    const properties = getProperties(boundaryLayerData, admin1Id, 1);
-    onAdmin1Change(admin1Id, properties, 1);
+    const properties = getProperties(boundaryLayerData, admin1Id, admin1Level);
+    onAdmin1Change(admin1Id, properties, admin1Level);
   };
 
   const handleAdmin2Change = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -111,14 +120,18 @@ function ChartLocationSelector({
 
     if (!value) {
       // Clear Admin 2 selection - go back to Admin 1 level
-      const properties = getProperties(boundaryLayerData, admin1Key, 1);
-      onAdmin2Change('' as AdminCodeString, properties, 1);
+      const properties = getProperties(
+        boundaryLayerData,
+        admin1Key,
+        admin1Level,
+      );
+      onAdmin2Change('' as AdminCodeString, properties, admin1Level);
       return;
     }
 
     const admin2Id = value as AdminCodeString;
-    const properties = getProperties(boundaryLayerData, admin2Id, 2);
-    onAdmin2Change(admin2Id, properties, 2);
+    const properties = getProperties(boundaryLayerData, admin2Id, admin2Level);
+    onAdmin2Change(admin2Id, properties, admin2Level);
   };
 
   const renderMenuItemList = (trees: AdminBoundaryTree[]) =>

--- a/frontend/src/components/Common/ChartFormComponents/ChartLocationSelector.tsx
+++ b/frontend/src/components/Common/ChartFormComponents/ChartLocationSelector.tsx
@@ -25,8 +25,14 @@ import React from 'react';
 interface ChartLocationSelectorProps {
   boundaryLayerData: BoundaryLayerData | undefined;
   boundaryLayer: BoundaryLayerProps;
+  admin0Key?: AdminCodeString;
   admin1Key: AdminCodeString;
   admin2Key: AdminCodeString;
+  onAdmin0Change?: (
+    key: AdminCodeString,
+    properties: GeoJsonProperties,
+    adminLevel: AdminLevelType,
+  ) => void;
   onAdmin1Change: (
     key: AdminCodeString,
     properties: GeoJsonProperties,
@@ -46,8 +52,10 @@ interface ChartLocationSelectorProps {
 function ChartLocationSelector({
   boundaryLayerData,
   boundaryLayer,
+  admin0Key = '' as AdminCodeString,
   admin1Key,
   admin2Key,
+  onAdmin0Change,
   onAdmin1Change,
   onAdmin2Change,
   disabled = false,
@@ -58,13 +66,24 @@ function ChartLocationSelector({
   const classes = useStyles();
   const { t, i18n: i18nLocale } = useSafeTranslation();
 
-  // The chart `levels` config (and getProperties) uses a 0-based admin level
-  // for multi-country deployments (level 0 = country) and a 1-based level for
-  // single-country deployments (level 1 = admin 1). The two dropdowns below
-  // therefore map to different admin levels depending on the deployment.
+  // In multi-country deployments the boundary hierarchy starts at the country
+  // (admin 0). When a consumer wires up `onAdmin0Change` we surface a dedicated
+  // Country dropdown, and the chart levels line up directly with the hierarchy:
+  // 0 = country, 1 = admin 1, 2 = admin 2.
+  //
+  // Otherwise we keep the flat two-dropdown behaviour and absorb the
+  // multi-country offset in the level math (the chart `levels` config and
+  // getProperties treat multi-country as 0-based and single-country as 1-based).
   const { multiCountry } = appConfig;
-  const admin1Level = (multiCountry ? 0 : 1) as AdminLevelType;
-  const admin2Level = (multiCountry ? 1 : 2) as AdminLevelType;
+  const showCountryLevel = multiCountry && Boolean(onAdmin0Change);
+
+  const admin1Level = (
+    showCountryLevel ? 1 : multiCountry ? 0 : 1
+  ) as AdminLevelType;
+
+  const admin2Level = (
+    showCountryLevel ? 2 : multiCountry ? 1 : 2
+  ) as AdminLevelType;
 
   if (!boundaryLayerData) {
     return null;
@@ -76,36 +95,78 @@ function ChartLocationSelector({
     i18nLocale,
   );
 
-  const admin0BoundaryTree = adminBoundaryTree.children;
-
-  const orderedAdmin1Areas: AdminBoundaryTree[] = boundaryLayerData
-    ? sortBy(Object.values(admin0BoundaryTree), 'label')
+  // Countries are only selectable when the country dropdown is shown.
+  const orderedCountries: AdminBoundaryTree[] = showCountryLevel
+    ? sortBy(Object.values(adminBoundaryTree.children), 'label')
     : [];
+  const selectedCountry = showCountryLevel
+    ? adminBoundaryTree.children[admin0Key]
+    : undefined;
 
-  const selectedAdmin1Area = admin0BoundaryTree?.[admin1Key];
+  // Admin 1 areas live under the selected country (multi-country) or at the top
+  // level of the tree (single-country / flat mode).
+  const admin1ParentTree: { [code: string]: AdminBoundaryTree } =
+    showCountryLevel
+      ? (selectedCountry?.children ?? {})
+      : adminBoundaryTree.children;
+
+  const orderedAdmin1Areas: AdminBoundaryTree[] = sortBy(
+    Object.values(admin1ParentTree),
+    'label',
+  );
+
+  const selectedAdmin1Area = admin1ParentTree[admin1Key];
 
   const orderedAdmin2Areas: AdminBoundaryTree[] =
-    boundaryLayerData && admin1Key && selectedAdmin1Area
+    admin1Key && selectedAdmin1Area
       ? sortBy(Object.values(selectedAdmin1Area.children), 'label')
       : [];
 
   const selectedAdmin2Area = selectedAdmin1Area?.children[admin2Key];
 
+  const renderCountryValue = (countryKeyValue: any) =>
+    adminBoundaryTree.children[countryKeyValue]?.label;
+
   const renderAdmin1Value = (admin1keyValue: any) =>
-    admin0BoundaryTree[admin1keyValue]?.label;
+    admin1ParentTree[admin1keyValue]?.label;
 
   const renderAdmin2Value = (admin2KeyValue: any) =>
     selectedAdmin1Area?.children[admin2KeyValue]?.label;
+
+  const handleCountryChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const { value } = event.target;
+
+    if (!value) {
+      onAdmin0Change?.(
+        '' as AdminCodeString,
+        getProperties(boundaryLayerData),
+        0 as AdminLevelType,
+      );
+      return;
+    }
+
+    const admin0Id = value as AdminCodeString;
+    const properties = getProperties(
+      boundaryLayerData,
+      admin0Id,
+      0 as AdminLevelType,
+    );
+    onAdmin0Change?.(admin0Id, properties, 0 as AdminLevelType);
+  };
 
   const handleAdmin1Change = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = event.target;
 
     if (!value) {
-      // Clear selection - go back to country level
+      // Clear Admin 1 - fall back to the country level (multi-country) or the
+      // country aggregate (single-country).
+      const fallbackProperties = showCountryLevel
+        ? getProperties(boundaryLayerData, admin0Key, 0 as AdminLevelType)
+        : getProperties(boundaryLayerData);
       onAdmin1Change(
         '' as AdminCodeString,
-        getProperties(boundaryLayerData),
-        0,
+        fallbackProperties,
+        0 as AdminLevelType,
       );
       return;
     }
@@ -157,6 +218,23 @@ function ChartLocationSelector({
         className={classes.fieldsRow}
         style={{ flexDirection: stacked ? 'column' : 'row' }}
       >
+        {showCountryLevel && (
+          <TextField
+            classes={{ root: classes.selectRoot }}
+            select
+            label={t('Country')}
+            value={selectedCountry?.adminCode ?? ''}
+            SelectProps={{
+              renderValue: renderCountryValue,
+            }}
+            onChange={handleCountryChange}
+            variant="outlined"
+            disabled={disabled || orderedCountries.length === 0}
+          >
+            {renderMenuItemList(orderedCountries)}
+          </TextField>
+        )}
+
         <TextField
           classes={{ root: classes.selectRoot }}
           select
@@ -170,7 +248,9 @@ function ChartLocationSelector({
           disabled={disabled || orderedAdmin1Areas.length === 0}
         >
           <MenuItem value="">
-            <Box className={classes.removeAdmin}>{t('Country Level')}</Box>
+            <Box className={classes.removeAdmin}>
+              {showCountryLevel ? t('Remove Admin 1') : t('Country Level')}
+            </Box>
           </MenuItem>
           {renderMenuItemList(orderedAdmin1Areas)}
         </TextField>

--- a/frontend/src/components/DashboardView/ChartBlock.tsx
+++ b/frontend/src/components/DashboardView/ChartBlock.tsx
@@ -176,15 +176,16 @@ function ChartBlock({
   };
 
   const handleLocationChange = (
+    admin0Key: AdminCodeString,
     admin1Key: AdminCodeString,
     admin2Key: AdminCodeString,
     properties: GeoJsonProperties,
     level: AdminLevelType,
   ) => {
-    formState.setLocation(admin1Key, admin2Key, properties, level);
+    formState.setLocation(admin0Key, admin1Key, admin2Key, properties, level);
     persistBlockConfig({
       adminUnitLevel: level,
-      adminUnitId: adminUnitIdFromKeys(admin1Key, admin2Key, level),
+      adminUnitId: adminUnitIdFromKeys(admin0Key, admin1Key, admin2Key, level),
     });
   };
 
@@ -491,11 +492,22 @@ function ChartBlock({
           <ChartLocationSelector
             boundaryLayerData={formState.boundaryLayerData?.data}
             boundaryLayer={formState.boundaryLayer}
+            admin0Key={formState.admin0Key}
             admin1Key={formState.admin1Key}
             admin2Key={formState.admin2Key}
             labelMarginBottom={8}
+            onAdmin0Change={(key, properties, level) => {
+              handleLocationChange(
+                key,
+                '' as AdminCodeString,
+                '' as AdminCodeString,
+                properties,
+                level,
+              );
+            }}
             onAdmin1Change={(key, properties, level) => {
               handleLocationChange(
+                formState.admin0Key,
                 key,
                 '' as AdminCodeString,
                 properties,
@@ -503,7 +515,13 @@ function ChartBlock({
               );
             }}
             onAdmin2Change={(key, properties, level) => {
-              handleLocationChange(formState.admin1Key, key, properties, level);
+              handleLocationChange(
+                formState.admin0Key,
+                formState.admin1Key,
+                key,
+                properties,
+                level,
+              );
             }}
           />
           <FormControl variant="outlined" className={classes.formControl}>

--- a/frontend/src/components/MapView/LeftPanel/ChartsPanel/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/ChartsPanel/index.tsx
@@ -79,6 +79,18 @@ const MAX_ADMIN_LEVEL = multiCountry ? 3 : 2;
 const boundaryLayer = getBoundaryLayersByAdminLevel(MAX_ADMIN_LEVEL);
 const chartLayers = getWMSLayersWithChart();
 
+// Resolves the admin area name for a chart level from boundary feature
+// properties. Multi-country deployments use 0-based levels (level 0 = country),
+// single-country deployments use 1-based levels (level 1 = admin 1).
+const getAdminAreaName = (
+  properties: GeoJsonProperties,
+  level: AdminLevelType,
+): string => {
+  const nameKey =
+    boundaryLayer?.adminLevelNames?.[level - (multiCountry ? 0 : 1)];
+  return (nameKey && properties?.[nameKey]) || '';
+};
+
 // Time constants
 const yearsToFetchDataFor = 5;
 const oneYearInTicks = 34;
@@ -669,22 +681,18 @@ const ChartsPanel = memo(() => {
                 setAdmin2Key('' as AdminCodeString);
                 setAdminLevel(level);
                 setAdminProperties(properties);
-                const admin1Name =
-                  data &&
-                  boundaryLayer?.adminLevelNames?.[level - 1] &&
-                  properties?.[boundaryLayer.adminLevelNames[level - 1]];
-                setSelectedAdmin1Area(admin1Name || '');
+                setSelectedAdmin1Area(
+                  data ? getAdminAreaName(properties, level) : '',
+                );
                 setSelectedAdmin2Area('');
               }}
               onAdmin2Change={(key, properties, level) => {
                 setAdmin2Key(key);
                 setAdminLevel(level);
                 setAdminProperties(properties);
-                const admin2Name =
-                  data &&
-                  boundaryLayer?.adminLevelNames?.[level - 1] &&
-                  properties?.[boundaryLayer.adminLevelNames[level - 1]];
-                setSelectedAdmin2Area(admin2Name || '');
+                setSelectedAdmin2Area(
+                  data ? getAdminAreaName(properties, level) : '',
+                );
               }}
             />
           </Box>
@@ -713,22 +721,18 @@ const ChartsPanel = memo(() => {
                   setSecondAdmin2Key('' as AdminCodeString);
                   setSecondAdminLevel(level);
                   setSecondAdminProperties(properties);
-                  const admin1Name =
-                    data &&
-                    boundaryLayer?.adminLevelNames?.[level - 1] &&
-                    properties?.[boundaryLayer.adminLevelNames[level - 1]];
-                  setSecondSelectedAdmin1Area(admin1Name || '');
+                  setSecondSelectedAdmin1Area(
+                    data ? getAdminAreaName(properties, level) : '',
+                  );
                   setSecondSelectedAdmin2Area('');
                 }}
                 onAdmin2Change={(key, properties, level) => {
                   setSecondAdmin2Key(key);
                   setSecondAdminLevel(level);
                   setSecondAdminProperties(properties);
-                  const admin2Name =
-                    data &&
-                    boundaryLayer?.adminLevelNames?.[level - 1] &&
-                    properties?.[boundaryLayer.adminLevelNames[level - 1]];
-                  setSecondSelectedAdmin2Area(admin2Name || '');
+                  setSecondSelectedAdmin2Area(
+                    data ? getAdminAreaName(properties, level) : '',
+                  );
                 }}
               />
             </Box>

--- a/frontend/src/components/MapView/LeftPanel/ChartsPanel/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/ChartsPanel/index.tsx
@@ -697,7 +697,7 @@ const ChartsPanel = memo(() => {
                 setAdminLevel(level);
                 setAdminProperties(properties);
                 setSelectedAdmin1Area(
-                  data ? getAdminAreaName(properties, level) : '',
+                  key && data ? getAdminAreaName(properties, level) : '',
                 );
                 setSelectedAdmin2Area('');
               }}
@@ -706,7 +706,7 @@ const ChartsPanel = memo(() => {
                 setAdminLevel(level);
                 setAdminProperties(properties);
                 setSelectedAdmin2Area(
-                  data ? getAdminAreaName(properties, level) : '',
+                  key && data ? getAdminAreaName(properties, level) : '',
                 );
               }}
             />
@@ -747,7 +747,7 @@ const ChartsPanel = memo(() => {
                   setSecondAdminLevel(level);
                   setSecondAdminProperties(properties);
                   setSecondSelectedAdmin1Area(
-                    data ? getAdminAreaName(properties, level) : '',
+                    key && data ? getAdminAreaName(properties, level) : '',
                   );
                   setSecondSelectedAdmin2Area('');
                 }}
@@ -756,7 +756,7 @@ const ChartsPanel = memo(() => {
                   setSecondAdminLevel(level);
                   setSecondAdminProperties(properties);
                   setSecondSelectedAdmin2Area(
-                    data ? getAdminAreaName(properties, level) : '',
+                    key && data ? getAdminAreaName(properties, level) : '',
                   );
                 }}
               />

--- a/frontend/src/components/MapView/LeftPanel/ChartsPanel/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/ChartsPanel/index.tsx
@@ -104,7 +104,9 @@ const ChartsPanel = memo(() => {
   const [comparePeriods, setComparePeriods] = useState(false);
 
   // first location state
-  const [admin0Key] = useState<AdminCodeString>('' as AdminCodeString);
+  const [admin0Key, setAdmin0Key] = useState<AdminCodeString>(
+    '' as AdminCodeString,
+  );
   const [admin1Key, setAdmin1Key] = useState<AdminCodeString>(
     '' as AdminCodeString,
   );
@@ -546,6 +548,9 @@ const ChartsPanel = memo(() => {
     // reset the admin level
     setAdminLevel((countryAdmin0Id ? 0 : 1) as AdminLevelType);
     setSecondAdminLevel((countryAdmin0Id ? 0 : 1) as AdminLevelType);
+    // reset the country selection (multi-country deployments)
+    setAdmin0Key('' as AdminCodeString);
+    setSecondAdmin0Key('' as AdminCodeString);
     // reset admin 1 titles
     setAdmin1Key('' as AdminCodeString);
     setSecondAdmin1Key('' as AdminCodeString);
@@ -672,10 +677,20 @@ const ChartsPanel = memo(() => {
             <ChartLocationSelector
               boundaryLayerData={data}
               boundaryLayer={boundaryLayer}
+              admin0Key={admin0Key}
               admin1Key={admin1Key}
               admin2Key={admin2Key}
               stacked
               hideLabel={compareLocations}
+              onAdmin0Change={(key, properties, level) => {
+                setAdmin0Key(key);
+                setAdmin1Key('' as AdminCodeString);
+                setAdmin2Key('' as AdminCodeString);
+                setAdminLevel(level);
+                setAdminProperties(properties);
+                setSelectedAdmin1Area('');
+                setSelectedAdmin2Area('');
+              }}
               onAdmin1Change={(key, properties, level) => {
                 setAdmin1Key(key);
                 setAdmin2Key('' as AdminCodeString);
@@ -712,10 +727,20 @@ const ChartsPanel = memo(() => {
               <ChartLocationSelector
                 boundaryLayerData={data}
                 boundaryLayer={boundaryLayer}
+                admin0Key={secondAdmin0Key}
                 admin1Key={secondAdmin1Key}
                 admin2Key={secondAdmin2Key}
                 stacked
                 hideLabel
+                onAdmin0Change={(key, properties, level) => {
+                  setSecondAdmin0Key(key);
+                  setSecondAdmin1Key('' as AdminCodeString);
+                  setSecondAdmin2Key('' as AdminCodeString);
+                  setSecondAdminLevel(level);
+                  setSecondAdminProperties(properties);
+                  setSecondSelectedAdmin1Area('');
+                  setSecondSelectedAdmin2Area('');
+                }}
                 onAdmin1Change={(key, properties, level) => {
                   setSecondAdmin1Key(key);
                   setSecondAdmin2Key('' as AdminCodeString);

--- a/frontend/src/utils/chart-hooks.multicountry.test.ts
+++ b/frontend/src/utils/chart-hooks.multicountry.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Regression tests for the dashboard chart persistence/restore encoding in
+ * multi-country (RBD) deployments.
+ *
+ * The bug: a country selection was persisted as "admin unit at level 1", so on
+ * restore getProperties looked up the wrong admin level code, returned {}, and
+ * the chart request went out with id_code=undefined. These tests lock in the
+ * country (0) -> admin 1 (1) -> admin 2 (2) round trip.
+ */
+const ADMIN_LEVEL_CODES = ['admin0Pcod', 'admin1Pcod', 'admin2Pcod'];
+
+// Force a multi-country deployment regardless of the test runner's COUNTRY.
+jest.mock('config', () => {
+  const actual = jest.requireActual('config');
+  return {
+    ...actual,
+    appConfig: { ...actual.appConfig, multiCountry: true, countryAdmin0Id: '' },
+  };
+});
+jest.mock('config/utils', () => ({
+  ...jest.requireActual('config/utils'),
+  getBoundaryLayersByAdminLevel: () => ({
+    id: 'admin_boundaries',
+    adminCode: 'admin2Pcod',
+    adminLevelCodes: ADMIN_LEVEL_CODES,
+    adminLevelNames: ['admin0Name', 'admin1Name', 'admin2Name'],
+    adminLevelLocalNames: ['admin0Name', 'admin1Name', 'admin2Name'],
+  }),
+}));
+
+import { AdminCodeString, AdminLevelType } from 'config/types';
+
+import {
+  adminUnitIdFromKeys,
+  deriveAdminKeysFromProperties,
+} from './chart-hooks';
+
+const code = (v: string) => v as AdminCodeString;
+const level = (v: number) => v as AdminLevelType;
+
+describe('adminUnitIdFromKeys (multi-country)', () => {
+  it('persists the country code at level 0', () => {
+    expect(adminUnitIdFromKeys(code('ML'), code(''), code(''), level(0))).toBe(
+      'ML',
+    );
+  });
+
+  it('persists the admin 1 code at level 1', () => {
+    expect(
+      adminUnitIdFromKeys(code('ML'), code('ML07'), code(''), level(1)),
+    ).toBe('ML07');
+  });
+
+  it('persists the admin 2 code at level 2', () => {
+    expect(
+      adminUnitIdFromKeys(code('ML'), code('ML07'), code('ML0701'), level(2)),
+    ).toBe('ML0701');
+  });
+});
+
+describe('deriveAdminKeysFromProperties (multi-country)', () => {
+  it('restores the country at level 0', () => {
+    expect(
+      deriveAdminKeysFromProperties(
+        { admin0Pcod: 'ML' },
+        level(0),
+        'ML',
+        ADMIN_LEVEL_CODES,
+      ),
+    ).toEqual({ admin0Key: 'ML', admin1Key: '', admin2Key: '' });
+  });
+
+  it('restores the country + admin 1 at level 1', () => {
+    expect(
+      deriveAdminKeysFromProperties(
+        { admin0Pcod: 'ML', admin1Pcod: 'ML07' },
+        level(1),
+        'ML07',
+        ADMIN_LEVEL_CODES,
+      ),
+    ).toEqual({ admin0Key: 'ML', admin1Key: 'ML07', admin2Key: '' });
+  });
+
+  it('restores the full hierarchy at level 2', () => {
+    expect(
+      deriveAdminKeysFromProperties(
+        { admin0Pcod: 'ML', admin1Pcod: 'ML07', admin2Pcod: 'ML0701' },
+        level(2),
+        'ML0701',
+        ADMIN_LEVEL_CODES,
+      ),
+    ).toEqual({ admin0Key: 'ML', admin1Key: 'ML07', admin2Key: 'ML0701' });
+  });
+});
+
+describe('persist -> restore round trip (multi-country)', () => {
+  // The boundary feature getProperties would resolve for each saved code/level.
+  const featureProps = {
+    admin0Pcod: 'ML',
+    admin1Pcod: 'ML07',
+    admin2Pcod: 'ML0701',
+  };
+
+  it.each([
+    [level(0), { admin0Key: 'ML', admin1Key: '', admin2Key: '' }],
+    [level(1), { admin0Key: 'ML', admin1Key: 'ML07', admin2Key: '' }],
+    [level(2), { admin0Key: 'ML', admin1Key: 'ML07', admin2Key: 'ML0701' }],
+  ])('round-trips level %s without losing the country', (lvl, keys) => {
+    const savedId = adminUnitIdFromKeys(
+      code(keys.admin0Key),
+      code(keys.admin1Key),
+      code(keys.admin2Key),
+      lvl,
+    );
+
+    // Country (level 0) must persist a non-empty id, otherwise restore can't
+    // know which country was selected (the original id_code=undefined bug).
+    expect(savedId).toBeTruthy();
+
+    const restored = deriveAdminKeysFromProperties(
+      featureProps,
+      lvl,
+      String(savedId),
+      ADMIN_LEVEL_CODES,
+    );
+
+    expect(restored).toEqual(keys);
+  });
+});

--- a/frontend/src/utils/chart-hooks.ts
+++ b/frontend/src/utils/chart-hooks.ts
@@ -50,44 +50,70 @@ export interface UseChartFormOptions {
   latestPeriod?: ChartLatestPeriod;
 }
 
+/**
+ * Resolves the persisted admin unit id (the boundary code that getProperties
+ * uses on restore) for the currently-selected level.
+ *
+ * In multi-country deployments the hierarchy is country (0) -> admin 1 (1) ->
+ * admin 2 (2), so level 0 stores the selected country. In single-country
+ * deployments level 0 is the whole country and has no admin unit id.
+ */
 export function adminUnitIdFromKeys(
+  admin0Key: AdminCodeString,
   admin1Key: AdminCodeString,
   admin2Key: AdminCodeString,
   level: AdminLevelType,
 ): string | undefined {
-  if (level === 0) {
-    return undefined;
-  }
   if (level === 2 && admin2Key) {
     return String(admin2Key);
   }
-  if (admin1Key) {
+  if (level === 1 && admin1Key) {
     return String(admin1Key);
+  }
+  if (level === 0) {
+    return multiCountry && admin0Key ? String(admin0Key) : undefined;
   }
   return undefined;
 }
 
-function deriveAdminKeysFromProperties(
+/**
+ * Rebuilds the admin key hierarchy (country / admin 1 / admin 2) from a restored
+ * boundary feature's properties, accounting for the multi-country level offset.
+ */
+export function deriveAdminKeysFromProperties(
   properties: GeoJsonProperties,
   level: AdminLevelType,
   deepestCode: string,
   adminLevelCodes: string[],
-): { admin1Key: AdminCodeString; admin2Key: AdminCodeString } {
+): {
+  admin0Key: AdminCodeString;
+  admin1Key: AdminCodeString;
+  admin2Key: AdminCodeString;
+} {
+  const empty = '' as AdminCodeString;
+  const admin0CodeField = adminLevelCodes[0];
+  const admin1CodeField = adminLevelCodes[multiCountry ? 1 : 0];
+
+  const restoredAdmin0 = multiCountry
+    ? ((properties?.[admin0CodeField] ?? '') as AdminCodeString)
+    : empty;
+
   if (level === 0) {
     return {
-      admin1Key: '' as AdminCodeString,
-      admin2Key: '' as AdminCodeString,
+      admin0Key: multiCountry ? (deepestCode as AdminCodeString) : empty,
+      admin1Key: empty,
+      admin2Key: empty,
     };
   }
-  const admin1Index = multiCountry ? 1 : 0;
-  const admin1CodeField = adminLevelCodes[admin1Index];
   if (level === 1) {
     return {
+      admin0Key: restoredAdmin0,
       admin1Key: deepestCode as AdminCodeString,
-      admin2Key: '' as AdminCodeString,
+      admin2Key: empty,
     };
   }
   return {
+    admin0Key: restoredAdmin0,
     admin1Key: (properties?.[admin1CodeField] ?? '') as AdminCodeString,
     admin2Key: deepestCode as AdminCodeString,
   };
@@ -97,10 +123,12 @@ export interface UseChartFormReturn {
   // Form state
   chartLayerId: LayerKey | undefined;
   setChartLayerId: (id: LayerKey | undefined) => void;
+  admin0Key: AdminCodeString;
   admin1Key: AdminCodeString;
   admin2Key: AdminCodeString;
   adminLevel: AdminLevelType;
   setLocation: (
+    admin0Key: AdminCodeString,
     admin1Key: AdminCodeString,
     admin2Key: AdminCodeString,
     properties: GeoJsonProperties,
@@ -144,6 +172,9 @@ export const useChartForm = (
   const [chartLayerId, setChartLayerId] = useState<LayerKey | undefined>(
     initialChartLayerId,
   );
+  const [admin0Key, setAdmin0Key] = useState<AdminCodeString>(
+    '' as AdminCodeString,
+  );
   const [admin1Key, setAdmin1Key] = useState<AdminCodeString>(
     '' as AdminCodeString,
   );
@@ -174,11 +205,13 @@ export const useChartForm = (
   >(undefined);
 
   const setLocationInternal = (
+    newAdmin0Key: AdminCodeString,
     newAdmin1Key: AdminCodeString,
     newAdmin2Key: AdminCodeString,
     properties: GeoJsonProperties,
     level: AdminLevelType,
   ) => {
+    setAdmin0Key(newAdmin0Key);
     setAdmin1Key(newAdmin1Key);
     setAdmin2Key(newAdmin2Key);
     setAdminLevel(level);
@@ -186,12 +219,19 @@ export const useChartForm = (
   };
 
   const setLocation = (
+    newAdmin0Key: AdminCodeString,
     newAdmin1Key: AdminCodeString,
     newAdmin2Key: AdminCodeString,
     properties: GeoJsonProperties,
     level: AdminLevelType,
   ) => {
-    setLocationInternal(newAdmin1Key, newAdmin2Key, properties, level);
+    setLocationInternal(
+      newAdmin0Key,
+      newAdmin1Key,
+      newAdmin2Key,
+      properties,
+      level,
+    );
   };
 
   const boundaryDataResult = useBoundaryData(boundaryLayer.id);
@@ -235,16 +275,25 @@ export const useChartForm = (
     const level = (initialAdminLevel ?? 0) as AdminLevelType;
     const code = String(initialAdminUnitId) as AdminCodeString;
     const properties = getProperties(boundaryLayerData.data, code, level);
-    const { admin1Key: restoredAdmin1, admin2Key: restoredAdmin2 } =
-      deriveAdminKeysFromProperties(
-        properties,
-        level,
-        String(initialAdminUnitId),
-        boundaryLayer.adminLevelCodes,
-      );
+    const {
+      admin0Key: restoredAdmin0,
+      admin1Key: restoredAdmin1,
+      admin2Key: restoredAdmin2,
+    } = deriveAdminKeysFromProperties(
+      properties,
+      level,
+      String(initialAdminUnitId),
+      boundaryLayer.adminLevelCodes,
+    );
 
     hasRestoredAdminRef.current = true;
-    setLocationInternal(restoredAdmin1, restoredAdmin2, properties, level);
+    setLocationInternal(
+      restoredAdmin0,
+      restoredAdmin1,
+      restoredAdmin2,
+      properties,
+      level,
+    );
   }, [
     boundaryLayerData,
     initialAdminUnitId,
@@ -323,6 +372,7 @@ export const useChartForm = (
     // Form state
     chartLayerId,
     setChartLayerId,
+    admin0Key,
     admin1Key,
     admin2Key,
     adminLevel,


### PR DESCRIPTION
### Description

Chart location dropdowns hard-coded single-country admin levels (1, 2), but in multi-country deployments those map to country (level 0) and admin 1 (level 1). The mismatch made getProperties resolve empty properties, producing id_code=undefined with no countryAdmin0Id fallback. Compute dropdown levels from the deployment type and align the admin name lookups via a shared helper.

This fixes #1935.

## How to test the feature:
- [ ] Pull up the RBD and load charts for various admin units
- [ ] Pull up the a different country and load charts for various admin units

## Checklist - did you ...

Test your changes with:
- [x] `REACT_APP_COUNTRY=rbd yarn start`
- [x] `REACT_APP_COUNTRY=cambodia yarn start`
- [X] `REACT_APP_COUNTRY=mozambique yarn start`

## Screenshot/video of feature:
<img width="1873" height="889" alt="Screenshot 2026-06-08 at 4 22 17 PM" src="https://github.com/user-attachments/assets/40de2e0d-69ab-4a43-b154-98eb42b9bf56" />
