### PR TITLE
Hide country field for non-admins

### DIFF
--- a/api/prism_app/admin_map_export.py
+++ b/api/prism_app/admin_map_export.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict, Optional, Sequence
 from uuid import UUID
 
 from prism_app.admin import PrismGatedModelView, ReadOnlyModelView
 from prism_app.auth.admin_request import (
     admin_user_from_request,
+    request_can_manage_map_exports,
     request_has_prism_admin_access,
 )
 from prism_app.dashboard.dashboard_config_field import PrettyJSONField
@@ -43,6 +44,7 @@ from starlette_admin.actions import link_row_action
 from starlette_admin.contrib.sqla import Admin
 from starlette_admin.contrib.sqla.helpers import OPERATORS
 from starlette_admin.exceptions import FormValidationError
+from starlette_admin.fields import BaseField
 
 _DEFAULT_EQ = OPERATORS["eq"]
 _DEFAULT_NEQ = OPERATORS["neq"]
@@ -455,8 +457,62 @@ class MapExportScheduleView(CaseInsensitiveColumnFilterMixin, PrismGatedModelVie
     actions: list[str] = []
     row_actions = ["view", "edit", "clone", "delete"]
 
+    _ADMIN_ONLY_FIELD_NAMES = frozenset({"country"})
+
+    def _admin_only_field_names(self, request: Request) -> frozenset[str]:
+        if request_has_prism_admin_access(request):
+            return frozenset()
+        return self._ADMIN_ONLY_FIELD_NAMES
+
+    def get_fields_list(
+        self,
+        request: Request,
+        action: RequestAction = RequestAction.LIST,
+    ) -> Sequence[BaseField]:
+        hidden = self._admin_only_field_names(request)
+        if not hidden:
+            return super().get_fields_list(request, action)
+        return [
+            field
+            for field in super().get_fields_list(request, action)
+            if field.name not in hidden
+        ]
+
+    def _searchable_fields_for_request(self, request: Request) -> tuple[str, ...]:
+        hidden = self._admin_only_field_names(request)
+        return tuple(
+            name
+            for name in self.searchable_fields  # type: ignore[union-attr]
+            if name not in hidden
+        )
+
+    async def _configs(self, request: Request) -> dict[str, Any]:
+        configs = await super()._configs(request)
+        hidden = self._admin_only_field_names(request)
+        if not hidden:
+            return configs
+        searchable = self._searchable_fields_for_request(request)
+        exportable = tuple(
+            name for name in self.export_fields if name not in hidden  # type: ignore[union-attr]
+        )
+        configs["searchColumns"] = [f"{name}:name" for name in searchable]
+        configs["exportColumns"] = [f"{name}:name" for name in exportable]
+        return configs
+
+    def is_accessible(self, request: Request) -> bool:
+        return request_can_manage_map_exports(request)
+
+    def can_view_details(self, request: Request) -> bool:
+        return request_can_manage_map_exports(request)
+
+    def can_edit(self, request: Request) -> bool:
+        return request_can_manage_map_exports(request)
+
+    def can_delete(self, request: Request) -> bool:
+        return request_has_prism_admin_access(request)
+
     def can_create(self, request: Request) -> bool:
-        if not super().can_create(request):
+        if not request_can_manage_map_exports(request):
             return False
         return "clone_from" in request.query_params
 
@@ -490,7 +546,7 @@ class MapExportScheduleView(CaseInsensitiveColumnFilterMixin, PrismGatedModelVie
         if not term_lower:
             return None
         clauses = []
-        for field_name in self.searchable_fields:
+        for field_name in self._searchable_fields_for_request(request):
             attr = getattr(self.model, field_name, None)
             if attr is None:
                 continue

--- a/api/prism_app/auth/admin_request.py
+++ b/api/prism_app/auth/admin_request.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
-from prism_app.auth.permission_codes import ADMIN_ACCESS, can_manage_dashboards_in_admin
+from prism_app.auth.permission_codes import (
+    ADMIN_ACCESS,
+    can_manage_dashboards_in_admin,
+    can_manage_map_exports_in_admin,
+)
 from prism_app.database.user_model import User
 from starlette.requests import Request
 from starlette_admin.exceptions import FormValidationError
@@ -18,6 +22,12 @@ def request_can_manage_dashboards(request: Request) -> bool:
     """Dashboard model view in admin: full admins or dashboard managers."""
     codes = getattr(request.state, "permission_codes", None)
     return bool(codes and can_manage_dashboards_in_admin(codes))
+
+
+def request_can_manage_map_exports(request: Request) -> bool:
+    """Map export schedules view in admin: full admins or map export managers."""
+    codes = getattr(request.state, "permission_codes", None)
+    return bool(codes and can_manage_map_exports_in_admin(codes))
 
 
 def admin_user_from_request(request: Request) -> User:

--- a/api/prism_app/auth/permission_codes.py
+++ b/api/prism_app/auth/permission_codes.py
@@ -16,13 +16,22 @@ MAP_EXPORTS_MANAGE = "prism.map_exports.manage"
 
 
 def can_access_admin_panel(codes: set[str] | frozenset[str]) -> bool:
-    """Enter Starlette-admin: full admins or dashboard managers."""
-    return ADMIN_ACCESS in codes or DASHBOARD_MANAGE in codes
+    """Enter Starlette-admin: full admins, dashboard managers, or map export managers."""
+    return (
+        ADMIN_ACCESS in codes
+        or DASHBOARD_MANAGE in codes
+        or MAP_EXPORTS_MANAGE in codes
+    )
 
 
 def can_manage_dashboards_in_admin(codes: set[str] | frozenset[str]) -> bool:
-    """Dashboard model view in admin: same as panel entry for scoped managers."""
-    return can_access_admin_panel(codes)
+    """Dashboard model view in admin: full admins or dashboard managers."""
+    return ADMIN_ACCESS in codes or DASHBOARD_MANAGE in codes
+
+
+def can_manage_map_exports_in_admin(codes: set[str] | frozenset[str]) -> bool:
+    """Map export schedules view in admin: full admins or map export managers."""
+    return ADMIN_ACCESS in codes or MAP_EXPORTS_MANAGE in codes
 
 
 # Full set for auth-disabled dev mode (all gates pass that the admin UI expects).

--- a/api/prism_app/tests/test_admin_map_export.py
+++ b/api/prism_app/tests/test_admin_map_export.py
@@ -13,7 +13,7 @@ from prism_app.admin_map_export import (
     _normalize_dekad_interval,
     _validate_dekad_interval,
 )
-from prism_app.auth.permission_codes import ADMIN_ACCESS
+from prism_app.auth.permission_codes import ADMIN_ACCESS, MAP_EXPORTS_MANAGE
 from prism_app.database.map_export_job_model import MapExportJob
 from prism_app.database.map_export_schedule_model import (
     MAX_DEKAD_INTERVAL,
@@ -22,10 +22,17 @@ from prism_app.database.map_export_schedule_model import (
 )
 from sqlalchemy import select
 from starlette.requests import Request
+from starlette_admin._types import RequestAction
 from starlette_admin.exceptions import FormValidationError
 
 
-def _request(*, admin_access: bool, user_id=None, query_string: bytes = b"") -> Request:
+def _request(
+    *,
+    admin_access: bool,
+    map_exports_manage: bool = False,
+    user_id=None,
+    query_string: bytes = b"",
+) -> Request:
     scope = {
         "type": "http",
         "method": "GET",
@@ -34,7 +41,12 @@ def _request(*, admin_access: bool, user_id=None, query_string: bytes = b"") -> 
         "headers": [],
     }
     request = Request(scope)
-    request.state.permission_codes = {ADMIN_ACCESS} if admin_access else set()
+    codes: set[str] = set()
+    if admin_access:
+        codes.add(ADMIN_ACCESS)
+    if map_exports_manage:
+        codes.add(MAP_EXPORTS_MANAGE)
+    request.state.permission_codes = codes
     if user_id is not None:
         request.state.prism_user = SimpleNamespace(id=user_id)
     return request
@@ -65,6 +77,23 @@ def test_schedule_view_allows_delete_for_admin() -> None:
     view = MapExportScheduleView(MapExportSchedule)
     assert view.can_delete(_request(admin_access=True)) is True
     assert view.can_delete(_request(admin_access=False)) is False
+    assert (
+        view.can_delete(_request(admin_access=False, map_exports_manage=True)) is False
+    )
+
+
+def test_schedule_view_accessible_to_map_export_manager_only() -> None:
+    view = MapExportScheduleView(MapExportSchedule)
+    manager_request = _request(admin_access=False, map_exports_manage=True)
+
+    assert view.is_accessible(manager_request) is True
+    assert view.can_view_details(manager_request) is True
+    assert view.can_edit(manager_request) is True
+
+
+def test_schedule_view_not_accessible_without_map_exports_or_admin() -> None:
+    view = MapExportScheduleView(MapExportSchedule)
+    assert view.is_accessible(_request(admin_access=False)) is False
 
 
 def test_normalize_dekad_interval_only_for_every_n_dekads() -> None:
@@ -143,10 +172,61 @@ def test_schedule_searchable_fields_include_cadence_and_format() -> None:
     assert "format" in view.searchable_fields
 
 
+def test_schedule_list_hides_country_for_map_export_manager() -> None:
+    view = MapExportScheduleView(MapExportSchedule)
+    manager_request = _request(admin_access=False, map_exports_manage=True)
+    admin_request = _request(admin_access=True)
+
+    manager_fields = {
+        f.name for f in view.get_fields_list(manager_request, RequestAction.LIST)
+    }
+    admin_fields = {
+        f.name for f in view.get_fields_list(admin_request, RequestAction.LIST)
+    }
+
+    assert "country" not in manager_fields
+    assert "country" in admin_fields
+
+
+def test_schedule_detail_hides_country_for_map_export_manager() -> None:
+    view = MapExportScheduleView(MapExportSchedule)
+    manager_request = _request(admin_access=False, map_exports_manage=True)
+    admin_request = _request(admin_access=True)
+
+    manager_fields = {
+        f.name for f in view.get_fields_list(manager_request, RequestAction.DETAIL)
+    }
+    admin_fields = {
+        f.name for f in view.get_fields_list(admin_request, RequestAction.DETAIL)
+    }
+
+    assert "country" not in manager_fields
+    assert "country" in admin_fields
+
+
+def test_schedule_search_excludes_country_for_map_export_manager() -> None:
+    view = MapExportScheduleView(MapExportSchedule)
+    manager_request = _request(admin_access=False, map_exports_manage=True)
+    clause = view.get_search_query(manager_request, "mozambique")
+    compiled = str(clause.compile(compile_kwargs={"literal_binds": True}))
+    assert "country" not in compiled.lower()
+
+
+def test_schedule_search_includes_country_for_admin() -> None:
+    view = MapExportScheduleView(MapExportSchedule)
+    admin_request = _request(admin_access=True)
+    clause = view.get_search_query(admin_request, "mozambique")
+    compiled = str(clause.compile(compile_kwargs={"literal_binds": True}))
+    assert "country" in compiled.lower()
+
+
 def test_schedule_view_can_create_only_with_clone_from() -> None:
     view = MapExportScheduleView(MapExportSchedule)
     assert view.create_template == "map_export_schedule_create.html"
     assert view.can_create(_request(admin_access=True)) is False
+    assert (
+        view.can_create(_request(admin_access=False, map_exports_manage=True)) is False
+    )
     scope = {
         "type": "http",
         "method": "GET",
@@ -157,6 +237,17 @@ def test_schedule_view_can_create_only_with_clone_from() -> None:
     request = Request(scope)
     request.state.permission_codes = {ADMIN_ACCESS}
     assert view.can_create(request) is True
+
+    manager_scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/",
+        "query_string": b"clone_from=abc",
+        "headers": [],
+    }
+    manager_request = Request(manager_scope)
+    manager_request.state.permission_codes = {MAP_EXPORTS_MANAGE}
+    assert view.can_create(manager_request) is True
 
 
 @pytest.mark.asyncio

--- a/api/prism_app/tests/test_admin_permissions.py
+++ b/api/prism_app/tests/test_admin_permissions.py
@@ -1,16 +1,23 @@
 """Admin panel permission helpers and view gates."""
 
+from prism_app.admin import AlertView
+from prism_app.admin_map_export import MapExportScheduleView
 from prism_app.auth.admin_request import (
     request_can_manage_dashboards,
+    request_can_manage_map_exports,
     request_has_prism_admin_access,
 )
 from prism_app.auth.permission_codes import (
     ADMIN_ACCESS,
     CONTENT_VIEW,
     DASHBOARD_MANAGE,
+    MAP_EXPORTS_MANAGE,
     can_access_admin_panel,
     can_manage_dashboards_in_admin,
+    can_manage_map_exports_in_admin,
 )
+from prism_app.database.alert_model import AlertModel
+from prism_app.database.map_export_schedule_model import MapExportSchedule
 from starlette.requests import Request
 
 
@@ -24,6 +31,7 @@ def _request_with_codes(codes: set[str]) -> Request:
 def test_can_access_admin_panel() -> None:
     assert can_access_admin_panel({ADMIN_ACCESS})
     assert can_access_admin_panel({DASHBOARD_MANAGE})
+    assert can_access_admin_panel({MAP_EXPORTS_MANAGE})
     assert not can_access_admin_panel({CONTENT_VIEW})
     assert not can_access_admin_panel(set())
 
@@ -31,7 +39,15 @@ def test_can_access_admin_panel() -> None:
 def test_can_manage_dashboards_in_admin() -> None:
     assert can_manage_dashboards_in_admin({DASHBOARD_MANAGE})
     assert can_manage_dashboards_in_admin({ADMIN_ACCESS})
+    assert not can_manage_dashboards_in_admin({MAP_EXPORTS_MANAGE})
     assert not can_manage_dashboards_in_admin({CONTENT_VIEW})
+
+
+def test_can_manage_map_exports_in_admin() -> None:
+    assert can_manage_map_exports_in_admin({MAP_EXPORTS_MANAGE})
+    assert can_manage_map_exports_in_admin({ADMIN_ACCESS})
+    assert not can_manage_map_exports_in_admin({DASHBOARD_MANAGE})
+    assert not can_manage_map_exports_in_admin({CONTENT_VIEW})
 
 
 def test_request_has_prism_admin_access() -> None:
@@ -42,4 +58,21 @@ def test_request_has_prism_admin_access() -> None:
 def test_request_can_manage_dashboards() -> None:
     assert request_can_manage_dashboards(_request_with_codes({DASHBOARD_MANAGE}))
     assert request_can_manage_dashboards(_request_with_codes({ADMIN_ACCESS}))
+    assert not request_can_manage_dashboards(_request_with_codes({MAP_EXPORTS_MANAGE}))
     assert not request_can_manage_dashboards(_request_with_codes({CONTENT_VIEW}))
+
+
+def test_request_can_manage_map_exports() -> None:
+    assert request_can_manage_map_exports(_request_with_codes({MAP_EXPORTS_MANAGE}))
+    assert request_can_manage_map_exports(_request_with_codes({ADMIN_ACCESS}))
+    assert not request_can_manage_map_exports(_request_with_codes({DASHBOARD_MANAGE}))
+    assert not request_can_manage_map_exports(_request_with_codes({CONTENT_VIEW}))
+
+
+def test_map_export_manager_sees_only_schedule_view_in_admin() -> None:
+    request = _request_with_codes({MAP_EXPORTS_MANAGE})
+    schedule_view = MapExportScheduleView(MapExportSchedule)
+    alert_view = AlertView(AlertModel)
+
+    assert schedule_view.is_accessible(request) is True
+    assert alert_view.is_accessible(request) is False


### PR DESCRIPTION
### Description

This implements #1923 .

<!-- what this does -->

- Hides the `country` field in the map export schedule view for non-admins
- Allows users with map manager permission to enter admin and only access the schedules table

## How to test the feature:

- Login as an admin user and navigate to the schedules page, you should be able to see and search on the country field
- Change your permissions to a map export manager, you should only be able to access the schedules table, and not be able to see or search on the country field

## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

## Screenshot/video of feature:

https://www.loom.com/share/2826f76d27f348b2975f278403c2530f