### PR TITLE
Fix export_map_worker crash and add CI import smoke check.

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -146,6 +146,11 @@ jobs:
       - uses: actions/checkout@v4
       - name: Build ${{ matrix.image_label }} image
         run: docker build -f "api/${{ matrix.dockerfile }}" -t "${{ matrix.image_tag }}" api
+      - name: Worker entrypoint import smoke
+        if: matrix.image_label == 'export-map-worker'
+        run: |
+          docker run --rm "${{ matrix.image_tag }}" \
+            python -m prism_app.ci.worker_import_smoke
       - name: Trivy vulnerability scan
         uses: aquasecurity/trivy-action@v0.36.0
         with:

--- a/api/Makefile
+++ b/api/Makefile
@@ -50,6 +50,12 @@ db-downgrade:
 db-seed: db-migrate
 	$(DEV_COMPOSE) exec -T api bash -c "poetry run python /scripts/seed_alerts_db.py"
 
+# Verify all worker entrypoints import in the slim worker image (CI parity).
+worker-import-smoke:
+	docker compose -f docker-compose.yml build export_map_worker
+	docker compose -f docker-compose.yml run --rm --no-deps export_map_worker \
+	  python -m prism_app.ci.worker_import_smoke
+
 # Enqueue map_export_jobs from active map_export_schedules (requires `make api` running).
 schedule-cron:
 	$(DEV_COMPOSE) exec -T api poetry run python -m prism_app.workers.scheduled_public_maps.cron

--- a/api/prism_app/ci/worker_import_smoke.py
+++ b/api/prism_app/ci/worker_import_smoke.py
@@ -1,0 +1,42 @@
+"""Import every worker entrypoint to catch missing deps in the slim worker image.
+
+Runs inside the Dockerfile.export-map-worker image in CI. Catches the class of bug
+where requirements-export-map-worker.txt drifts from the worker import graph
+(e.g. a transitive `pydantic_settings` import added to prism_app.auth.admin_settings).
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+WORKER_ENTRYPOINTS = (
+    "prism_app.workers.export_map_worker",
+    "prism_app.workers.alert_runner",
+    "prism_app.workers.scheduled_public_maps.cron",
+    "prism_app.workers.schedule_export_email_runner",
+)
+
+
+def main() -> None:
+    failures: list[str] = []
+    for module in WORKER_ENTRYPOINTS:
+        try:
+            importlib.import_module(module)
+            print(f"OK  {module}")
+        except Exception as exc:  # noqa: BLE001 - report all import-time failures
+            failures.append(f"{module}: {type(exc).__name__}: {exc}")
+            print(f"FAIL {module}: {type(exc).__name__}: {exc}", file=sys.stderr)
+
+    if failures:
+        print(
+            f"\nWorker import smoke FAILED ({len(failures)} module(s)). "
+            "Likely a missing dependency in requirements-export-map-worker.txt.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    print(f"\nWorker import smoke OK ({len(WORKER_ENTRYPOINTS)} entrypoints)")
+
+
+if __name__ == "__main__":
+    main()

--- a/api/requirements-export-map-worker.txt
+++ b/api/requirements-export-map-worker.txt
@@ -10,6 +10,9 @@ sqlmodel==0.0.22
 SQLAlchemy==2.0.48
 psycopg2-binary==2.9.11
 pydantic[email]==2.12.5
+pydantic-settings==2.14.2
+python-dotenv==1.2.2
+typing-inspection==0.4.2
 fastapi==0.136.1
 starlette==1.3.1
 markupsafe==3.0.3


### PR DESCRIPTION
### Description
Add pydantic-settings and its related deps to worker requirements so export_map_worker can import admin_settings via the database model graph. 

Add a CI step that imports all worker entrypoints inside the built export-map-worker image to catch future dependency drift.

<img width="1017" height="396" alt="Screenshot 2026-07-01 at 1 35 48 PM" src="https://github.com/user-attachments/assets/47852cfc-53a5-407a-b2d6-5e812cb913ea" />
