### PR TITLE
Bugfix: admin user permission assignment

### DIFF
--- a/api/prism_app/admin.py
+++ b/api/prism_app/admin.py
@@ -12,7 +12,9 @@ from prism_app.database.kobo_user_model import KoboUser
 from prism_app.database.permission_model import Permission, UserPermission
 from prism_app.database.user_model import User
 from starlette.requests import Request
+from starlette_admin import HasOne
 from starlette_admin.contrib.sqla import Admin, ModelView
+from starlette_admin.exceptions import FormValidationError
 
 
 class PrismGatedModelView(ModelView):
@@ -110,8 +112,38 @@ class UserPermissionView(PrismGatedModelView):
     """Grant or revoke capability codes (e.g. ``prism.admin.access``, ``prism.content.view``)."""
 
     label = "User permissions"
-    fields = ("user", "permission", "granted_at")
+    fields = (
+        HasOne("user", label="User", identity="user"),
+        HasOne("permission", label="Permission", identity="permission"),
+        "granted_at",
+    )
     exclude_fields_from_create = ("granted_at",)  # auto-set to now() by DB default
+
+    async def _populate_obj(
+        self,
+        request: Request,
+        obj: UserPermission,
+        data: dict,
+        is_edit: bool = False,
+    ) -> UserPermission:
+        obj = await super()._populate_obj(request, obj, data, is_edit)
+        user = data.get("user")
+        permission = data.get("permission")
+        if user is not None:
+            obj.user_id = user.id
+        if permission is not None:
+            obj.permission_id = permission.id
+        return obj
+
+    async def validate(self, request: Request, data: dict) -> None:
+        errors: dict[str, str] = {}
+        if data.get("user") is None:
+            errors["user"] = "Select a user."
+        if data.get("permission") is None:
+            errors["permission"] = "Select a permission."
+        if errors:
+            raise FormValidationError(errors)
+        await super().validate(request, data)
 
 
 def register_alerts_admin_views(admin: Admin) -> None:

--- a/api/prism_app/database/permission_model.py
+++ b/api/prism_app/database/permission_model.py
@@ -8,6 +8,7 @@ import sqlalchemy as sa
 from markupsafe import escape
 from sqlalchemy import Column, DateTime, ForeignKey, String, Text, text
 from sqlalchemy.dialects.postgresql import UUID as PG_UUID
+from sqlalchemy.orm import relationship
 from sqlmodel import Field, Relationship, SQLModel
 
 
@@ -79,5 +80,19 @@ class UserPermission(SQLModel, table=True):
             server_default=sa.text("now()"),
         ),
     )
-    user: "User" = Relationship()
-    permission: Permission = Relationship()
+    user: "User" = Relationship(
+        sa_relationship=relationship(
+            "User",
+            primaryjoin="UserPermission.user_id == User.id",
+            foreign_keys="UserPermission.user_id",
+            uselist=False,
+        ),
+    )
+    permission: Permission = Relationship(
+        sa_relationship=relationship(
+            Permission,
+            primaryjoin="UserPermission.permission_id == Permission.id",
+            foreign_keys="UserPermission.permission_id",
+            uselist=False,
+        ),
+    )

--- a/api/prism_app/tests/test_admin_permissions.py
+++ b/api/prism_app/tests/test_admin_permissions.py
@@ -1,6 +1,9 @@
 """Admin panel permission helpers and view gates."""
 
-from prism_app.admin import AlertView
+from uuid import uuid4
+
+import pytest
+from prism_app.admin import AlertView, UserPermissionView
 from prism_app.admin_map_export import MapExportScheduleView
 from prism_app.auth.admin_request import (
     request_can_manage_dashboards,
@@ -18,7 +21,11 @@ from prism_app.auth.permission_codes import (
 )
 from prism_app.database.alert_model import AlertModel
 from prism_app.database.map_export_schedule_model import MapExportSchedule
+from prism_app.database.permission_model import Permission, UserPermission
+from prism_app.database.user_model import User
 from starlette.requests import Request
+from starlette_admin._types import RequestAction
+from starlette_admin.exceptions import FormValidationError
 
 
 def _request_with_codes(codes: set[str]) -> Request:
@@ -76,3 +83,54 @@ def test_map_export_manager_sees_only_schedule_view_in_admin() -> None:
 
     assert schedule_view.is_accessible(request) is True
     assert alert_view.is_accessible(request) is False
+
+
+def _admin_create_request() -> Request:
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/admin/user-permission/create",
+        "headers": [],
+    }
+    request = Request(scope)
+    request.state.action = RequestAction.CREATE
+    return request
+
+
+def test_user_permission_relationship_assign_does_not_sync_fk_columns() -> None:
+    """Starlette-admin sets relationships; SQLModel leaves FK columns unset without help."""
+    user = User(id=uuid4(), ciam_sub="ciam-sub")
+    permission = Permission(id=uuid4(), code="prism.admin.access", label="Admin")
+    link = UserPermission()
+    link.user = user
+    link.permission = permission
+    assert link.user_id is None
+    assert link.permission_id is None
+
+
+@pytest.mark.asyncio
+async def test_user_permission_populate_obj_sets_foreign_keys() -> None:
+    view = UserPermissionView(UserPermission)
+    request = _admin_create_request()
+    user = User(id=uuid4(), ciam_sub="ciam-sub")
+    permission = Permission(id=uuid4(), code="prism.admin.access", label="Admin")
+    data = {"user": user, "permission": permission, "granted_at": None}
+
+    obj = await view._populate_obj(request, UserPermission(), data)
+
+    assert obj.user_id == user.id
+    assert obj.permission_id == permission.id
+
+
+@pytest.mark.asyncio
+async def test_user_permission_validate_requires_user_and_permission() -> None:
+    view = UserPermissionView(UserPermission)
+    request = _admin_create_request()
+
+    with pytest.raises(FormValidationError) as exc_info:
+        await view.validate(request, {"user": None, "permission": None})
+
+    assert exc_info.value.errors == {
+        "user": "Select a user.",
+        "permission": "Select a permission.",
+    }


### PR DESCRIPTION
### Description

Prior to this PR, we weren't able to create new `user_permission` instances in admin.

<!-- what this does -->

## How to test the feature:

- Clone an existing db user
- As a user with admin access, create a "user permission" from the user permissions admin page and verify that it does not error

## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

## Screenshot/video of feature:

<img width="884" height="444" alt="image" src="https://github.com/user-attachments/assets/11c2a6b7-2b20-4a9b-a394-6db0a140d33f" />