### PR TITLE
Upload CSV for all countries permission

### DIFF
--- a/api/prism_app/aa_drought/country_scope.py
+++ b/api/prism_app/aa_drought/country_scope.py
@@ -13,14 +13,38 @@ from prism_app.database.aa_drought_model import AaDroughtCountry
 from starlette.requests import Request
 from starlette_admin.exceptions import FormValidationError
 
+_AA_COUNTRY_CHOICES = [(c.value, c.value) for c in AaDroughtCountry]
+
 _AMBIGUOUS_AA_COUNTRY_MSG = (
     "Your account must have AA drought access for exactly one country."
 )
 
 
+def aa_drought_selectable_countries(request: Request) -> frozenset[str] | None:
+    """Countries the user may pick in the AA admin form; ``None`` means all AA countries."""
+    if request_has_prism_admin_access(request):
+        return None
+    return request_allowed_countries(request, AA_DATA_MANAGE)
+
+
 def aa_drought_country_field_visible(request: Request) -> bool:
-    """Full admins pick country; scoped AA managers have it inferred."""
-    return request_has_prism_admin_access(request)
+    """Show country when the user must pick (admin, ``*``, or multi-country grant)."""
+    if request_has_prism_admin_access(request):
+        return True
+    allowed = aa_drought_selectable_countries(request)
+    if allowed is None:
+        return True
+    return len(allowed) != 1
+
+
+def aa_drought_country_choices(
+    request: Request,
+) -> list[tuple[str, str]]:
+    """Dropdown choices for the country field, limited to the user's AA scope."""
+    allowed = aa_drought_selectable_countries(request)
+    if allowed is None:
+        return list(_AA_COUNTRY_CHOICES)
+    return [(code, code) for code in sorted(allowed)]
 
 
 def infer_aa_drought_country(request: Request) -> AaDroughtCountry:

--- a/api/prism_app/admin.py
+++ b/api/prism_app/admin.py
@@ -7,6 +7,7 @@ from prism_app.aa_drought.aa_drought_admin import (
     register_aa_drought_admin_routes,
 )
 from prism_app.aa_drought.country_scope import (
+    aa_drought_country_choices,
     aa_drought_country_field_visible,
     apply_inferred_aa_drought_country,
 )
@@ -302,9 +303,24 @@ class GatedAaDroughtAdminView(AaDroughtAdminView):
         action: RequestAction = RequestAction.LIST,
     ) -> list[Any]:
         fields = super().get_fields_list(request, action)
-        if aa_drought_country_field_visible(request):
+        if not aa_drought_country_field_visible(request):
+            return [field for field in fields if field.name != "country"]
+        if request_has_prism_admin_access(request):
             return fields
-        return [field for field in fields if field.name != "country"]
+        scoped_fields: list[Any] = []
+        for field in fields:
+            if field.name != "country":
+                scoped_fields.append(field)
+                continue
+            scoped_fields.append(
+                EnumField(
+                    "country",
+                    label=field.label,
+                    required=True,
+                    choices_loader=aa_drought_country_choices,
+                )
+            )
+        return scoped_fields
 
     def _aa_drought_searchable_fields(self, request: Request) -> tuple[str, ...]:
         if aa_drought_country_field_visible(request):

--- a/api/prism_app/tests/test_aa_drought_admin_form.py
+++ b/api/prism_app/tests/test_aa_drought_admin_form.py
@@ -1,6 +1,10 @@
 """AA drought admin form: country dropdown for admins; inferred for AA managers."""
 
 import pytest
+from prism_app.aa_drought.country_scope import (
+    aa_drought_country_choices,
+    aa_drought_country_field_visible,
+)
 from prism_app.admin import GatedAaDroughtAdminView
 from prism_app.auth.permission_codes import AA_DATA_MANAGE, ADMIN_ACCESS
 from prism_app.database.aa_drought_model import (
@@ -11,49 +15,108 @@ from prism_app.database.aa_drought_model import (
 from starlette.requests import Request
 from starlette_admin._types import RequestAction
 
+_UNSET = object()
 
-def _request(*, codes: set[str], countries: frozenset[str] | None = None) -> Request:
+
+def _request(
+    *,
+    codes: set[str],
+    aa_countries: frozenset[str] | None | object = _UNSET,
+) -> Request:
     scope = {"type": "http", "method": "GET", "path": "/admin/", "headers": []}
     request = Request(scope)
     request.state.permission_codes = codes
     if ADMIN_ACCESS in codes:
         request.state.permission_scopes = {}
-    elif countries is not None:
-        request.state.permission_scopes = {AA_DATA_MANAGE: countries}
+    elif aa_countries is not _UNSET:
+        request.state.permission_scopes = {AA_DATA_MANAGE: aa_countries}
     else:
         request.state.permission_scopes = {}
     return request
 
 
-def test_country_field_visible_for_admin_only() -> None:
+def test_country_field_visible_for_admin_and_unrestricted_aa_manager() -> None:
     view = GatedAaDroughtAdminView(AaDroughtDatasetModel)
     admin_request = _request(codes={ADMIN_ACCESS})
-    manager_request = _request(codes={AA_DATA_MANAGE}, countries=frozenset({"malawi"}))
+    star_request = _request(codes={AA_DATA_MANAGE}, aa_countries=None)
+    multi_request = _request(
+        codes={AA_DATA_MANAGE},
+        aa_countries=frozenset({"malawi", "zambia"}),
+    )
+    single_request = _request(
+        codes={AA_DATA_MANAGE}, aa_countries=frozenset({"malawi"})
+    )
 
     for action in (RequestAction.CREATE, RequestAction.EDIT, RequestAction.LIST):
         admin_fields = {f.name for f in view.get_fields_list(admin_request, action)}
-        manager_fields = {f.name for f in view.get_fields_list(manager_request, action)}
+        star_fields = {f.name for f in view.get_fields_list(star_request, action)}
+        multi_fields = {f.name for f in view.get_fields_list(multi_request, action)}
+        single_fields = {f.name for f in view.get_fields_list(single_request, action)}
         assert "country" in admin_fields
-        assert "country" not in manager_fields
+        assert "country" in star_fields
+        assert "country" in multi_fields
+        assert "country" not in single_fields
 
-    # Starlette-admin list config calls get_fields_list(request) without action.
-    manager_list_fields = {f.name for f in view.get_fields_list(manager_request)}
-    assert "country" not in manager_list_fields
+    assert aa_drought_country_field_visible(admin_request)
+    assert aa_drought_country_field_visible(star_request)
+    assert aa_drought_country_field_visible(multi_request)
+    assert not aa_drought_country_field_visible(single_request)
 
 
-def test_aa_manager_search_excludes_country_column() -> None:
+def test_aa_drought_country_choices_respects_scope() -> None:
+    admin_request = _request(codes={ADMIN_ACCESS})
+    star_request = _request(codes={AA_DATA_MANAGE}, aa_countries=None)
+    multi_request = _request(
+        codes={AA_DATA_MANAGE},
+        aa_countries=frozenset({"zambia", "malawi"}),
+    )
+
+    all_countries = {code for code, _ in aa_drought_country_choices(admin_request)}
+    assert all_countries == {c.value for c in AaDroughtCountry}
+
+    star_countries = {code for code, _ in aa_drought_country_choices(star_request)}
+    assert star_countries == {c.value for c in AaDroughtCountry}
+
+    multi_countries = {code for code, _ in aa_drought_country_choices(multi_request)}
+    assert multi_countries == {"malawi", "zambia"}
+
+
+def test_unrestricted_aa_manager_country_field_uses_scoped_choices_loader() -> None:
     view = GatedAaDroughtAdminView(AaDroughtDatasetModel)
-    manager_request = _request(codes={AA_DATA_MANAGE}, countries=frozenset({"malawi"}))
+    request = _request(codes={AA_DATA_MANAGE}, aa_countries=None)
+    country_fields = [
+        f
+        for f in view.get_fields_list(request, RequestAction.CREATE)
+        if f.name == "country"
+    ]
+    assert len(country_fields) == 1
+    assert country_fields[0].choices_loader is aa_drought_country_choices
+
+
+def test_aa_manager_search_excludes_country_column_for_single_country() -> None:
+    view = GatedAaDroughtAdminView(AaDroughtDatasetModel)
+    manager_request = _request(
+        codes={AA_DATA_MANAGE}, aa_countries=frozenset({"malawi"})
+    )
     clause = view.get_search_query(manager_request, "malawi")
     compiled = str(clause.compile(compile_kwargs={"literal_binds": True})).lower()
     assert "country" not in compiled
     assert "status" in compiled
 
 
+def test_aa_manager_search_includes_country_column_for_unrestricted_scope() -> None:
+    view = GatedAaDroughtAdminView(AaDroughtDatasetModel)
+    manager_request = _request(codes={AA_DATA_MANAGE}, aa_countries=None)
+    clause = view.get_search_query(manager_request, "malawi")
+    compiled = str(clause.compile(compile_kwargs={"literal_binds": True})).lower()
+    assert "country" in compiled
+    assert "status" in compiled
+
+
 @pytest.mark.asyncio
 async def test_populate_obj_persists_inferred_country_when_field_hidden() -> None:
     view = GatedAaDroughtAdminView(AaDroughtDatasetModel)
-    request = _request(codes={AA_DATA_MANAGE}, countries=frozenset({"malawi"}))
+    request = _request(codes={AA_DATA_MANAGE}, aa_countries=frozenset({"malawi"}))
     request.state.action = RequestAction.CREATE
     data: dict = {
         "status": "draft",
@@ -67,3 +130,25 @@ async def test_populate_obj_persists_inferred_country_when_field_hidden() -> Non
     )
     populated = await view._populate_obj(request, obj, data)
     assert populated.country == AaDroughtCountry.malawi
+
+
+@pytest.mark.asyncio
+async def test_populate_obj_keeps_explicit_country_for_unrestricted_aa_manager() -> (
+    None
+):
+    view = GatedAaDroughtAdminView(AaDroughtDatasetModel)
+    request = _request(codes={AA_DATA_MANAGE}, aa_countries=None)
+    request.state.action = RequestAction.CREATE
+    data: dict = {
+        "country": AaDroughtCountry.zimbabwe,
+        "status": "draft",
+        "csv_content": "district,index\nA,B\n",
+        "row_count": 1,
+    }
+    obj = AaDroughtDatasetModel(
+        csv_content="district,index\nA,B\n",
+        status=AaDroughtStatus.draft,
+        row_count=0,
+    )
+    populated = await view._populate_obj(request, obj, data)
+    assert populated.country == AaDroughtCountry.zimbabwe

--- a/api/prism_app/tests/test_aa_drought_validate_csv.py
+++ b/api/prism_app/tests/test_aa_drought_validate_csv.py
@@ -108,6 +108,20 @@ async def test_validate_csv_upload_infers_country_for_scoped_manager() -> None:
 
 
 @pytest.mark.asyncio
+async def test_validate_csv_upload_accepts_explicit_country_for_unrestricted_scope() -> (
+    None
+):
+    form = FormData(
+        [
+            ("country", "zimbabwe"),
+            ("csv_content", _upload("aa.csv", _GOOD_CSV.encode())),
+        ]
+    )
+    response = await validate_aa_drought_csv_upload(_request(form, countries=None))
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
 async def test_validate_csv_upload_forbidden_for_country_outside_scope() -> None:
     form = FormData(
         [


### PR DESCRIPTION
### Description

Prior to this PR the "AA CSV upload permission" allowed two cases;

- Global admin can upload for any country
- AA CSV permissioned users can upload for a single country

This change allows for the AA CSV permissioned user to upload for all countries.

<!-- what this does -->

## How to test the feature:

```
make db-migrate && make db-seed
PRISM_ADMIN_AUTH_DISABLED=true
# test user that has upload csv permission for all countries
PRISM_DEV_USER_ID=b000000e-0000-4000-8000-00000000000e
```

Go to `localhost:admin` and verify that you can upload and view CSVs for any of the 5 valid CSV countries.

## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

## Screenshot/video of feature:

<img width="964" height="420" alt="image" src="https://github.com/user-attachments/assets/2e26578c-a8e2-4031-adbc-4c5376787c9f" />

