### PR TITLE
Revive AA drought CSV staging on S3; COUNTRY=zimbabwe

### DIFF
--- a/frontend/src/config/malawi/prism.json
+++ b/frontend/src/config/malawi/prism.json
@@ -1,7 +1,7 @@
 {
   "country": "Malawi",
   "anticipatoryActionDroughtUrl": "https://hip-workshop-sharing-public-eu-central-1-485262375119.s3.eu-central-1.amazonaws.com/anticipatory-action/mwi/prism/aa_probabilities_triggers_mwi.csv",
-  "anticipatoryActionDroughtStagingUrl": "https://hip-workshop-sharing-public-eu-central-1-485262375119.s3.eu-central-1.amazonaws.com/anticipatory-action/mwi/prism/staging/aa_probabilities_triggers_mwi.csv",
+  "anticipatoryActionDroughtPreviewUrl": "https://hip-workshop-sharing-public-eu-central-1-485262375119.s3.eu-central-1.amazonaws.com/anticipatory-action/mwi/prism/staging/aa_probabilities_triggers_mwi.csv",
   "countryAdmin0Id": 152,
   "alertFormActive": false,
   "enableNavigationDropdown": true,

--- a/frontend/src/config/mozambique/prism.json
+++ b/frontend/src/config/mozambique/prism.json
@@ -2,7 +2,7 @@
   "country": "Mozambique",
   "defaultLanguage": "en",
   "anticipatoryActionDroughtUrl": "https://hip-workshop-sharing-public-eu-central-1-485262375119.s3.eu-central-1.amazonaws.com/anticipatory-action/moz/prism/aa_probabilities_triggers_moz.csv",
-  "anticipatoryActionDroughtStagingUrl": "https://data.earthobservation.vam.wfp.org/public-share/aa/staging/aa_probabilities_triggers_moz.csv",
+  "anticipatoryActionDroughtPreviewUrl": "https://data.earthobservation.vam.wfp.org/public-share/aa/staging/aa_probabilities_triggers_moz.csv",
   "anticipatoryActionStormUrl": "https://data.earthobservation.vam.wfp.org/public-share/aa/ts/outputs/latest.json.",
   "anticipatoryActionFloodUrl": "https://data.earthobservation.vam.wfp.org/public-share/aa/flood/moz/dates.json",
   "header": {

--- a/frontend/src/config/tanzania/prism.json
+++ b/frontend/src/config/tanzania/prism.json
@@ -2,7 +2,7 @@
   "country": "Tanzania",
   "countryAdmin0Id": 257,
   "anticipatoryActionDroughtUrl": "https://hip-workshop-sharing-public-eu-central-1-485262375119.s3.eu-central-1.amazonaws.com/anticipatory-action/tza/prism/aa_probabilities_triggers_tza.csv",
-  "anticipatoryActionDroughtStagingUrl": "https://hip-workshop-sharing-public-eu-central-1-485262375119.s3.eu-central-1.amazonaws.com/anticipatory-action/tza/prism/staging/aa_probabilities_triggers_tza.csv",
+  "anticipatoryActionDroughtPreviewUrl": "https://hip-workshop-sharing-public-eu-central-1-485262375119.s3.eu-central-1.amazonaws.com/anticipatory-action/tza/prism/staging/aa_probabilities_triggers_tza.csv",
   "alertFormActive": false,
   "enableNavigationDropdown": true,
   "serversUrls": {

--- a/frontend/src/config/zambia/prism.json
+++ b/frontend/src/config/zambia/prism.json
@@ -4,7 +4,7 @@
   "alertFormActive": false,
   "enableNavigationDropdown": true,
   "anticipatoryActionDroughtUrl": "https://hip-workshop-sharing-public-eu-central-1-485262375119.s3.eu-central-1.amazonaws.com/anticipatory-action/zmb/prism/aa_probabilities_triggers_zmb.csv",
-  "anticipatoryActionDroughtStagingUrl": "https://hip-workshop-sharing-public-eu-central-1-485262375119.s3.eu-central-1.amazonaws.com/anticipatory-action/zmb/prism/staging/aa_probabilities_triggers_zmb.csv",
+  "anticipatoryActionDroughtPreviewUrl": "https://hip-workshop-sharing-public-eu-central-1-485262375119.s3.eu-central-1.amazonaws.com/anticipatory-action/zmb/prism/staging/aa_probabilities_triggers_zmb.csv",
   "serversUrls": {
     "wms": ["https://api.earthobservation.vam.wfp.org/ows/wms"]
   },

--- a/frontend/src/config/zimbabwe/prism.json
+++ b/frontend/src/config/zimbabwe/prism.json
@@ -4,7 +4,7 @@
   "alertFormActive": false,
   "enableNavigationDropdown": true,
   "anticipatoryActionDroughtUrl": "https://hip-workshop-sharing-public-eu-central-1-485262375119.s3.eu-central-1.amazonaws.com/anticipatory-action/zwe/prism/aa_probabilities_triggers_zwe.csv",
-  "anticipatoryActionDroughtStagingUrl": "https://hip-workshop-sharing-public-eu-central-1-485262375119.s3.eu-central-1.amazonaws.com/anticipatory-action/zwe/prism/staging/aa_probabilities_triggers_zwe.csv",
+  "anticipatoryActionDroughtPreviewUrl": "https://hip-workshop-sharing-public-eu-central-1-485262375119.s3.eu-central-1.amazonaws.com/anticipatory-action/zwe/prism/staging/aa_probabilities_triggers_zwe.csv",
   "serversUrls": {
     "wms": ["https://api.earthobservation.vam.wfp.org/ows/wms"]
   },

--- a/frontend/src/utils/url-utils.test.ts
+++ b/frontend/src/utils/url-utils.test.ts
@@ -1,9 +1,9 @@
 import { AA_DROUGHT_API_URL } from './constants';
 import {
-  getAACsvPreviewParam,
   getAADroughtCdnUrl,
+  getAADroughtPreviewParam,
+  getAADroughtStagingParam,
   getAADroughtUrl,
-  getStagingParam,
 } from './url-utils';
 
 const PROD_URL = 'https://cdn.example.com/zimbabwe/aa_drought.csv';
@@ -20,19 +20,19 @@ function setSearch(search: string) {
 
 afterEach(() => setSearch(''));
 
-describe('getStagingParam / getAACsvPreviewParam', () => {
+describe('getAADroughtStagingParam / getAADroughtPreviewParam', () => {
   test('read their own params independently', () => {
-    setSearch('staging=true');
-    expect(getStagingParam()).toBe(true);
-    expect(getAACsvPreviewParam()).toBe(false);
+    setSearch('aa-drought-staging=true');
+    expect(getAADroughtStagingParam()).toBe(true);
+    expect(getAADroughtPreviewParam()).toBe(false);
 
-    setSearch('aa-csv-preview=true');
-    expect(getStagingParam()).toBe(false);
-    expect(getAACsvPreviewParam()).toBe(true);
+    setSearch('aa-drought-preview=true');
+    expect(getAADroughtStagingParam()).toBe(false);
+    expect(getAADroughtPreviewParam()).toBe(true);
 
     setSearch('');
-    expect(getStagingParam()).toBe(false);
-    expect(getAACsvPreviewParam()).toBe(false);
+    expect(getAADroughtStagingParam()).toBe(false);
+    expect(getAADroughtPreviewParam()).toBe(false);
   });
 });
 
@@ -42,18 +42,18 @@ describe('getAADroughtCdnUrl', () => {
     expect(getAADroughtCdnUrl(appConfig)).toBe(PROD_URL);
   });
 
-  test('returns the S3 preview URL only for aa-csv-preview=true', () => {
-    setSearch('aa-csv-preview=true');
+  test('returns the S3 preview URL only for aa-drought-preview=true', () => {
+    setSearch('aa-drought-preview=true');
     expect(getAADroughtCdnUrl(appConfig)).toBe(PREVIEW_URL);
   });
 
-  test('staging=true does not select the S3 preview URL', () => {
-    setSearch('staging=true');
+  test('aa-drought-staging=true does not select the S3 preview URL', () => {
+    setSearch('aa-drought-staging=true');
     expect(getAADroughtCdnUrl(appConfig)).toBe(PROD_URL);
   });
 
   test('falls back to prod URL when no preview URL is configured', () => {
-    setSearch('aa-csv-preview=true');
+    setSearch('aa-drought-preview=true');
     expect(getAADroughtCdnUrl({ anticipatoryActionDroughtUrl: PROD_URL })).toBe(
       PROD_URL,
     );
@@ -72,8 +72,8 @@ describe('getAADroughtUrl', () => {
     expect(url.searchParams.get('date')).toBeTruthy();
   });
 
-  test('staging=true: routes through the API with include_staging=true', () => {
-    setSearch('staging=true');
+  test('aa-drought-staging=true: routes through the API with include_staging=true', () => {
+    setSearch('aa-drought-staging=true');
     const url = new URL(getAADroughtUrl(appConfig, 'zimbabwe') as string);
     expect(`${url.origin}${url.pathname}`).toBe(
       `${AA_DROUGHT_API_URL}/zimbabwe.csv`,
@@ -82,22 +82,22 @@ describe('getAADroughtUrl', () => {
     expect(url.searchParams.get('fallback')).toBe(PROD_URL);
   });
 
-  test('aa-csv-preview=true: fetches the S3 preview URL directly (bypasses API)', () => {
-    setSearch('aa-csv-preview=true');
+  test('aa-drought-preview=true: fetches the S3 preview URL directly (bypasses API)', () => {
+    setSearch('aa-drought-preview=true');
     const url = new URL(getAADroughtUrl(appConfig, 'zimbabwe') as string);
     expect(`${url.origin}${url.pathname}`).toBe(PREVIEW_URL);
     expect(url.searchParams.get('date')).toBeTruthy();
   });
 
   test('both params: S3 preview wins over the DB staging path', () => {
-    setSearch('aa-csv-preview=true&staging=true');
+    setSearch('aa-drought-preview=true&aa-drought-staging=true');
     const url = new URL(getAADroughtUrl(appConfig, 'zimbabwe') as string);
     expect(`${url.origin}${url.pathname}`).toBe(PREVIEW_URL);
     expect(url.searchParams.get('include_staging')).toBeNull();
   });
 
-  test('aa-csv-preview=true without a preview URL falls back to the API path', () => {
-    setSearch('aa-csv-preview=true');
+  test('aa-drought-preview=true without a preview URL falls back to the API path', () => {
+    setSearch('aa-drought-preview=true');
     const url = new URL(
       getAADroughtUrl(
         { anticipatoryActionDroughtUrl: PROD_URL },

--- a/frontend/src/utils/url-utils.test.ts
+++ b/frontend/src/utils/url-utils.test.ts
@@ -7,11 +7,11 @@ import {
 } from './url-utils';
 
 const PROD_URL = 'https://cdn.example.com/zimbabwe/aa_drought.csv';
-const STAGING_URL = 'https://staging.example.com/zimbabwe/aa_drought.csv';
+const PREVIEW_URL = 'https://preview.example.com/zimbabwe/aa_drought.csv';
 
 const appConfig = {
   anticipatoryActionDroughtUrl: PROD_URL,
-  anticipatoryActionDroughtStagingUrl: STAGING_URL,
+  anticipatoryActionDroughtPreviewUrl: PREVIEW_URL,
 };
 
 function setSearch(search: string) {
@@ -42,17 +42,17 @@ describe('getAADroughtCdnUrl', () => {
     expect(getAADroughtCdnUrl(appConfig)).toBe(PROD_URL);
   });
 
-  test('returns the S3 staging URL only for aa-csv-preview=true', () => {
+  test('returns the S3 preview URL only for aa-csv-preview=true', () => {
     setSearch('aa-csv-preview=true');
-    expect(getAADroughtCdnUrl(appConfig)).toBe(STAGING_URL);
+    expect(getAADroughtCdnUrl(appConfig)).toBe(PREVIEW_URL);
   });
 
-  test('staging=true does not select the S3 staging URL', () => {
+  test('staging=true does not select the S3 preview URL', () => {
     setSearch('staging=true');
     expect(getAADroughtCdnUrl(appConfig)).toBe(PROD_URL);
   });
 
-  test('falls back to prod URL when no staging URL is configured', () => {
+  test('falls back to prod URL when no preview URL is configured', () => {
     setSearch('aa-csv-preview=true');
     expect(getAADroughtCdnUrl({ anticipatoryActionDroughtUrl: PROD_URL })).toBe(
       PROD_URL,
@@ -82,21 +82,21 @@ describe('getAADroughtUrl', () => {
     expect(url.searchParams.get('fallback')).toBe(PROD_URL);
   });
 
-  test('aa-csv-preview=true: fetches the S3 staging URL directly (bypasses API)', () => {
+  test('aa-csv-preview=true: fetches the S3 preview URL directly (bypasses API)', () => {
     setSearch('aa-csv-preview=true');
     const url = new URL(getAADroughtUrl(appConfig, 'zimbabwe') as string);
-    expect(`${url.origin}${url.pathname}`).toBe(STAGING_URL);
+    expect(`${url.origin}${url.pathname}`).toBe(PREVIEW_URL);
     expect(url.searchParams.get('date')).toBeTruthy();
   });
 
   test('both params: S3 preview wins over the DB staging path', () => {
     setSearch('aa-csv-preview=true&staging=true');
     const url = new URL(getAADroughtUrl(appConfig, 'zimbabwe') as string);
-    expect(`${url.origin}${url.pathname}`).toBe(STAGING_URL);
+    expect(`${url.origin}${url.pathname}`).toBe(PREVIEW_URL);
     expect(url.searchParams.get('include_staging')).toBeNull();
   });
 
-  test('aa-csv-preview=true without a staging URL falls back to the API path', () => {
+  test('aa-csv-preview=true without a preview URL falls back to the API path', () => {
     setSearch('aa-csv-preview=true');
     const url = new URL(
       getAADroughtUrl(

--- a/frontend/src/utils/url-utils.test.ts
+++ b/frontend/src/utils/url-utils.test.ts
@@ -1,0 +1,112 @@
+import { AA_DROUGHT_API_URL } from './constants';
+import {
+  getAACsvPreviewParam,
+  getAADroughtCdnUrl,
+  getAADroughtUrl,
+  getStagingParam,
+} from './url-utils';
+
+const PROD_URL = 'https://cdn.example.com/zimbabwe/aa_drought.csv';
+const STAGING_URL = 'https://staging.example.com/zimbabwe/aa_drought.csv';
+
+const appConfig = {
+  anticipatoryActionDroughtUrl: PROD_URL,
+  anticipatoryActionDroughtStagingUrl: STAGING_URL,
+};
+
+function setSearch(search: string) {
+  window.history.pushState({}, '', search ? `/?${search}` : '/');
+}
+
+afterEach(() => setSearch(''));
+
+describe('getStagingParam / getAACsvPreviewParam', () => {
+  test('read their own params independently', () => {
+    setSearch('staging=true');
+    expect(getStagingParam()).toBe(true);
+    expect(getAACsvPreviewParam()).toBe(false);
+
+    setSearch('aa-csv-preview=true');
+    expect(getStagingParam()).toBe(false);
+    expect(getAACsvPreviewParam()).toBe(true);
+
+    setSearch('');
+    expect(getStagingParam()).toBe(false);
+    expect(getAACsvPreviewParam()).toBe(false);
+  });
+});
+
+describe('getAADroughtCdnUrl', () => {
+  test('returns the prod URL by default', () => {
+    setSearch('');
+    expect(getAADroughtCdnUrl(appConfig)).toBe(PROD_URL);
+  });
+
+  test('returns the S3 staging URL only for aa-csv-preview=true', () => {
+    setSearch('aa-csv-preview=true');
+    expect(getAADroughtCdnUrl(appConfig)).toBe(STAGING_URL);
+  });
+
+  test('staging=true does not select the S3 staging URL', () => {
+    setSearch('staging=true');
+    expect(getAADroughtCdnUrl(appConfig)).toBe(PROD_URL);
+  });
+
+  test('falls back to prod URL when no staging URL is configured', () => {
+    setSearch('aa-csv-preview=true');
+    expect(getAADroughtCdnUrl({ anticipatoryActionDroughtUrl: PROD_URL })).toBe(
+      PROD_URL,
+    );
+  });
+});
+
+describe('getAADroughtUrl', () => {
+  test('no param: routes through the API with prod fallback, no include_staging', () => {
+    setSearch('');
+    const url = new URL(getAADroughtUrl(appConfig, 'zimbabwe') as string);
+    expect(`${url.origin}${url.pathname}`).toBe(
+      `${AA_DROUGHT_API_URL}/zimbabwe.csv`,
+    );
+    expect(url.searchParams.get('fallback')).toBe(PROD_URL);
+    expect(url.searchParams.get('include_staging')).toBeNull();
+    expect(url.searchParams.get('date')).toBeTruthy();
+  });
+
+  test('staging=true: routes through the API with include_staging=true', () => {
+    setSearch('staging=true');
+    const url = new URL(getAADroughtUrl(appConfig, 'zimbabwe') as string);
+    expect(`${url.origin}${url.pathname}`).toBe(
+      `${AA_DROUGHT_API_URL}/zimbabwe.csv`,
+    );
+    expect(url.searchParams.get('include_staging')).toBe('true');
+    expect(url.searchParams.get('fallback')).toBe(PROD_URL);
+  });
+
+  test('aa-csv-preview=true: fetches the S3 staging URL directly (bypasses API)', () => {
+    setSearch('aa-csv-preview=true');
+    const url = new URL(getAADroughtUrl(appConfig, 'zimbabwe') as string);
+    expect(`${url.origin}${url.pathname}`).toBe(STAGING_URL);
+    expect(url.searchParams.get('date')).toBeTruthy();
+  });
+
+  test('both params: S3 preview wins over the DB staging path', () => {
+    setSearch('aa-csv-preview=true&staging=true');
+    const url = new URL(getAADroughtUrl(appConfig, 'zimbabwe') as string);
+    expect(`${url.origin}${url.pathname}`).toBe(STAGING_URL);
+    expect(url.searchParams.get('include_staging')).toBeNull();
+  });
+
+  test('aa-csv-preview=true without a staging URL falls back to the API path', () => {
+    setSearch('aa-csv-preview=true');
+    const url = new URL(
+      getAADroughtUrl(
+        { anticipatoryActionDroughtUrl: PROD_URL },
+        'zimbabwe',
+      ) as string,
+    );
+    expect(`${url.origin}${url.pathname}`).toBe(
+      `${AA_DROUGHT_API_URL}/zimbabwe.csv`,
+    );
+    expect(url.searchParams.get('fallback')).toBe(PROD_URL);
+  });
+});

--- a/frontend/src/utils/url-utils.ts
+++ b/frontend/src/utils/url-utils.ts
@@ -185,43 +185,46 @@ export function combineURLs(baseURL: string, relativeURL: string) {
 }
 
 /**
- * Returns true if the URL contains staging=true, otherwise false.
+ * Returns true if the URL contains aa-drought-staging=true, otherwise false.
  *
  * Controls whether the read API includes DB-uploaded status=staging datasets
  * (via the `include_staging` query param).
  */
-export function getStagingParam(): boolean {
+export function getAADroughtStagingParam(): boolean {
   if (typeof window === 'undefined') {
     return false;
   }
   const params = new URLSearchParams(window.location.search);
-  return params.get('staging') === 'true';
+  return params.get('aa-drought-staging') === 'true';
 }
 
 /**
- * Returns true if the URL contains aa-csv-preview=true, otherwise false.
+ * Returns true if the URL contains aa-drought-preview=true, otherwise false.
  *
- * Enables previewing an AA drought CSV hosted on a remote (staging) S3 bucket,
+ * Enables previewing an AA drought CSV hosted on a remote (preview) S3 bucket,
  * configured via `anticipatoryActionDroughtPreviewUrl` in prism.json. Kept
- * separate from `staging=true` (which controls whether the read API serves
- * DB-uploaded status=staging datasets) so the S3 bucket can be previewed
+ * separate from `aa-drought-staging=true` (which controls whether the read API
+ * serves DB-uploaded status=staging datasets) so the S3 bucket can be previewed
  * independently.
  */
-export function getAACsvPreviewParam(): boolean {
+export function getAADroughtPreviewParam(): boolean {
   if (typeof window === 'undefined') {
     return false;
   }
   const params = new URLSearchParams(window.location.search);
-  return params.get('aa-csv-preview') === 'true';
+  return params.get('aa-drought-preview') === 'true';
 }
 
 /**
  * Returns the configured CDN URL for the anticipatory action drought CSV.
- * Only returns the preview (S3 bucket) URL if aa-csv-preview=true is set and
- * the staging URL exists.
+ * Only returns the preview (S3 bucket) URL if aa-drought-preview=true is set
+ * and the preview URL exists.
  */
 export function getAADroughtCdnUrl(appConfig: any): string | undefined {
-  if (getAACsvPreviewParam() && appConfig.anticipatoryActionDroughtPreviewUrl) {
+  if (
+    getAADroughtPreviewParam() &&
+    appConfig.anticipatoryActionDroughtPreviewUrl
+  ) {
     return appConfig.anticipatoryActionDroughtPreviewUrl;
   }
   return appConfig.anticipatoryActionDroughtUrl;
@@ -230,7 +233,7 @@ export function getAADroughtCdnUrl(appConfig: any): string | undefined {
 /**
  * Returns the fetch URL for the anticipatory action drought CSV, cache-busted.
  *
- * When `aa-csv-preview=true` is set, fetches the configured S3 staging CSV
+ * When `aa-drought-preview=true` is set, fetches the configured S3 preview CSV
  * directly (bypassing the API) so the remote preview is always shown, even when
  * a DB-uploaded dataset exists for the country.
  *
@@ -248,13 +251,13 @@ export function getAADroughtUrl(
   // S3 preview always wins: fetch the remote CSV directly, skipping the
   // DB-first API so a published/staging DB dataset cannot shadow the preview.
   const previewUrl = appConfig.anticipatoryActionDroughtPreviewUrl;
-  if (getAACsvPreviewParam() && previewUrl) {
+  if (getAADroughtPreviewParam() && previewUrl) {
     const previewParams = new URLSearchParams({ date: cacheBust });
     return `${previewUrl}?${previewParams.toString()}`;
   }
 
   const params = new URLSearchParams({ date: cacheBust });
-  if (getStagingParam()) {
+  if (getAADroughtStagingParam()) {
     params.set('include_staging', 'true');
   }
   if (cdnUrl) {

--- a/frontend/src/utils/url-utils.ts
+++ b/frontend/src/utils/url-utils.ts
@@ -202,7 +202,7 @@ export function getStagingParam(): boolean {
  * Returns true if the URL contains aa-csv-preview=true, otherwise false.
  *
  * Enables previewing an AA drought CSV hosted on a remote (staging) S3 bucket,
- * configured via `anticipatoryActionDroughtStagingUrl` in prism.json. Kept
+ * configured via `anticipatoryActionDroughtPreviewUrl` in prism.json. Kept
  * separate from `staging=true` (which controls whether the read API serves
  * DB-uploaded status=staging datasets) so the S3 bucket can be previewed
  * independently.
@@ -221,8 +221,8 @@ export function getAACsvPreviewParam(): boolean {
  * the staging URL exists.
  */
 export function getAADroughtCdnUrl(appConfig: any): string | undefined {
-  if (getAACsvPreviewParam() && appConfig.anticipatoryActionDroughtStagingUrl) {
-    return appConfig.anticipatoryActionDroughtStagingUrl;
+  if (getAACsvPreviewParam() && appConfig.anticipatoryActionDroughtPreviewUrl) {
+    return appConfig.anticipatoryActionDroughtPreviewUrl;
   }
   return appConfig.anticipatoryActionDroughtUrl;
 }
@@ -247,10 +247,10 @@ export function getAADroughtUrl(
 
   // S3 preview always wins: fetch the remote CSV directly, skipping the
   // DB-first API so a published/staging DB dataset cannot shadow the preview.
-  const stagingUrl = appConfig.anticipatoryActionDroughtStagingUrl;
-  if (getAACsvPreviewParam() && stagingUrl) {
+  const previewUrl = appConfig.anticipatoryActionDroughtPreviewUrl;
+  if (getAACsvPreviewParam() && previewUrl) {
     const previewParams = new URLSearchParams({ date: cacheBust });
-    return `${stagingUrl}?${previewParams.toString()}`;
+    return `${previewUrl}?${previewParams.toString()}`;
   }
 
   const params = new URLSearchParams({ date: cacheBust });

--- a/frontend/src/utils/url-utils.ts
+++ b/frontend/src/utils/url-utils.ts
@@ -217,7 +217,7 @@ export function getAACsvPreviewParam(): boolean {
 
 /**
  * Returns the configured CDN URL for the anticipatory action drought CSV.
- * Only returns the staging (S3 bucket) URL if aa-csv-preview=true is set and
+ * Only returns the preview (S3 bucket) URL if aa-csv-preview=true is set and
  * the staging URL exists.
  */
 export function getAADroughtCdnUrl(appConfig: any): string | undefined {

--- a/frontend/src/utils/url-utils.ts
+++ b/frontend/src/utils/url-utils.ts
@@ -186,6 +186,9 @@ export function combineURLs(baseURL: string, relativeURL: string) {
 
 /**
  * Returns true if the URL contains staging=true, otherwise false.
+ *
+ * Controls whether the read API includes DB-uploaded status=staging datasets
+ * (via the `include_staging` query param).
  */
 export function getStagingParam(): boolean {
   if (typeof window === 'undefined') {
@@ -196,12 +199,29 @@ export function getStagingParam(): boolean {
 }
 
 /**
+ * Returns true if the URL contains aa-csv-preview=true, otherwise false.
+ *
+ * Enables previewing an AA drought CSV hosted on a remote (staging) S3 bucket,
+ * configured via `anticipatoryActionDroughtStagingUrl` in prism.json. Kept
+ * separate from `staging=true` (which controls whether the read API serves
+ * DB-uploaded status=staging datasets) so the S3 bucket can be previewed
+ * independently.
+ */
+export function getAACsvPreviewParam(): boolean {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+  const params = new URLSearchParams(window.location.search);
+  return params.get('aa-csv-preview') === 'true';
+}
+
+/**
  * Returns the configured CDN URL for the anticipatory action drought CSV.
- * Only returns the staging URL if isStaging is true and the staging URL exists.
+ * Only returns the staging (S3 bucket) URL if aa-csv-preview=true is set and
+ * the staging URL exists.
  */
 export function getAADroughtCdnUrl(appConfig: any): string | undefined {
-  const isStaging = getStagingParam();
-  if (isStaging && appConfig.anticipatoryActionDroughtStagingUrl) {
+  if (getAACsvPreviewParam() && appConfig.anticipatoryActionDroughtStagingUrl) {
     return appConfig.anticipatoryActionDroughtStagingUrl;
   }
   return appConfig.anticipatoryActionDroughtUrl;
@@ -210,9 +230,13 @@ export function getAADroughtCdnUrl(appConfig: any): string | undefined {
 /**
  * Returns the fetch URL for the anticipatory action drought CSV, cache-busted.
  *
- * Routes through the PRISM API (`/aa/drought/{country}.csv`), which serves a
- * government-uploaded dataset when one is published and otherwise redirects to
- * the configured CDN URL (passed as `fallback`).
+ * When `aa-csv-preview=true` is set, fetches the configured S3 staging CSV
+ * directly (bypassing the API) so the remote preview is always shown, even when
+ * a DB-uploaded dataset exists for the country.
+ *
+ * Otherwise routes through the PRISM API (`/aa/drought/{country}.csv`), which
+ * serves a government-uploaded dataset when one is published and otherwise
+ * redirects to the configured CDN URL (passed as `fallback`).
  */
 export function getAADroughtUrl(
   appConfig: any,
@@ -220,6 +244,15 @@ export function getAADroughtUrl(
 ): string | undefined {
   const cdnUrl = getAADroughtCdnUrl(appConfig);
   const cacheBust = getCurrentDateTimeForUrl();
+
+  // S3 preview always wins: fetch the remote CSV directly, skipping the
+  // DB-first API so a published/staging DB dataset cannot shadow the preview.
+  const stagingUrl = appConfig.anticipatoryActionDroughtStagingUrl;
+  if (getAACsvPreviewParam() && stagingUrl) {
+    const previewParams = new URLSearchParams({ date: cacheBust });
+    return `${stagingUrl}?${previewParams.toString()}`;
+  }
+
   const params = new URLSearchParams({ date: cacheBust });
   if (getStagingParam()) {
     params.set('include_staging', 'true');


### PR DESCRIPTION
### Description

This fixes #1996.

<!-- what this does -->

Restore remote S3 CSV preview for AA drought, decoupled from DB-dataset preview

- PR #1945 overloaded the` staging=true` URL param to do two things — select the remote S3 staging CSV and include DB-uploaded `staging` datasets — so the original S3 preview (via `anticipatoryActionDroughtStagingUrl` in `prism.json`) could be shadowed by a DB dataset.
- Introduce a dedicated `aa-drought-preview=true` URL param that previews the remote S3 CSV, decoupled from the renamed `aa-drought-staging=true`.
- `aa-drought-preview=true` fetches the S3 URL directly, bypassing the DB-first API, so a published/staging DB dataset can never shadow the preview.
- `aa-drought-staging` now controls only the DB path (`include_staging`) — previews DB-uploaded staging datasets through the API.
- Default (no param) is unchanged: serves the published DB dataset if one exists, otherwise redirects to `prism.json`'s `anticipatoryActionDroughtUrl`.
- Precedence when both params are set: S3 preview wins.
- Rename config key `anticipatoryActionDroughtStagingUrl` to `anticipatoryActionDroughtPreviewUrl` across all 5 country configs (zambia, zimbabwe, tanzania, mozambique, malawi), removing the naming overlap with the DB staging path. ⚠️ Breaking config change — any deployment still using the old key must rename it.
- The S3 bypass only triggers when `anticipatoryActionDroughtStagingUrl` is configured; otherwise it falls through to the normal API path.
- Add `getAACsvPreviewParam()`; `getAADroughtCdnUrl` now keys off it instead of `getStagingParam()`.
- Add `url-utils.test.ts` covering all param combinations (none / `aa-drought-staging` / `aa-csv-preview` / both, and the no-staging-URL fallback).

## How to test the feature:

- [ ] build with an AA drought country (malawi, mozambique, tanzania, zambia, zimbabwe)
- [ ] verify AA drought source through network requests
- [ ] if no URL param, read from DB with `published` state; fallback to `anticipatoryActionDroughtUrl` (https://hip-workshop-sharing-public-eu-central-1-485262375119.s3.eu-central-1....)
- [ ] If URL param is `aa-drought-staging=true` read from DB with `staging` state
- [ ] if URL param is `aa-drought-preview=true` read from `anticipatoryActionDroughtPreviewUrl` location in `prism.json`

## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [ ] `REACT_APP_COUNTRY=rbd yarn start`
- [ ] `REACT_APP_COUNTRY=cambodia yarn start`
- [ ] `REACT_APP_COUNTRY=mozambique yarn start`
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

## Screenshot/video of feature:
