### PR TITLE
Fix AA drought CSV preview URL configuration; COUNTRY=mozambique

### DIFF
--- a/frontend/src/config/mozambique/prism.json
+++ b/frontend/src/config/mozambique/prism.json
@@ -2,7 +2,7 @@
   "country": "Mozambique",
   "defaultLanguage": "en",
   "anticipatoryActionDroughtUrl": "https://hip-workshop-sharing-public-eu-central-1-485262375119.s3.eu-central-1.amazonaws.com/anticipatory-action/moz/prism/aa_probabilities_triggers_moz.csv",
-  "anticipatoryActionDroughtPreviewUrl": "https://data.earthobservation.vam.wfp.org/public-share/aa/staging/aa_probabilities_triggers_moz.csv",
+  "anticipatoryActionDroughtPreviewUrl": "https://hip-workshop-sharing-public-eu-central-1-485262375119.s3.eu-central-1.amazonaws.com/anticipatory-action/moz/prism/staging/aa_probabilities_triggers_moz.csv",
   "anticipatoryActionStormUrl": "https://data.earthobservation.vam.wfp.org/public-share/aa/ts/outputs/latest.json.",
   "anticipatoryActionFloodUrl": "https://data.earthobservation.vam.wfp.org/public-share/aa/flood/moz/dates.json",
   "header": {


### PR DESCRIPTION
### Description

<!-- what this does -->

Quick fix to update the AA drought CSV preview URL 

- [ ] `REACT_APP_COUNTRY=mozambique yarn start`
- [ ] add URL param `aa-drought-preview=true`
- [ ] load AA module
- [ ] verify that CSV loads from  https://hip-workshop-sharing-public-eu-central-1-485262375119.s3.eu-central-1.amazonaws.com/anticipatory-action/moz/prism/staging/aa_probabilities_triggers_moz.csv


## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [ ] `REACT_APP_COUNTRY=rbd yarn start`
- [ ] `REACT_APP_COUNTRY=cambodia yarn start`
- [ ] `REACT_APP_COUNTRY=mozambique yarn start`
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

## Screenshot/video of feature:
