### PR TITLE
Dashboard bulk actions

### DIFF
--- a/api/prism_app/admin_bulk_actions.py
+++ b/api/prism_app/admin_bulk_actions.py
@@ -1,0 +1,46 @@
+"""Shared helpers for Starlette Admin batch action forms."""
+
+from __future__ import annotations
+
+from enum import Enum
+from html import escape
+from typing import Iterable
+
+# Starlette-admin batch actions take pre-rendered HTML for ``form``, not a template
+# path. The list page embeds this string in each action link's ``data-form``
+# attribute; client JS copies it into the confirmation modal on click.
+
+
+def bulk_status_select_form(
+    choices: Iterable[Enum | str | tuple[str, str]],
+    *,
+    field_name: str = "status",
+    select_id: str = "bulk-status",
+    placeholder: str = "Select status…",
+) -> str:
+    """Return HTML for a bulk status ``<select>`` embedded in a batch action form."""
+    option_lines = [f'<option value="">{escape(placeholder)}</option>']
+    for choice in choices:
+        value, label = _value_and_label(choice)
+        option_lines.append(
+            f'<option value="{escape(value)}">{escape(label)}</option>'
+        )
+    options_html = "\n            ".join(option_lines)
+    return f"""
+<form>
+    <div class="mt-3">
+        <label class="form-label" for="{escape(select_id)}">Status</label>
+        <select id="{escape(select_id)}" class="form-select" name="{escape(field_name)}" required>
+            {options_html}
+        </select>
+    </div>
+</form>
+"""
+
+
+def _value_and_label(choice: Enum | str | tuple[str, str]) -> tuple[str, str]:
+    if isinstance(choice, tuple):
+        return str(choice[0]), str(choice[1])
+    if isinstance(choice, Enum):
+        return str(choice.value), str(choice.value)
+    return str(choice), str(choice)

--- a/api/prism_app/admin_bulk_actions.py
+++ b/api/prism_app/admin_bulk_actions.py
@@ -22,9 +22,7 @@ def bulk_status_select_form(
     option_lines = [f'<option value="">{escape(placeholder)}</option>']
     for choice in choices:
         value, label = _value_and_label(choice)
-        option_lines.append(
-            f'<option value="{escape(value)}">{escape(label)}</option>'
-        )
+        option_lines.append(f'<option value="{escape(value)}">{escape(label)}</option>')
     options_html = "\n            ".join(option_lines)
     return f"""
 <form>

--- a/api/prism_app/admin_map_export.py
+++ b/api/prism_app/admin_map_export.py
@@ -8,6 +8,7 @@ from typing import Any, Callable, Dict, Optional, Sequence
 from uuid import UUID
 
 from prism_app.admin import PrismGatedModelView, ReadOnlyModelView
+from prism_app.admin_bulk_actions import bulk_status_select_form
 from prism_app.auth.admin_request import (
     admin_user_from_request,
     request_can_manage_map_exports,
@@ -51,22 +52,7 @@ from starlette_admin.i18n import ngettext
 _DEFAULT_EQ = OPERATORS["eq"]
 _DEFAULT_NEQ = OPERATORS["neq"]
 
-# Starlette-admin batch actions take pre-rendered HTML for ``form``, not a template
-# path. The list page embeds this string in each action link's ``data-form``
-# attribute; client JS copies it into the confirmation modal on click. Unlike
-# create/edit/list pages, there is no request-time TemplateResponse hook for it.
-_BULK_UPDATE_STATUS_FORM = """
-<form>
-    <div class="mt-3">
-        <label class="form-label" for="bulk-status">Status</label>
-        <select id="bulk-status" class="form-select" name="status" required>
-            <option value="">Select status…</option>
-            <option value="active">Active</option>
-            <option value="stopped">Stopped</option>
-        </select>
-    </div>
-</form>
-"""
+_MAP_EXPORT_BULK_UPDATE_STATUS_FORM = bulk_status_select_form(MapExportScheduleStatus)
 
 _CASE_INSENSITIVE_STRING_OPERATORS: Dict[str, Callable[..., ClauseElement]] = {
     **OPERATORS,
@@ -666,7 +652,7 @@ class MapExportScheduleView(CaseInsensitiveColumnFilterMixin, PrismGatedModelVie
         submit_btn_text="Update status",
         submit_btn_class="btn-primary",
         icon_class="fa-solid fa-toggle-on",
-        form=_BULK_UPDATE_STATUS_FORM,
+        form=_MAP_EXPORT_BULK_UPDATE_STATUS_FORM,
     )
     async def update_status_action(self, request: Request, pks: List[Any]) -> str:
         data = await request.form()

--- a/api/prism_app/dashboard/dashboard_admin.py
+++ b/api/prism_app/dashboard/dashboard_admin.py
@@ -3,6 +3,7 @@
 import json
 from typing import Any, cast
 
+from prism_app.admin_bulk_actions import bulk_status_select_form
 from prism_app.dashboard.dashboard_config_field import DashboardConfigJsonFileField
 from prism_app.database.dashboard_model import DashboardCountry, DashboardStatus
 from prism_app.utils import utc_now
@@ -24,23 +25,7 @@ _DUPLICATE_DASHBOARD_FALLBACK_MSG = (
     "Change the title in your config JSON or edit the existing dashboard."
 )
 
-# Starlette-admin batch actions take pre-rendered HTML for ``form``, not a template
-# path. The list page embeds this string in each action link's ``data-form``
-# attribute; client JS copies it into the confirmation modal on click.
-_BULK_UPDATE_STATUS_FORM = """
-<form>
-    <div class="mt-3">
-        <label class="form-label" for="bulk-status">Status</label>
-        <select id="bulk-status" class="form-select" name="status" required>
-            <option value="">Select status…</option>
-            <option value="draft">draft</option>
-            <option value="published">published</option>
-            <option value="staging">staging</option>
-            <option value="archived">archived</option>
-        </select>
-    </div>
-</form>
-"""
+_DASHBOARD_BULK_UPDATE_STATUS_FORM = bulk_status_select_form(DashboardStatus)
 
 
 class DashboardAdminView(ModelView):
@@ -114,7 +99,7 @@ class DashboardAdminView(ModelView):
         submit_btn_text="Update status",
         submit_btn_class="btn-primary",
         icon_class="fa-solid fa-toggle-on",
-        form=_BULK_UPDATE_STATUS_FORM,
+        form=_DASHBOARD_BULK_UPDATE_STATUS_FORM,
     )
     async def update_status_action(self, request: Request, pks: list[Any]) -> str:
         data = await request.form()

--- a/api/prism_app/dashboard/dashboard_admin.py
+++ b/api/prism_app/dashboard/dashboard_admin.py
@@ -5,11 +5,15 @@ from typing import Any, cast
 
 from prism_app.dashboard.dashboard_config_field import DashboardConfigJsonFileField
 from prism_app.database.dashboard_model import DashboardCountry, DashboardStatus
+from prism_app.utils import utc_now
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
 from starlette.requests import Request
+from starlette_admin.actions import action
 from starlette_admin.contrib.sqla import ModelView
-from starlette_admin.exceptions import FormValidationError
+from starlette_admin.exceptions import ActionFailed, FormValidationError
 from starlette_admin.fields import EnumField
+from starlette_admin.i18n import ngettext
 
 _DASHBOARD_COUNTRY_CHOICES = [
     (country.value, country.value) for country in DashboardCountry
@@ -19,6 +23,24 @@ _DUPLICATE_DASHBOARD_FALLBACK_MSG = (
     "A dashboard with this title already exists for the selected country. "
     "Change the title in your config JSON or edit the existing dashboard."
 )
+
+# Starlette-admin batch actions take pre-rendered HTML for ``form``, not a template
+# path. The list page embeds this string in each action link's ``data-form``
+# attribute; client JS copies it into the confirmation modal on click.
+_BULK_UPDATE_STATUS_FORM = """
+<form>
+    <div class="mt-3">
+        <label class="form-label" for="bulk-status">Status</label>
+        <select id="bulk-status" class="form-select" name="status" required>
+            <option value="">Select status…</option>
+            <option value="draft">draft</option>
+            <option value="published">published</option>
+            <option value="staging">staging</option>
+            <option value="archived">archived</option>
+        </select>
+    </div>
+</form>
+"""
 
 
 class DashboardAdminView(ModelView):
@@ -33,6 +55,7 @@ class DashboardAdminView(ModelView):
 
     label = "Dashboards"
     name = "dashboard"
+    list_template = "dashboard_list.html"
     detail_template = "detail_dashboard.html"
     edit_template = "edit_no_add_another.html"
     create_template = "create_no_add_another.html"
@@ -82,6 +105,61 @@ class DashboardAdminView(ModelView):
         "status",
         "country",
     ]
+    actions = ["update_status", "delete"]
+
+    @action(
+        name="update_status",
+        text="Update status",
+        confirmation="Update the status of the selected dashboards?",
+        submit_btn_text="Update status",
+        submit_btn_class="btn-primary",
+        icon_class="fa-solid fa-toggle-on",
+        form=_BULK_UPDATE_STATUS_FORM,
+    )
+    async def update_status_action(self, request: Request, pks: list[Any]) -> str:
+        data = await request.form()
+        status_raw = data.get("status")
+        if not status_raw:
+            raise ActionFailed("Status is required")
+        try:
+            new_status = DashboardStatus(str(status_raw))
+        except ValueError as exc:
+            raise ActionFailed(f"Invalid status: {status_raw}") from exc
+
+        session: Session = request.state.session
+        dashboards = list(await self.find_by_pks(request, pks))
+        if not dashboards:
+            raise ActionFailed("No accessible dashboards selected")
+
+        now = utc_now()
+        for dashboard in dashboards:
+            dashboard.status = new_status
+            dashboard.updated_at = now
+            session.add(dashboard)
+        session.commit()
+
+        count = len(dashboards)
+        label = new_status.value
+        return f"Updated {count} dashboard{'s' if count != 1 else ''} to {label}."
+
+    @action(
+        name="delete",
+        text="Delete dashboards",
+        confirmation=(
+            "Are you sure you want to delete the selected dashboards? "
+            "This cannot be undone."
+        ),
+        submit_btn_text="Yes, delete",
+        submit_btn_class="btn-danger",
+        icon_class="fa-solid fa-trash",
+    )
+    async def delete_action(self, request: Request, pks: list[Any]) -> str:
+        affected_rows = await self.delete(request, pks)
+        return ngettext(
+            "Dashboard was successfully deleted",
+            "%(count)d dashboards were successfully deleted",
+            affected_rows or 0,
+        ) % {"count": affected_rows}
 
     async def validate(self, request: Request, data: dict[str, Any]) -> None:
         errors: dict[str, str] = {}

--- a/api/prism_app/templates/dashboard_list.html
+++ b/api/prism_app/templates/dashboard_list.html
@@ -1,0 +1,7 @@
+{% extends "list.html" %}
+
+{% block modal %}
+    {% include "modals/loading.html" %}
+    {% include "modals/error.html" %}
+    {% include "modals/bulk_action_confirm.html" %}
+{% endblock %}

--- a/api/prism_app/tests/test_admin_bulk_actions.py
+++ b/api/prism_app/tests/test_admin_bulk_actions.py
@@ -33,8 +33,8 @@ def test_bulk_status_select_form_renders_tuple_labels() -> None:
 
 def test_dashboard_view_uses_shared_bulk_status_form() -> None:
     from prism_app.dashboard.dashboard_admin import (
-        DashboardAdminView,
         _DASHBOARD_BULK_UPDATE_STATUS_FORM,
+        DashboardAdminView,
     )
     from prism_app.database.dashboard_model import DashboardModel
 
@@ -44,8 +44,8 @@ def test_dashboard_view_uses_shared_bulk_status_form() -> None:
 
 def test_map_export_view_uses_shared_bulk_status_form() -> None:
     from prism_app.admin_map_export import (
-        MapExportScheduleView,
         _MAP_EXPORT_BULK_UPDATE_STATUS_FORM,
+        MapExportScheduleView,
     )
     from prism_app.database.map_export_schedule_model import MapExportSchedule
 

--- a/api/prism_app/tests/test_admin_bulk_actions.py
+++ b/api/prism_app/tests/test_admin_bulk_actions.py
@@ -1,0 +1,67 @@
+"""Tests for shared Starlette Admin batch action form helpers."""
+
+from enum import Enum
+
+from prism_app.admin_bulk_actions import bulk_status_select_form
+from prism_app.database.dashboard_model import DashboardStatus
+from prism_app.database.map_export_schedule_model import MapExportScheduleStatus
+
+
+class _SampleStatus(str, Enum):
+    on = "on"
+    off = "off"
+
+
+def test_bulk_status_select_form_renders_enum_values() -> None:
+    form = bulk_status_select_form(DashboardStatus)
+
+    assert 'name="status"' in form
+    assert 'id="bulk-status"' in form
+    for status in DashboardStatus:
+        assert f'value="{status.value}"' in form
+        assert f">{status.value}</option>" in form
+
+
+def test_bulk_status_select_form_renders_tuple_labels() -> None:
+    form = bulk_status_select_form([("active", "Active"), ("stopped", "Stopped")])
+
+    assert 'value="active"' in form
+    assert ">Active</option>" in form
+    assert 'value="stopped"' in form
+    assert ">Stopped</option>" in form
+
+
+def test_dashboard_view_uses_shared_bulk_status_form() -> None:
+    from prism_app.dashboard.dashboard_admin import (
+        DashboardAdminView,
+        _DASHBOARD_BULK_UPDATE_STATUS_FORM,
+    )
+    from prism_app.database.dashboard_model import DashboardModel
+
+    view = DashboardAdminView(DashboardModel)
+    assert view._actions["update_status"]["form"] == _DASHBOARD_BULK_UPDATE_STATUS_FORM
+
+
+def test_map_export_view_uses_shared_bulk_status_form() -> None:
+    from prism_app.admin_map_export import (
+        MapExportScheduleView,
+        _MAP_EXPORT_BULK_UPDATE_STATUS_FORM,
+    )
+    from prism_app.database.map_export_schedule_model import MapExportSchedule
+
+    view = MapExportScheduleView(MapExportSchedule)
+    assert view._actions["update_status"]["form"] == _MAP_EXPORT_BULK_UPDATE_STATUS_FORM
+
+
+def test_map_export_bulk_form_includes_schedule_statuses() -> None:
+    form = bulk_status_select_form(MapExportScheduleStatus)
+
+    assert 'value="active"' in form
+    assert 'value="stopped"' in form
+
+
+def test_bulk_status_select_form_supports_string_choices() -> None:
+    form = bulk_status_select_form(_SampleStatus)
+
+    assert 'value="on"' in form
+    assert 'value="off"' in form

--- a/api/prism_app/tests/test_admin_map_export.py
+++ b/api/prism_app/tests/test_admin_map_export.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 from uuid import uuid4
 
 import pytest
+from prism_app.admin_bulk_actions import bulk_status_select_form
 from prism_app.admin_map_export import (
     MapExportJobView,
     MapExportScheduleView,
@@ -182,9 +183,9 @@ def test_schedule_view_bulk_actions_include_update_status_and_delete() -> None:
     assert "delete" in view._actions
     assert view._actions["update_status"]["confirmation"]
     assert view._actions["delete"]["confirmation"]
-    assert 'name="status"' in view._actions["update_status"]["form"]
-    assert 'value="active"' in view._actions["update_status"]["form"]
-    assert 'value="stopped"' in view._actions["update_status"]["form"]
+    assert view._actions["update_status"]["form"] == bulk_status_select_form(
+        MapExportScheduleStatus
+    )
 
 
 @pytest.mark.asyncio

--- a/api/prism_app/tests/test_dashboard_admin.py
+++ b/api/prism_app/tests/test_dashboard_admin.py
@@ -1,0 +1,96 @@
+"""Admin dashboard view bulk actions."""
+
+from uuid import uuid4
+
+import pytest
+from prism_app.dashboard.dashboard_admin import DashboardAdminView
+from prism_app.database.dashboard_model import (
+    DashboardCountry,
+    DashboardModel,
+    DashboardStatus,
+)
+from starlette.datastructures import FormData
+from starlette.requests import Request
+from starlette_admin.exceptions import ActionFailed
+
+
+def _request() -> Request:
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/",
+        "query_string": b"",
+        "headers": [],
+    }
+    return Request(scope)
+
+
+def test_dashboard_view_bulk_actions_include_update_status_and_delete() -> None:
+    view = DashboardAdminView(DashboardModel)
+    assert view.list_template == "dashboard_list.html"
+    assert view.actions == ["update_status", "delete"]
+    assert "update_status" in view._actions
+    assert "delete" in view._actions
+    assert view._actions["update_status"]["confirmation"]
+    assert view._actions["delete"]["confirmation"]
+    assert 'name="status"' in view._actions["update_status"]["form"]
+    assert 'value="draft"' in view._actions["update_status"]["form"]
+    assert 'value="published"' in view._actions["update_status"]["form"]
+    assert 'value="staging"' in view._actions["update_status"]["form"]
+    assert 'value="archived"' in view._actions["update_status"]["form"]
+
+
+@pytest.mark.asyncio
+async def test_update_status_action_requires_status() -> None:
+    view = DashboardAdminView(DashboardModel)
+    request = _request()
+    request._form = FormData([])  # noqa: SLF001
+
+    async def _fake_form() -> FormData:
+        return request._form  # noqa: SLF001
+
+    request.form = _fake_form  # type: ignore[method-assign]
+
+    with pytest.raises(ActionFailed, match="Status is required"):
+        await view.update_status_action(request, [str(uuid4())])
+
+
+@pytest.mark.asyncio
+async def test_update_status_action_updates_selected_dashboards(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from unittest.mock import AsyncMock, MagicMock
+
+    view = DashboardAdminView(DashboardModel)
+    dashboard = DashboardModel(
+        id=uuid4(),
+        title="Mozambique overview",
+        path="mozambique/mozambique-overview",
+        status=DashboardStatus.draft,
+        country=DashboardCountry.mozambique,
+        config={"title": "Mozambique overview", "country": "mozambique"},
+    )
+    request = _request()
+    request._form = FormData([("status", "published")])  # noqa: SLF001
+
+    async def _fake_form() -> FormData:
+        return request._form  # noqa: SLF001
+
+    request.form = _fake_form  # type: ignore[method-assign]
+
+    session = MagicMock()
+    request.state.session = session
+    monkeypatch.setattr(
+        view,
+        "find_by_pks",
+        AsyncMock(return_value=[dashboard]),
+    )
+
+    message = await view.update_status_action(request, [str(dashboard.id)])
+
+    assert dashboard.status == DashboardStatus.published
+    assert dashboard.updated_at is not None
+    session.add.assert_called_once_with(dashboard)
+    session.commit.assert_called_once()
+    assert "1 dashboard" in message
+    assert "published" in message

--- a/api/prism_app/tests/test_dashboard_admin.py
+++ b/api/prism_app/tests/test_dashboard_admin.py
@@ -3,6 +3,7 @@
 from uuid import uuid4
 
 import pytest
+from prism_app.admin_bulk_actions import bulk_status_select_form
 from prism_app.dashboard.dashboard_admin import DashboardAdminView
 from prism_app.database.dashboard_model import (
     DashboardCountry,
@@ -33,11 +34,9 @@ def test_dashboard_view_bulk_actions_include_update_status_and_delete() -> None:
     assert "delete" in view._actions
     assert view._actions["update_status"]["confirmation"]
     assert view._actions["delete"]["confirmation"]
-    assert 'name="status"' in view._actions["update_status"]["form"]
-    assert 'value="draft"' in view._actions["update_status"]["form"]
-    assert 'value="published"' in view._actions["update_status"]["form"]
-    assert 'value="staging"' in view._actions["update_status"]["form"]
-    assert 'value="archived"' in view._actions["update_status"]["form"]
+    assert view._actions["update_status"]["form"] == bulk_status_select_form(
+        DashboardStatus
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Description

Allows bulk updating of status and bulk deletion of dashboard items.

**Refactor:** bulk action forms are now dynamic for DRYness.

<!-- what this does -->

## How to test the feature:

- As either an admin or dashboard manager user, navigate to `/admin/dashboards`
- Select multiple dashboards and navigate to the the dropdown that says "selected"
- Updating status should open a modal - primary action should update the selected statuses accordingly
- Delete should also open a modal - primary action removes row(s) from the database

Regression test map export schedule bulk actions (same steps above)

## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [x] Add / update necessary tests?

## Screenshot/video of feature:

**Dashboard bulk actions dropdown**
<img width="210" height="148" alt="image" src="https://github.com/user-attachments/assets/869016a6-4211-4491-a707-664f1991e439" />

**Status modal**
<img width="428" height="296" alt="image" src="https://github.com/user-attachments/assets/f2a86309-5172-42f1-a5d0-5e89fa8c3f1a" />

**Delete modal**
<img width="403" height="240" alt="image" src="https://github.com/user-attachments/assets/79b4244f-8e6b-421b-a89a-8baedb1ad0ae" />

