### PR TITLE
Retain batch map layer selection after login

### DIFF
--- a/frontend/src/components/NavBar/PrintImage/image.tsx
+++ b/frontend/src/components/NavBar/PrintImage/image.tsx
@@ -52,7 +52,10 @@ import {
   getDisabledCadences,
   resolveValidCadence,
 } from '../../../utils/batchCadenceUtils';
-import { MAP_EXPORT_MAX_URLS_PER_REQUEST } from '../../../utils/constants';
+import {
+  BATCH_MAP_LAYER_URL_KEY,
+  MAP_EXPORT_MAX_URLS_PER_REQUEST,
+} from '../../../utils/constants';
 import { exportLanguage } from '../../../utils/exportLanguage';
 import {
   cadenceToApi,
@@ -210,6 +213,7 @@ function DownloadImage({ open, handleClose }: DownloadImageProps) {
       countryLayerIds.has(l.id),
   );
   const [selectedLayerId, setSelectedLayerId] = useState<LayerKey | null>(null);
+  const printLayerInitializedRef = useRef(false);
 
   useEffect(() => {
     if (!open) {
@@ -234,13 +238,69 @@ function DownloadImage({ open, handleClose }: DownloadImageProps) {
 
   const { selectedLayersWithDateSupport, selectedLayers } = useLayers();
 
+  // Batch-map layer in the print dialog is separate from the main map's
+  // `hazardLayerIds`. On open, read `batchMapLayerId` once (e.g. after login
+  // redirect); otherwise default to the main map's active layer. The ref ensures
+  // we do not re-run when the sync effect below updates the URL.
   useEffect(() => {
-    if (open) {
-      setSelectedLayerId(
-        (selectedLayersWithDateSupport[0]?.id as LayerKey) ?? null,
-      );
+    if (!open) {
+      printLayerInitializedRef.current = false;
+      return;
     }
-  }, [open]);
+    if (printLayerInitializedRef.current) {
+      return;
+    }
+
+    const params = new URLSearchParams(location.search);
+    const batchMapLayerId = params.get(BATCH_MAP_LAYER_URL_KEY);
+
+    if (batchMapLayerId) {
+      const batchMapLayerValid = selectableLayers.some(
+        layer => layer.id === batchMapLayerId,
+      );
+      if (!batchMapLayerValid && selectableLayers.length === 0) {
+        return;
+      }
+      if (batchMapLayerValid) {
+        setSelectedLayerId(batchMapLayerId as LayerKey);
+        printLayerInitializedRef.current = true;
+        return;
+      }
+    }
+
+    if (selectedLayersWithDateSupport.length === 0) {
+      return;
+    }
+
+    printLayerInitializedRef.current = true;
+    setSelectedLayerId(
+      (selectedLayersWithDateSupport[0]?.id as LayerKey) ?? null,
+    );
+  }, [open, selectableLayers, selectedLayersWithDateSupport]);
+
+  // Keep `batchMapLayerId` in the URL while batch maps is enabled so login
+  // redirect and modal restore preserve the print-layer choice. Intentionally
+  // omit `location.search` from deps so URL updates do not re-trigger init above.
+  useEffect(() => {
+    if (!open || !toggles.batchMapsVisibility || !selectedLayerId) {
+      return;
+    }
+    const params = new URLSearchParams(location.search);
+    if (params.get(BATCH_MAP_LAYER_URL_KEY) === selectedLayerId) {
+      return;
+    }
+    params.set(BATCH_MAP_LAYER_URL_KEY, selectedLayerId);
+    history.replace({
+      pathname: location.pathname,
+      search: params.toString() ? `?${params.toString()}` : '',
+    });
+  }, [
+    open,
+    toggles.batchMapsVisibility,
+    selectedLayerId,
+    history,
+    location.pathname,
+  ]);
 
   useEffect(() => {
     if (!toggles.batchMapsVisibility) {

--- a/frontend/src/components/NavBar/PrintImage/image.tsx
+++ b/frontend/src/components/NavBar/PrintImage/image.tsx
@@ -238,10 +238,22 @@ function DownloadImage({ open, handleClose }: DownloadImageProps) {
 
   const { selectedLayersWithDateSupport, selectedLayers } = useLayers();
 
+  const defaultBatchMapLayerId = useMemo((): LayerKey | null => {
+    if (selectableLayers.length === 0) {
+      return null;
+    }
+    const selectableIds = new Set(selectableLayers.map(layer => layer.id));
+    const fromMainMap = selectedLayersWithDateSupport.find(layer =>
+      selectableIds.has(layer.id),
+    )?.id as LayerKey | undefined;
+    return fromMainMap ?? selectableLayers[0].id;
+  }, [selectableLayers, selectedLayersWithDateSupport]);
+
   // Batch-map layer in the print dialog is separate from the main map's
   // `hazardLayerIds`. On open, read `batchMapLayerId` once (e.g. after login
-  // redirect); otherwise default to the main map's active layer. The ref ensures
-  // we do not re-run when the sync effect below updates the URL.
+  // redirect); otherwise default to the first batch-printable main-map layer, or
+  // the first selectable batch-print layer. The ref ensures we do not re-run
+  // when the sync effect below updates the URL.
   useEffect(() => {
     if (!open) {
       printLayerInitializedRef.current = false;
@@ -268,24 +280,28 @@ function DownloadImage({ open, handleClose }: DownloadImageProps) {
       }
     }
 
-    if (selectedLayersWithDateSupport.length === 0) {
+    if (defaultBatchMapLayerId === null) {
       return;
     }
 
     printLayerInitializedRef.current = true;
-    setSelectedLayerId(
-      (selectedLayersWithDateSupport[0]?.id as LayerKey) ?? null,
-    );
-  }, [open, selectableLayers, selectedLayersWithDateSupport]);
+    setSelectedLayerId(defaultBatchMapLayerId);
+  }, [open, selectableLayers, defaultBatchMapLayerId]);
 
   // Keep `batchMapLayerId` in the URL while batch maps is enabled so login
   // redirect and modal restore preserve the print-layer choice. Intentionally
   // omit `location.search` from deps so URL updates do not re-trigger init above.
+  // Skip syncing when `schedule=1` is present: the post-login redirect URL already
+  // carries `batchMapLayerId`, and replacing search here re-triggers schedule init
+  // and whoami work on every layer tweak.
   useEffect(() => {
     if (!open || !toggles.batchMapsVisibility || !selectedLayerId) {
       return;
     }
     const params = new URLSearchParams(location.search);
+    if (params.get('schedule') === '1') {
+      return;
+    }
     if (params.get(BATCH_MAP_LAYER_URL_KEY) === selectedLayerId) {
       return;
     }
@@ -337,10 +353,10 @@ function DownloadImage({ open, handleClose }: DownloadImageProps) {
   }, [open, selectedMap]);
 
   useEffect(() => {
-    if (selectedLayerId === null && selectableLayers.length > 0) {
-      setSelectedLayerId(selectableLayers[0].id);
+    if (selectedLayerId === null && defaultBatchMapLayerId !== null) {
+      setSelectedLayerId(defaultBatchMapLayerId);
     }
-  }, [selectableLayers, selectedLayerId]);
+  }, [defaultBatchMapLayerId, selectedLayerId]);
 
   const printSelectedLayer = useMemo(
     () =>

--- a/frontend/src/components/NavBar/PrintImage/index.tsx
+++ b/frontend/src/components/NavBar/PrintImage/index.tsx
@@ -8,6 +8,7 @@ import { mapSelector } from 'context/mapStateSlice/selectors';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useHistory, useLocation } from 'react-router-dom';
+import { BATCH_MAP_LAYER_URL_KEY } from 'utils/constants';
 
 import BatchMapExportGlobalTray from './batchMapExport/BatchMapExportGlobalTray';
 import BatchMapExportJobsProvider from './batchMapExport/BatchMapExportJobsProvider';
@@ -31,6 +32,7 @@ function PrintImage() {
     const params = new URLSearchParams(location.search);
     params.delete('printModal');
     params.delete('batchMaps');
+    params.delete(BATCH_MAP_LAYER_URL_KEY);
     params.delete('schedule');
     history.replace({
       pathname: location.pathname,

--- a/frontend/src/components/NavBar/PrintImage/printConfig.tsx
+++ b/frontend/src/components/NavBar/PrintImage/printConfig.tsx
@@ -29,6 +29,7 @@ import { cyanBlue } from 'muiTheme';
 import React, { useContext, useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import {
+  BATCH_MAP_LAYER_URL_KEY,
   MAP_EXPORT_MAX_URLS_PER_REQUEST,
   PRISM_SIGN_IN_URL,
 } from 'utils/constants';
@@ -408,6 +409,9 @@ function PrintConfig() {
       params.set('printModal', '1');
       params.set('batchMaps', '1');
       params.set('schedule', '1');
+      if (selectedLayerId) {
+        params.set(BATCH_MAP_LAYER_URL_KEY, selectedLayerId);
+      }
       const returnUrl = `${window.location.origin}${
         location.pathname
       }?${params.toString()}`;

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -34,6 +34,9 @@ export const ADMIN_ACCESS_PERMISSION = 'prism.admin.access';
 export const PRISM_SIGN_IN_URL = `${API_URL}/auth/sign-in`;
 export const PRISM_SIGN_OUT_URL = `${API_URL}/auth/sign-out`;
 
+/** Print-modal batch map layer; distinct from main-app `hazardLayerIds`. */
+export const BATCH_MAP_LAYER_URL_KEY = 'batchMapLayerId';
+
 /** Must match MAP_EXPORT_MAX_URLS_PER_REQUEST in api/prism_app/models.py */
 export const MAP_EXPORT_MAX_URLS_PER_REQUEST = 12;
 // Default to the VAM URL for HDC data.


### PR DESCRIPTION
### Description

This fixes #1934 .

<!-- what this does -->

Adds a batch map layer id url param that allows frontend to redirect to the print modal with the correctly selected layer id, while also maintaining any hazard layers that the user has selected on the main map.

## How to test the feature:

- Select a hazard layer on the main map
- Select a different layer in the print dialog
- Login via the print modal
- Upon redirect, the print layer should persist once the modal reopens and loads
- Close the print modal - the hazard layer on the main map should also persist

## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [ ] `REACT_APP_COUNTRY=rbd yarn start`
- [ ] `REACT_APP_COUNTRY=cambodia yarn start`
- [x] `REACT_APP_COUNTRY=mozambique yarn start`
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

## Screenshot/video of feature:

https://www.loom.com/share/6a1b5b1c0c034ea29ab0c3af8fce4ab5