### PR TITLE
Fix admin area clipping in universal deployment export/print.

### DIFF
--- a/frontend/src/utils/adminAreaClipPolygon.ts
+++ b/frontend/src/utils/adminAreaClipPolygon.ts
@@ -10,6 +10,7 @@ import {
   filterFeaturesBySelectedAdminCodes,
   resolveFeaturesForAdminCodes,
 } from './adminAreaSelection';
+import { isUniversalDeployment } from './universal-utils';
 
 export type AdminAreaClipPolygon = Feature<Polygon | MultiPolygon>;
 
@@ -116,6 +117,10 @@ export async function resolveAdminAreaClipPolygon(options: {
     if (fromSelection) {
       return fromSelection;
     }
+  }
+
+  if (isUniversalDeployment()) {
+    return buildCountryClipPolygonFromBoundaryData(effectiveBoundaryData);
   }
 
   try {

--- a/frontend/src/utils/useAdminAreaClipForExport.ts
+++ b/frontend/src/utils/useAdminAreaClipForExport.ts
@@ -49,20 +49,24 @@ export function useAdminAreaClipForExport(options: {
     ...clipOptions
   } = options;
 
+  // Source of boundary layer differs between non-universal and universal deployments.
   const effectiveBoundaryLayer = useMemo(() => {
     if (!isUniversalDeployment()) {
       return boundaryLayer;
     }
+    // Universal deployment: use the boundary layer for the current ISO3, unless it's hidden in Go To.
     return (
       getDisplayBoundaryLayersForIso3(iso3).find(layer => !layer.hideInGoTo) ??
       boundaryLayer
     );
   }, [boundaryLayer, iso3]);
 
+  // Source of boundary data differs between non-universal and universal deployments.
   const effectiveBoundaryData = useMemo(() => {
     if (!isUniversalDeployment()) {
       return boundaryData;
     }
+    // Universal deployment: use the cached boundary layer data for the current ISO3.
     return (
       getCachedBoundaryLayerData(effectiveBoundaryLayer.id, iso3) ??
       boundaryData

--- a/frontend/src/utils/useAdminAreaClipForExport.ts
+++ b/frontend/src/utils/useAdminAreaClipForExport.ts
@@ -13,7 +13,10 @@ import {
   type LngLatBbox,
 } from './adminAreaClipPolygon';
 import { getCachedBoundaryLayerData } from './boundary-cache';
-import { isUniversalDeployment } from './universal-utils';
+import {
+  getDisplayBoundaryLayersForIso3,
+  isUniversalDeployment,
+} from './universal-utils';
 import { useAdminAreaClipPolygon } from './useAdminAreaClipPolygon';
 
 /**
@@ -38,7 +41,33 @@ export function useAdminAreaClipForExport(options: {
   const { t } = useSafeTranslation();
   const { iso3 } = useCountryIso();
 
-  const { map, ...clipOptions } = options;
+  const {
+    map,
+    boundaryLayer,
+    boundaryData,
+    boundaryLayersVersion,
+    ...clipOptions
+  } = options;
+
+  const effectiveBoundaryLayer = useMemo(() => {
+    if (!isUniversalDeployment()) {
+      return boundaryLayer;
+    }
+    return (
+      getDisplayBoundaryLayersForIso3(iso3).find(layer => !layer.hideInGoTo) ??
+      boundaryLayer
+    );
+  }, [boundaryLayer, iso3]);
+
+  const effectiveBoundaryData = useMemo(() => {
+    if (!isUniversalDeployment()) {
+      return boundaryData;
+    }
+    return (
+      getCachedBoundaryLayerData(effectiveBoundaryLayer.id, iso3) ??
+      boundaryData
+    );
+  }, [boundaryData, effectiveBoundaryLayer.id, iso3, boundaryLayersVersion]);
 
   const getLayerData = useCallback(
     (layerId: string) =>
@@ -75,6 +104,9 @@ export function useAdminAreaClipForExport(options: {
 
   return useAdminAreaClipPolygon({
     ...clipOptions,
+    boundaryLayer: effectiveBoundaryLayer,
+    boundaryData: effectiveBoundaryData,
+    boundaryLayersVersion,
     getLayerData,
     coverageBounds,
     onIncompleteCoverage,


### PR DESCRIPTION
### Description

Fixes country-mask clipping for WMS raster layers in universal (COUNTRY=universal) export and print when an admin unit is selected:
* The clip resolver was using universal_admin3_boundaries (hidden from the dropdown), which had no cached geometry — so adminAreaClipPolygon was always null and rasters rendered unclipped.
* Also skips the unified boundary JSON fetch for universal deployments which was hitting the fallback and producing a misleading warning.

## How to test the feature:

- [ ] In universal deployment: open print/export with country mask enabled, no admin selection → WMS rasters clip to full country outline; no unified-boundary warning in console.
- [ ] Universal deployment: select an admin unit (admin1/admin2) → WMS rasters clip to selected area.
- [ ] Non-universal deployment (e.g. Mozambique): country mask still works via existing unified boundary file path.

## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [ ] `REACT_APP_COUNTRY=rbd yarn start`
- [ ] `REACT_APP_COUNTRY=cambodia yarn start`
- [x] `REACT_APP_COUNTRY=mozambique yarn start`
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

## Screenshot/video of feature:
<img width="1463" height="1195" alt="Screenshot 2026-07-01 at 11 24 21 AM" src="https://github.com/user-attachments/assets/bd76ad07-036c-42de-a681-baf8cb191e60" />
